### PR TITLE
(CMakeLists.txt) Add ${PYTHON_VERSION} argument in find_package of PythonLibs

### DIFF
--- a/util/simulator/CMakeLists.txt
+++ b/util/simulator/CMakeLists.txt
@@ -4,7 +4,7 @@ configure_file(hrpsys-simulator-python.in ${CMAKE_CURRENT_BINARY_DIR}/hrpsys-sim
 include_directories(${OpenCV_INCLUDE_DIRS})
 include_directories(${LIBXML2_INCLUDE_DIR})
 include_directories(${SDL_INCLUDE_DIR})
-find_package(PythonLibs)
+find_package(PythonLibs ${PYTHON_VERSION} REQUIRED)
 include_directories(${PYTHON_INCLUDE_DIRS})
 
 set(target hrpsys-simulator)


### PR DESCRIPTION
はじめまして。私の環境（Ubuntu 12.04 64bit）でhrpsys-baseをコンパイルを試みたところ、Pythonライブラリのバージョン問題が原因でコンパイルに失敗する例が発生しましたので、その解決策を含め、ご報告させてもらいます。より良い解決策がすでにあるようでしたら、このPRは無視してください。

https://github.com/fkanehiro/hrpsys-base/blob/master/INSTALL#L32
の通りインストールを進めたところ、`make`の過程で以下の部分でコンパイルエラーになりました。

``` sh
Scanning dependencies of target hrpsys-monitor
[ 96%] Building CXX object util/monitor/CMakeFiles/hrpsys-monitor.dir/GLscene.o
[ 96%] Building CXX object util/monitor/CMakeFiles/hrpsys-monitor.dir/Monitor.o
[ 97%] Building CXX object util/simulator/CMakeFiles/hrpsysext.dir/PyLink.o
[ 97%] Building CXX object util/monitor/CMakeFiles/hrpsys-monitor.dir/main.o
[ 97%] Building CXX object util/simulator/CMakeFiles/hrpsysext.dir/PyShape.o
Linking CXX shared library ../../lib/hrpsysext.so
CMakeFiles/hrpsysext.dir/PySimulator.o: In function `PyInit_hrpsysext':
PySimulator.cpp:(.text+0x34f0): undefined reference to `boost::python::detail::init_module(PyModuleDef&, void (*)())'
collect2: ld returned 1 exit status
make[2]: *** [lib/hrpsysext.so] Error 1
make[1]: *** [util/simulator/CMakeFiles/hrpsysext.dir/all] Error 2
make[1]: *** Waiting for unfinished jobs....
Linking CXX executable ../../bin/hrpsys-monitor
[ 97%] Built target hrpsys-monitor
make: *** [all] Error 2
```

原因を調べてみたところ、Pythonライブラリのバージョン指定に問題があることがわかりました。私の環境にはPythonの処理系が2.7と3.2のものがインストールされており、デフォルトでは2.7を使用するようになっているのですが、`cmake`の出力を詳しく見てみると、PythonLibsだけがバージョン3.2のものを使うようになってしまっているようでした。

``` sh
-- Found PythonLibs: /usr/lib/libpython3.2mu.so (found suitable version "3.2.3", required is "2.7")
```

そこで、今回のコミットで`${PYTHON_VERSION}`の引数をつけたところ、デフォルトバージョンである2.7がものが正しく使われるようになり、コンパイル、インストールに成功することができました。

``` sh
-- Found PythonLibs: /usr/lib/libpython2.7.so (found suitable version "2.7.3", required is "2.7") 
```
