### PR TITLE
Use .in file to specify openhrp3 directory and update RMFO sample

### DIFF
--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -11,14 +11,20 @@ foreach(_idx 0 1)
   configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.${_tmp_controller_period}.conf)
 endforeach()
 
+# Use configure_file to specify openhrp3 directory for sample1.wrl model
 configure_file(samplerobot_walk.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_walk.py)
+configure_file(samplerobot_auto_balancer.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_auto_balancer.py)
+configure_file(samplerobot_data_logger.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_data_logger.py)
+configure_file(samplerobot_impedance_controller.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_impedance_controller.py)
+configure_file(samplerobot_remove_force_offset.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_remove_force_offset.py)
+configure_file(samplerobot_stabilizer.py.in ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_stabilizer.py)
 
 install(PROGRAMS
-  samplerobot_data_logger.py
-  samplerobot_auto_balancer.py
-  samplerobot_stabilizer.py
-  samplerobot_remove_force_offset.py
-  samplerobot_impedance_controller.py
+  ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_data_logger.py
+  ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_auto_balancer.py
+  ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_stabilizer.py
+  ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_remove_force_offset.py
+  ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_impedance_controller.py
   ${CMAKE_CURRENT_BINARY_DIR}/samplerobot_walk.py
   DESTINATION share/hrpsys/samples/SampleRobot)
 

--- a/sample/SampleRobot/samplerobot_auto_balancer.py.in
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py.in
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0")
+    hcf.init ("SampleRobot(Robot)0", "@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/sample1.wrl")
 
 def demo():
     init()

--- a/sample/SampleRobot/samplerobot_data_logger.py.in
+++ b/sample/SampleRobot/samplerobot_data_logger.py.in
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0")
+    hcf.init ("SampleRobot(Robot)0", "@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/sample1.wrl")
 
 def demo ():
     init()

--- a/sample/SampleRobot/samplerobot_impedance_controller.py.in
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py.in
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0")
+    hcf.init ("SampleRobot(Robot)0", "@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/sample1.wrl")
 
 def demo():
     init()

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py.in
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py.in
@@ -17,18 +17,20 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0")
+    hcf.init ("SampleRobot(Robot)0", "@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/sample1.wrl")
 
 def demo():
     import numpy
     init()
     # set initial pose from sample/controller/SampleController/etc/Sample.pos
     initial_pose = [-7.779e-005,  -0.378613,  -0.000209793,  0.832038,  -0.452564,  0.000244781,  0.31129,  -0.159481,  -0.115399,  -0.636277,  0,  0,  0.637045,  -7.77902e-005,  -0.378613,  -0.000209794,  0.832038,  -0.452564,  0.000244781,  0.31129,  0.159481,  0.115399,  -0.636277,  0,  0,  -0.637045,  0,  0,  0]
-    hcf.seq_svc.setJointAngles(initial_pose, 0.5)
+    hcf.seq_svc.setJointAngles(initial_pose, 2.5)
     hcf.seq_svc.waitInterpolation()
     # 1. force and moment are large because of link offsets
-    print numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_rhsensor")).data) > 1e-2
-    print numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_lhsensor")).data) > 1e-2
+    fm=numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_rhsensor")).data)
+    print "no-offset-removed force moment (rhsensor) ", fm, "=> ", fm > 1e-2
+    fm=numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_lhsensor")).data)
+    print "no-offset-removed force moment (lhsensor) ", fm, "=> ", fm > 1e-2
     # 2. Set link offsets
     #    link_offset_centroid and link_offset_mass are identified value.
     hcf.rmfo_svc.setForceMomentOffsetParam("rhsensor", OpenHRP.RemoveForceSensorLinkOffsetService.forcemomentOffsetParam(force_offset=[0,0,0], moment_offset=[0,0,0], link_offset_centroid=[0,0.0368,-0.076271], link_offset_mass=0.800011))
@@ -40,5 +42,7 @@ def demo():
     if ret[0] and ret[1].link_offset_mass == 0.800011:
         print "getForceMomentOffsetParam(\"lhsensor\") => OK"
     # 3. force and moment are reduced
-    print numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_lhsensor")).data) < 1e-2
-    print numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_lhsensor")).data) < 1e-2
+    fm=numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_rhsensor")).data)
+    print "no-offset-removed force moment (rhsensor) ", fm, "=> ", fm < 1e-2
+    fm=numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_lhsensor")).data)
+    print "no-offset-removed force moment (lhsensor) ", fm, "=> ", fm < 1e-2

--- a/sample/SampleRobot/samplerobot_stabilizer.py.in
+++ b/sample/SampleRobot/samplerobot_stabilizer.py.in
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0")
+    hcf.init ("SampleRobot(Robot)0", "@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/sample1.wrl")
 
 def demo():
     init()


### PR DESCRIPTION
(samplerobot*, samples/SampleRobot/CMakeLists.txt)
Use .in file to specify openhrp3 directory for sample1.wrl model.
hrpsys_config.py requires VRML path (url) on initializing, which is used in `getBodyInfo` for sensors information.
Update RemoveForceSensorOffset sample according to update of sensor information.
