### PR TITLE
Add logger connection for walking RTCs

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -556,6 +556,12 @@ class HrpsysConfigurator:
             self.connectLoggerPort(self.sh, 'basePosOut')
             self.connectLoggerPort(self.sh, 'baseRpyOut')
             self.connectLoggerPort(self.sh, 'zmpOut')
+        if self.abc != None:
+            self.connectLoggerPort(self.abc, 'zmpRef')
+            self.connectLoggerPort(self.abc, 'baseTformOut')
+            self.connectLoggerPort(self.abc, 'q')
+        if self.st != None:
+            self.connectLoggerPort(self.st, 'zmp')
         if self.rh != None:
             self.connectLoggerPort(self.rh, 'emergencySignal',
                                    'emergencySignal')


### PR DESCRIPTION
(hrpsys_config.py) : Add logger connection for walking RTCs.

This PR will have no influence for the users for Stable RTCs because it check abc and st existence.
