### PR TITLE
avoid devision by zero

### DIFF
--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -234,8 +234,7 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
       z/g^2 = (1 - x/g^2) cosa^2
 #endif
       b = atan2( - sx / g, sqrt( sy/g * sy/g + sz/g * sz/g ) );
-      a = atan2( ( sy/g ) / sqrt( 1 - sx/g * sx/g),
-                 ( sz/g ) / sqrt( 1 - sx/g * sx/g) );
+      a = atan2( ( sy/g ), ( sz/g ) );
       //std::cerr << "a(roll) = " << a*180/M_PI << ", b(pitch) = " << b*180/M_PI << ",  sx = " << sx << ", sy = " << sy << ", sz = " << sz << std::endl;
       m_rpyRaw.data.r = a;
       m_rpyRaw.data.p = b;


### PR DESCRIPTION
このカルマンフィルタは直立時を想定しているかとは思いますが，転倒などでロボットが仰向け，または，うつ伏せになるときがあり，このとき
https://github.com/fkanehiro/hrpsys-base/blob/master/rtc/KalmanFilter/KalmanFilter.cpp#L237
の sx (加速度センサのx軸の値)が +g または -g になり，この行でゼロ除算が発生して制御ループが止まってしまいます．

``` TeX
a = atan2( ( sy/g ) / sqrt( 1 - sx/g * sx/g),
                 ( sz/g ) / sqrt( 1 - sx/g * sx/g) );
```

の`sqrt( 1 - sx/g * sx/g)`が0になるのですが，

atan2の両方の引数を同じ値`sqrt( 1 - sx/g * sx/g)`で割っているため，そもそも割る必要がないのではないかと思いました．
