### PR TITLE
Use % operator instead of format

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -265,7 +265,7 @@ def initCORBA():
                 if not nsport : nsport = 15005
 
         print "configuration ORB with ", nshost, ":", nsport
-        os.environ['ORBInitRef'] = 'NameService=corbaloc:iiop:{0}:{1}/NameService'.format(nshost,nsport)
+        os.environ['ORBInitRef'] = 'NameService=corbaloc:iiop:%s:%s/NameService'%(nshost,nsport)
 
         try:
                 orb = CORBA.ORB_init(sys.argv, CORBA.ORB_ID)


### PR DESCRIPTION
format による文字列操作はpyton 2.6以降でないと動かず、
使用している環境（ubuntu 8.04のpython 2.5.2）では以下にすると動きます。
%オペレータによる処理よりformatの方が推奨されてると思いますが、
deprecateでないので、変更していただけると助かります。
