### PR TITLE
add error message when socket.gethostbyadder() failed

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -332,9 +332,10 @@ def findRTCmanager(hostname=None, rnc=None):
         try:
                 socket.gethostbyaddr(hostname)
         except Exception as e:
-                sys.exit('[ERROR] {0}\n'.format(str(e))+
-                         '[ERROR] Could not get hostname for {0}\n'.format(hostname)+
-                         '[ERROR] Make sure that you set hostname and address in DNS or /etc/hosts')
+                sys.exit('[ERROR] {0}\n'.format(str(e)) +
+                         '[ERROR] Could not get hostname for {0}\n'.format(hostname) +
+                         '[ERROR] Make sure that you set the target hostname and address in DNS' +
+                         ' or /etc/hosts in linux/unix.')
 
 
         def getManagerFromNS(hostname, mgr = None):


### PR DESCRIPTION
https://github.com/start-jsk/rtmros_hironx/issues/136#event-138499873
で報告されているようにnameserverの場所をIPアドレスでしていしているけど，ホスト名が引けない場合に
エラーになるようですので，エラーチェックをするようにしました．（この説明でよかったでしょうか @130s)

また，そもそもここでhostnameに切り替えている理由はありますか？
nameserver（サーバ？）が立ち上がるときに自分の場所をホスト名だと思っていると，クライアントからIPアドレスでつなげようとすると動かない，みたいなはなしでしょうか？
