### PR TITLE
Move nullspace codes to calcInverseKinematics2Loop

### DIFF
--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -15,8 +15,8 @@ namespace hrp {
   public:
     JointPathEx(BodyPtr& robot, Link* base, Link* end);
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
-    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, dvector &dq);
-    bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R);
+    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, dvector &dq, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
+    bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     double getSRGain() { return sr_gain; }
     bool setSRGain(double g) { sr_gain = g; }
     double getManipulabilityLimit() { return manipulability_limit; }


### PR DESCRIPTION
#114

にあるように、solveLimbIK関数をなくしていくための変更で、
NullSpaceのコードの場所を移行するものです。

StableRTCであるSequenePlayerのsetTargetPoseで使われているコードに変更がありますが、
デフォルト引数によりNullSpaceをデフォルトでつかわなくしているので、挙動は同じになります。
（StableRTCの方にも影響がないと思います）

よろしくお願いします。

関連
#171

https://github.com/fkanehiro/hrpsys-base/issues/215
