### PR TITLE
Remove solveLimbIK and use calcInverseKinematics2Loop

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -445,7 +445,7 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param, const double transitio
   hrp::Vector3 vel_p, vel_r;
   vel_p = param.target_p0 - param.current_p0;
   rats::difference_rotation(vel_r, param.current_r0, param.target_r0);
-  param.manip->solveLimbIK(vel_p, vel_r, transition_count, 0.001, 0.01, MAX_TRANSITION_COUNT, qrefv, DEBUGP);
+  param.manip->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
   return true;
 }
 

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -446,7 +446,7 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
                 std::cerr << "vel_p : " << vel_p[0] << " " << vel_p[1] << " " << vel_p[2] << std::endl;
                 std::cerr << "vel_r : " << vel_r[0] << " " << vel_r[1] << " " << vel_r[2] << std::endl;
             }
-            manip->solveLimbIK(vel_p, vel_r, param.transition_count, param.avoid_gain, param.reference_gain, MAX_TRANSITION_COUNT, qrefv, DEBUGP);
+            manip->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, param.avoid_gain, param.reference_gain, &qrefv);
 
 	    param.current_p2 = param.current_p1;
 	    param.current_p1 = param.current_p0 + vel_p;

--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -15,21 +15,13 @@ namespace hrp {
   public:
     JointPathEx(BodyPtr& robot, Link* base, Link* end);
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
-    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, dvector &dq, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
+    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     double getSRGain() { return sr_gain; }
     bool setSRGain(double g) { sr_gain = g; }
     double getManipulabilityLimit() { return manipulability_limit; }
     bool setManipulabilityLimit(double l) { manipulability_limit = l; }
     bool setManipulabilityGain(double l) { manipulability_gain = l; }
-    void solveLimbIK (const hrp::Vector3& _vel_p,
-                      const hrp::Vector3& _vel_r,
-                      const int transition_count,
-                      const double avoid_gain,
-                      const double reference_gain,
-                      const double MAX_TRANSITION_COUNT,
-                      const hrp::dvector& qrefv,
-                      bool DEBUGP = false);
     void setMaxIKError(double epos, double erot);
     void setMaxIKError(double e);
     void setMaxIKIteration(int iter);

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -593,7 +593,7 @@ void Stabilizer::calcTPCC() {
           hrp::Vector3 vel_p, vel_r;
           vel_p = target_foot_p[i] - target->p;
           rats::difference_rotation(vel_r, target->R, target_foot_R[i]);
-          manip2[i]->solveLimbIK(vel_p, vel_r, transition_count, 0.001, 0.01, MAX_TRANSITION_COUNT, qrefv, false);
+          manip2[i]->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
         }
       }
     }
@@ -754,7 +754,7 @@ void Stabilizer::calcEEForceMomentControl() {
           hrp::Vector3 vel_p, vel_r;
           vel_p = total_target_foot_p[i] - target->p;
           rats::difference_rotation(vel_r, target->R, total_target_foot_R[i]);
-          manip2[i]->solveLimbIK(vel_p, vel_r, transition_count, 0.001, 0.01, MAX_TRANSITION_COUNT, qrefv, false);
+          manip2[i]->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
         }
       }
     }


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/114
で議論しておりました、solveLimbIKを消して逆運動学のコードを一本化する変更です。
（これが通れば#114はcloseにできると思います）

calcInverseKinematics2Loopが一回の関節角速度計算で、
calcInverseKinematics2がそれをループで呼んで収束計算まで行うもので、
calcInveseKinematics2LoopがsolveLimbIKに相当するので
今回の変更ではsolveLimbIKをけしてcalcInveseKinematics2Loopでおきかえています。

StableRTCのユーザが使うプログラムの挙動がかわりうる部分に、１点変更があります。
今まではcalcInverseKinematics2のループの最後でのみ
ulimitとllimitのチェックが行われておりましたが、
calcInverseKinematics2Loopの最後でチェックするようにしました。
