### PR TITLE
Add DataLogger clear in setupLogger to start log data with same starting time

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -513,6 +513,7 @@ class HrpsysConfigurator:
             self.connectLoggerPort(self.rh, 'emergencySignal', 'emergencySignal')
         for sen in filter(lambda x : x.type == "Force", self.sensors):
             self.connectLoggerPort(self.seq, sen.name+"Ref")
+        self.log_svc.clear()
 
     def waitForRTCManager(self, managerhost=nshost):
         self.ms = None


### PR DESCRIPTION
hrpsys_config.pyのsetupLoggerで、
ポート接続した後にlog_svc clearを呼ぶように変更したいです。
これがないと、最初のデータがlog_svc.addのタイミングで
各データポートごとにまちまちになるためです。

また、DataLoggerのログにもタイムスタンプはついていますが、
長さが揃っていた方が扱いやすいことが多いです。
