### PR TITLE
Interplate default_zmp_offsets

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -25,6 +25,7 @@
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "AutoBalancerService_impl.h"
+#include "interpolator.h"
 
 // </rtc-template>
 
@@ -203,6 +204,9 @@ class AutoBalancer
   double m_dt, move_base_gain;
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
+
+  double zmp_interpolate_time;
+  interpolator *zmp_interpolator;
 
   // static balance point offsetting
   hrp::Vector3 sbp_offset, sbp_cog_offset;

--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(comp_sources AutoBalancer.cpp AutoBalancerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp PreviewController.cpp GaitGenerator.cpp)
+set(comp_sources AutoBalancer.cpp AutoBalancerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp ../SequencePlayer/interpolator.cpp PreviewController.cpp GaitGenerator.cpp)
 set(libs hrpModel-3.1 hrpCollision-3.1 hrpUtil-3.1 hrpsysBaseStub)
 add_library(AutoBalancer SHARED ${comp_sources})
 target_link_libraries(AutoBalancer ${libs})
@@ -12,6 +12,8 @@ target_link_libraries(testGaitGenerator ${libs})
 
 add_executable(AutoBalancerComp AutoBalancerComp.cpp ${comp_sources})
 target_link_libraries(AutoBalancerComp ${libs})
+
+include_directories(${PROJECT_SOURCE_DIR}/rtc/SequencePlayer)
 
 set(target AutoBalancer AutoBalancerComp testPreviewController testGaitGenerator)
 


### PR DESCRIPTION
I talked with @snozawa , and modified AutoBalancer to interpolate default_zmp_offsets when `AutoBalancer::setAutoBalancerParam` is called.
SequencePlayer/interpolator is used to interpolate.

I'd like some experts to see whether this PR is OK or not.

I checked this PR works by the following test environment.

```
rtmlaunch hrpsys_ros_bridge_tutorials hrp2jsknt.launch
# another terminal
ipython -i `rospack find hrpsys_tools`/scripts/hrpsys_tools_config.py -- --use-unstable-rtc HRP2JSKNT\(Robot\)0 /home/murooka/prog/OpenHRP/etc/HRP2JSKNT_for_OpenHRP3/HRP2JSKNTmain.wrl \\-ORBInitRef NameService=corbaloc:iiop:localhost:15005/NameService
# reset pose
hcf.seq_svc.setJointAngles([0.0, 0.0, -0.453786, 0.872665, -0.418879, 0.0, 0.0, 0.0, 0.0, -0.453786, 0.872665, -0.418879, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.174533, -0.174533, 0.0, -0.436332, 0.0, 0.0, -0.174533, 0.261799, 0.174533, 0.174533, 0.0, -0.436332, 0.0, 0.0, -0.174533, -0.261799],1)
hcf.seq_svc.waitInterpolation()
# start AutoBalancer
hcf.abc_svc.startAutoBalancer([":rleg", ":lleg"])
# set AutoBalancer ZMP offset
p=hcf.abc_svc.getAutoBalancerParam()
p[1].default_zmp_offsets=[[0.05, 0.0, 0.0], [0.05, 0.0, 0.0]]
hcf.abc_svc.setAutoBalancerParam(p[1])
```

I confirmed that default_zmp_offsets is interpolated correctly by the log output: https://github.com/mmurooka/hrpsys-base/compare/interpolate-abc-zmp-offset?expand=1#diff-eb446f98e459d63000964d63fc0a3365R335.
HRP2 in hrpsys-simulator also moves smoothly when I changed default_zmp_offsets.
