### PR TITLE
Add getRTCList for unstable RTCs

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -450,6 +450,32 @@ class HrpsysConfigurator:
             ['log', "DataLogger"]
             ]
 
+    # public method to configure all RTCs to be activated on rtcd which includes unstable RTCs
+    def getRTCListUnstable(self):
+        '''
+        @rtype [[str]]
+        @rerutrn List of available unstable components. Each element consists of a list
+                 of abbreviated and full names of the component.
+        '''
+        return [
+            ['seq', "SequencePlayer"],
+            ['sh', "StateHolder"],
+            ['fk', "ForwardKinematics"],
+            ['tf', "TorqueFilter"],
+            ['kf', "KalmanFilter"],
+            ['vs', "VirtualForceSensor"],
+            ['rmfo', "RemoveForceSensorLinkOffset"],
+            ['ic', "ImpedanceController"],
+            ['abc', "AutoBalancer"],
+            ['st', "Stabilizer"],
+            ['co', "CollisionDetector"],
+            ['tc', "TorqueController"],
+            #['te', "ThermoEstimator"],
+            #['tl', "ThermoLimiter"],
+            ['el', "SoftErrorLimiter"],
+            ['log', "DataLogger"]
+            ]
+
     def getJointAngleControllerList(self):
         controller_list = [self.ic, self.gc, self.abc, self.st, self.co, self.tc, self.el]
         return filter(lambda c : c != None, controller_list) # only return existing controllers


### PR DESCRIPTION
[1]に議論されているように、UnstableなRTCのためのgetRTCListを追加しました。
stableRTCのユーザには副作用はないはずです。
リストは、まずはgetRTCListにもともとあったもの[2]をつらねてあります。

[1] https://github.com/fkanehiro/hrpsys-base/issues/210#issuecomment-41701441
[2] https://github.com/fkanehiro/hrpsys-base/commit/53de9aabf2ce9df93c9f243a223413f2f1081df6#diff-6c33bc3d5bb515b220c1b7d93821cd9d
