### PR TITLE
Removed TwoDofController, which is not used in ThermoLimiter now

### DIFF
--- a/rtc/ThermoLimiter/CMakeLists.txt
+++ b/rtc/ThermoLimiter/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(comp_sources ThermoLimiter.cpp ../SoftErrorLimiter/beep.cpp ../Stabilizer/TwoDofController.cpp)
+set(comp_sources ThermoLimiter.cpp ../SoftErrorLimiter/beep.cpp)
 set(libs hrpModel-3.1 hrpUtil-3.1 hrpsysBaseStub)
 add_library(ThermoLimiter SHARED ${comp_sources})
 target_link_libraries(ThermoLimiter ${libs})

--- a/rtc/ThermoLimiter/ThermoLimiter.cpp
+++ b/rtc/ThermoLimiter/ThermoLimiter.cpp
@@ -153,25 +153,6 @@ RTC::ReturnCode_t ThermoLimiter::onInitialize()
     }
     std::cerr << std::endl;
   }
-  
-  // make torque controller
-  // set limit of motor heat parameters
-  coil::vstring torqueControllerParamsFromConf = coil::split(prop["torque_controller_params"], ",");
-  m_motorTwoDofControllers.resize(m_robot->numJoints());
-  if (torqueControllerParamsFromConf.size() != 2 * m_robot->numJoints()) {
-    std::cerr <<  "[WARN]: size of torque_controller_params is " << torqueControllerParamsFromConf.size() << ", not equal to 2 * " << m_robot->numJoints() << std::endl;
-    for (std::vector<TwoDofController>::iterator it = m_motorTwoDofControllers.begin(); it != m_motorTwoDofControllers.end() ; ++it) {
-      (*it).setup(400.0, 0.04, m_dt); // set default params
-      // (*it).setup(400.0, 1.0, m_dt);
-    }
-  } else {
-    double tdcParamK, tdcParamT;
-    for (int i = 0; i < m_robot->numJoints(); i++) {
-      coil::stringTo(tdcParamK, torqueControllerParamsFromConf[2 * i].c_str());
-      coil::stringTo(tdcParamT, torqueControllerParamsFromConf[2 * i + 1].c_str());
-      m_motorTwoDofControllers[i].setup(tdcParamK, tdcParamT, m_dt);
-    }
-  }
 
   // allocate memory for outPorts
   m_tauMaxOut.data.length(m_robot->numJoints());

--- a/rtc/ThermoLimiter/ThermoLimiter.h
+++ b/rtc/ThermoLimiter/ThermoLimiter.h
@@ -21,7 +21,6 @@
 #include <hrpModel/Link.h>
 #include <hrpModel/JointPath.h>
 
-#include "../Stabilizer/TwoDofController.h"
 #include "../ThermoEstimator/MotorHeatParam.h"
 
 // Service implementation headers
@@ -149,7 +148,6 @@ class ThermoLimiter
   unsigned int m_debugLevel;
   std::vector<double> m_motorTemperatureLimit;
   hrp::BodyPtr m_robot;
-  std::vector<TwoDofController> m_motorTwoDofControllers;
   std::vector<MotorHeatParam> m_motorHeatParams;
 
   bool limitTemperature(hrp::dvector &tauMax);


### PR DESCRIPTION
Removed dependancy to TwoDofController in ThermoLimiter.
TwoDofController is not used in ThermoLimiter because the feature of torque control was separated to TorqueController.
