### PR TITLE
Add sample6dofrobot VRML

### DIFF
--- a/sample/CMakeLists.txt
+++ b/sample/CMakeLists.txt
@@ -8,6 +8,7 @@ endif()
 add_subdirectory(PA10)
 add_subdirectory(HRP4C)
 add_subdirectory(SampleRobot)
+add_subdirectory(Sample6dofRobot)
 
 install(PROGRAMS
   simTest1.py simTest2.py simTest3.py simTest4.py simTest5.py

--- a/sample/Sample6dofRobot/CMakeLists.txt
+++ b/sample/Sample6dofRobot/CMakeLists.txt
@@ -1,0 +1,18 @@
+configure_file(Sample6dofRobot.RobotHardware.conf.in ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.RobotHardware.conf)
+configure_file(Sample6dofRobot.xml.in ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.xml)
+configure_file(Sample6dofRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.conf)
+
+# Use configure_file to specify hrpsys install directory for sample6dofrobot model
+configure_file(sample6dofrobot_kalman_filter.py.in ${CMAKE_CURRENT_BINARY_DIR}/sample6dofrobot_kalman_filter.py)
+
+install(PROGRAMS
+  ${CMAKE_CURRENT_BINARY_DIR}/sample6dofrobot_kalman_filter.py
+  DESTINATION share/hrpsys/samples/Sample6dofRobot)
+
+install(FILES 
+  ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.conf
+  ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.xml
+  ${CMAKE_CURRENT_BINARY_DIR}/Sample6dofRobot.RobotHardware.conf
+  Sample6dofRobot.wrl
+  DESTINATION share/hrpsys/samples/Sample6dofRobot)
+

--- a/sample/Sample6dofRobot/Sample6dofRobot.RobotHardware.conf.in
+++ b/sample/Sample6dofRobot/Sample6dofRobot.RobotHardware.conf.in
@@ -1,0 +1,4 @@
+model: file://@CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/Sample6dofRobot/Sample6dofRobot.wrl
+exec_cxt.periodic.type: hrpExecutionContext
+exec_cxt.periodic.rate: 200
+

--- a/sample/Sample6dofRobot/Sample6dofRobot.conf.in
+++ b/sample/Sample6dofRobot/Sample6dofRobot.conf.in
@@ -1,0 +1,3 @@
+model: file://@CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/Sample6dofRobot/Sample6dofRobot.wrl
+dt: 0.005
+

--- a/sample/Sample6dofRobot/Sample6dofRobot.wrl
+++ b/sample/Sample6dofRobot/Sample6dofRobot.wrl
@@ -1,0 +1,1514 @@
+#VRML V2.0 utf8
+
+# Produced by EusLisp 9.00(e6031bb 8939ea3 63139) for Linux64 created on W540-nozawa(Sat Jul 19 16:26:23 JST 2014)
+# Date: Wed Jul 30 13:40:36 2014
+
+
+PROTO Joint [
+ exposedField     SFVec3f      center              0 0 0
+ exposedField     MFNode       children            []
+ exposedField     MFFloat      llimit              []
+ exposedField     SFRotation   limitOrientation    0 0 1 0
+ exposedField     SFString     name                ""
+ exposedField     SFRotation   rotation            0 0 1 0
+ exposedField     SFVec3f      scale               1 1 1
+ exposedField     SFRotation   scaleOrientation    0 0 1 0
+ exposedField     MFFloat      stiffness           [ 0 0 0 ]
+ exposedField     SFVec3f      translation         0 0 0
+ exposedField     MFFloat      ulimit              []
+ exposedField     MFFloat      dh                  [0 0 0 0]
+ exposedField     SFString     jointType           ""
+ exposedField     SFInt32      jointId             -1
+ exposedField     SFVec3f     jointAxis           0 0 1
+]
+{
+   Transform {
+      center           IS center
+      children         IS children
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+   }
+}
+
+PROTO Segment [
+ field           SFVec3f     bboxCenter        0 0 0
+ field           SFVec3f     bboxSize          -1 -1 -1
+ exposedField    SFVec3f     centerOfMass      0 0 0
+ exposedField    MFNode      children          [ ]
+ exposedField    SFNode      coord             NULL
+ exposedField    MFNode      displacers        [ ]
+ exposedField    SFFloat     mass              0
+ exposedField    MFFloat     momentsOfInertia  [ 0 0 0 0 0 0 0 0 0 ]
+ exposedField    SFString    name              ""
+ eventIn         MFNode      addChildren
+ eventIn         MFNode      removeChildren
+]
+{
+   Group {
+      addChildren    IS addChildren
+      bboxCenter     IS bboxCenter
+      bboxSize       IS bboxSize
+      children       IS children
+      removeChildren IS removeChildren
+   }
+}
+
+
+PROTO Humanoid [
+ field           SFVec3f    bboxCenter            0 0 0
+ field           SFVec3f    bboxSize              -1 -1 -1
+ exposedField    SFVec3f    center                0 0 0
+ exposedField    MFNode     humanoidBody          [ ]
+ exposedField    MFString   info                  [ ]
+ exposedField    MFNode     joints                [ ]
+ exposedField    SFString   name                  ""
+ exposedField    SFRotation rotation              0 0 1 0
+ exposedField    SFVec3f    scale                 1 1 1
+ exposedField    SFRotation scaleOrientation      0 0 1 0
+ exposedField    MFNode     segments              [ ]
+ exposedField    MFNode     sites                 [ ]
+ exposedField    SFVec3f    translation           0 0 0
+ exposedField    SFString   version               "1.1"
+ exposedField    MFNode     viewpoints            [ ]
+]
+{
+   Transform {
+      bboxCenter       IS bboxCenter
+      bboxSize         IS bboxSize
+      center           IS center
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+      children [
+         Group {
+            children IS viewpoints
+         }
+         Group {
+            children IS humanoidBody
+         }
+      ]
+   }
+}
+
+
+PROTO VisionSensor [
+  exposedField SFVec3f    translation       0 0 0
+  exposedField SFRotation rotation              0 0 1 0
+  #exposedField SFRotation orientation       0 0 1 0
+  exposedField SFFloat    fieldOfView       0.785398
+  exposedField SFString   name              ""
+  exposedField SFFloat    frontClipDistance 0.01
+  exposedField SFFloat    backClipDistance  10.0
+  exposedField SFString   type              "NONE"
+  exposedField SFInt32    sensorId          -1
+  exposedField SFInt32    width             320  # 
+  exposedField SFInt32    height            240  # 
+  #exposedField MFNode       children            [] # for me
+]
+{
+  Transform {
+    rotation         IS rotation
+    translation      IS translation
+    #children IS children # for me
+  }
+}
+
+
+PROTO ForceSensor [
+  exposedField SFVec3f maxForce -1 -1 -1
+  exposedField SFVec3f maxTorque -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO Gyro [
+  exposedField SFVec3f maxAngularVelocity -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO AccelerationSensor [
+  exposedField SFVec3f maxAcceleration -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO PressureSensor [
+  exposedField SFFloat maxPressure -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+
+NavigationInfo {
+   avatarSize    0.5
+   headlight     TRUE
+   type  ["EXAMINE", "ANY"]
+}
+Viewpoint {
+   position    3 0 0.835
+   orientation 0.5770 0.5775 0.5775 2.0935
+}
+DEF Sample6dofRobot Humanoid {
+   humanoidBody [
+    DEF WAIST Joint {
+       jointType "fixed"
+       dh [0 0 0 0]
+       translation 0.000000 0.000000 0.250000
+       rotation 0.0 0.0 1.0 0
+       children [
+          DEF link0_S Segment {
+             centerOfMass 0.0 0.0 0.0
+             mass 1.0
+             momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+             children [
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF link0-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.996094 0.414062 0.414062,
+                         ]
+                      }
+                      coord DEF link0-COORD Coordinate {
+                         point[
+                          0.250000 0.005000 -0.005000,
+                          0.250000 0.005000 0.005000,
+                          0.250000 -0.005000 -0.005000,
+                          0.250000 -0.005000 0.005000,
+                          -0.250000 0.005000 -0.005000,
+                          -0.250000 -0.005000 -0.005000,
+                          -0.250000 -0.005000 0.005000,
+                          -0.250000 0.005000 0.005000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+             ]
+          } #Segment
+          DEF link1 Joint {
+             jointType "slide"
+             dh [0 0 0 0]
+             jointId 0
+             jointAxis 1.0 0.0 0.0
+             ulimit [0.25]
+             llimit [-0.25]
+             translation 0.000000 0.000000 0.000000
+             rotation 0.0 0.0 1.0 0
+             children [
+                DEF link1_S Segment {
+                   centerOfMass 0.0 0.0 0.0
+                   mass 1.0
+                   momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                   children [
+                      Shape {
+                         appearance Appearance {
+                            material Material {
+                            }
+                         }
+                         geometry DEF link1-FACES IndexedFaceSet {
+                            creaseAngle 0.8
+                            ccw TRUE
+                            solid TRUE
+                            colorPerVertex FALSE
+                            color Color {
+                               color [
+                                0.304688 0.929688 0.578125,
+                               ]
+                            }
+                            coord DEF link1-COORD Coordinate {
+                               point[
+                                0.005000 0.250000 -0.005000,
+                                0.005000 0.250000 0.005000,
+                                0.005000 -0.250000 -0.005000,
+                                0.005000 -0.250000 0.005000,
+                                -0.005000 0.250000 -0.005000,
+                                -0.005000 -0.250000 -0.005000,
+                                -0.005000 -0.250000 0.005000,
+                                -0.005000 0.250000 0.005000,
+                               ]
+                            }
+                            coordIndex [
+                             3, 1, 7, -1,
+                             7, 6, 3, -1,
+                             5, 4, 0, -1,
+                             0, 2, 5, -1,
+                             7, 1, 0, -1,
+                             0, 4, 7, -1,
+                             1, 3, 2, -1,
+                             2, 0, 1, -1,
+                             3, 6, 5, -1,
+                             5, 2, 3, -1,
+                             6, 7, 4, -1,
+                             4, 5, 6, -1,
+                            ]
+                            colorIndex [
+                             0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                            ]
+                         }
+                      }
+                   ]
+                } #Segment
+                DEF link2 Joint {
+                   jointType "slide"
+                   dh [0 0 0 0]
+                   jointId 1
+                   jointAxis 0.0 1.0 0.0
+                   ulimit [0.25]
+                   llimit [-0.25]
+                   translation 0.000000 0.000000 0.000000
+                   rotation 0.0 0.0 1.0 0
+                   children [
+                      DEF link2_S Segment {
+                         centerOfMass 0.0 0.0 0.0
+                         mass 1.0
+                         momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                         children [
+                            Shape {
+                               appearance Appearance {
+                                  material Material {
+                                  }
+                               }
+                               geometry DEF link2-FACES IndexedFaceSet {
+                                  creaseAngle 0.8
+                                  ccw TRUE
+                                  solid TRUE
+                                  colorPerVertex FALSE
+                                  color Color {
+                                     color [
+                                      0.476562 0.402344 0.929688,
+                                     ]
+                                  }
+                                  coord DEF link2-COORD Coordinate {
+                                     point[
+                                      0.005000 0.005000 -0.250000,
+                                      0.005000 0.005000 0.250000,
+                                      0.005000 -0.005000 -0.250000,
+                                      0.005000 -0.005000 0.250000,
+                                      -0.005000 0.005000 -0.250000,
+                                      -0.005000 -0.005000 -0.250000,
+                                      -0.005000 -0.005000 0.250000,
+                                      -0.005000 0.005000 0.250000,
+                                     ]
+                                  }
+                                  coordIndex [
+                                   3, 1, 7, -1,
+                                   7, 6, 3, -1,
+                                   5, 4, 0, -1,
+                                   0, 2, 5, -1,
+                                   7, 1, 0, -1,
+                                   0, 4, 7, -1,
+                                   1, 3, 2, -1,
+                                   2, 0, 1, -1,
+                                   3, 6, 5, -1,
+                                   5, 2, 3, -1,
+                                   6, 7, 4, -1,
+                                   4, 5, 6, -1,
+                                  ]
+                                  colorIndex [
+                                   0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                  ]
+                               }
+                            }
+                         ]
+                      } #Segment
+                      DEF link3 Joint {
+                         jointType "slide"
+                         dh [0 0 0 0]
+                         jointId 2
+                         jointAxis 0.0 0.0 1.0
+                         ulimit [0.25]
+                         llimit [-0.25]
+                         translation 0.000000 0.000000 0.000000
+                         rotation 0.0 0.0 1.0 0
+                         children [
+                            DEF link3_S Segment {
+                               centerOfMass 0.0 0.0 0.0
+                               mass 1.0
+                               momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                               children [
+                                  Shape {
+                                     appearance Appearance {
+                                        material Material {
+                                        }
+                                     }
+                                     geometry DEF link3-FACES IndexedFaceSet {
+                                        creaseAngle 0.8
+                                        ccw TRUE
+                                        solid TRUE
+                                        colorPerVertex FALSE
+                                        color Color {
+                                           color [
+                                            0.0 0.0 0.0,
+                                           ]
+                                        }
+                                        coord DEF link3-COORD Coordinate {
+                                           point[
+                                            0.000500 0.000500 -0.000500,
+                                            0.000500 0.000500 0.000500,
+                                            0.000500 -0.000500 -0.000500,
+                                            0.000500 -0.000500 0.000500,
+                                            -0.000500 0.000500 -0.000500,
+                                            -0.000500 -0.000500 -0.000500,
+                                            -0.000500 -0.000500 0.000500,
+                                            -0.000500 0.000500 0.000500,
+                                           ]
+                                        }
+                                        coordIndex [
+                                         3, 1, 7, -1,
+                                         7, 6, 3, -1,
+                                         5, 4, 0, -1,
+                                         0, 2, 5, -1,
+                                         7, 1, 0, -1,
+                                         0, 4, 7, -1,
+                                         1, 3, 2, -1,
+                                         2, 0, 1, -1,
+                                         3, 6, 5, -1,
+                                         5, 2, 3, -1,
+                                         6, 7, 4, -1,
+                                         4, 5, 6, -1,
+                                        ]
+                                        colorIndex [
+                                         0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                        ]
+                                     }
+                                  }
+                               ]
+                            } #Segment
+                            DEF link4 Joint {
+                               jointType "rotate"
+                               dh [0 0 0 0]
+                               jointId 3
+                               jointAxis 1.0 0.0 0.0
+                               ulimit [6.28319]
+                               llimit [-6.28319]
+                               translation 0.000000 0.000000 0.000000
+                               rotation 0.0 0.0 1.0 0
+                               children [
+                                  DEF link4_S Segment {
+                                     centerOfMass 0.0 0.0 0.0
+                                     mass 1.0
+                                     momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                                     children [
+                                        Shape {
+                                           appearance Appearance {
+                                              material Material {
+                                              }
+                                           }
+                                           geometry DEF link4-FACES IndexedFaceSet {
+                                              creaseAngle 0.8
+                                              ccw TRUE
+                                              solid TRUE
+                                              colorPerVertex FALSE
+                                              color Color {
+                                                 color [
+                                                  0.0 0.0 0.0,
+                                                 ]
+                                              }
+                                              coord DEF link4-COORD Coordinate {
+                                                 point[
+                                                  0.000500 0.000500 -0.000500,
+                                                  0.000500 0.000500 0.000500,
+                                                  0.000500 -0.000500 -0.000500,
+                                                  0.000500 -0.000500 0.000500,
+                                                  -0.000500 0.000500 -0.000500,
+                                                  -0.000500 -0.000500 -0.000500,
+                                                  -0.000500 -0.000500 0.000500,
+                                                  -0.000500 0.000500 0.000500,
+                                                 ]
+                                              }
+                                              coordIndex [
+                                               3, 1, 7, -1,
+                                               7, 6, 3, -1,
+                                               5, 4, 0, -1,
+                                               0, 2, 5, -1,
+                                               7, 1, 0, -1,
+                                               0, 4, 7, -1,
+                                               1, 3, 2, -1,
+                                               2, 0, 1, -1,
+                                               3, 6, 5, -1,
+                                               5, 2, 3, -1,
+                                               6, 7, 4, -1,
+                                               4, 5, 6, -1,
+                                              ]
+                                              colorIndex [
+                                               0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                              ]
+                                           }
+                                        }
+                                     ]
+                                  } #Segment
+                                  DEF link5 Joint {
+                                     jointType "rotate"
+                                     dh [0 0 0 0]
+                                     jointId 4
+                                     jointAxis 0.0 1.0 0.0
+                                     ulimit [6.28319]
+                                     llimit [-6.28319]
+                                     translation 0.000000 0.000000 0.000000
+                                     rotation 0.0 0.0 1.0 0
+                                     children [
+                                        DEF link5_S Segment {
+                                           centerOfMass 0.0 0.0 0.0
+                                           mass 1.0
+                                           momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                                           children [
+                                              Shape {
+                                                 appearance Appearance {
+                                                    material Material {
+                                                    }
+                                                 }
+                                                 geometry DEF link5-FACES IndexedFaceSet {
+                                                    creaseAngle 0.8
+                                                    ccw TRUE
+                                                    solid TRUE
+                                                    colorPerVertex FALSE
+                                                    color Color {
+                                                       color [
+                                                        0.0 0.0 0.0,
+                                                       ]
+                                                    }
+                                                    coord DEF link5-COORD Coordinate {
+                                                       point[
+                                                        0.000500 0.000500 -0.000500,
+                                                        0.000500 0.000500 0.000500,
+                                                        0.000500 -0.000500 -0.000500,
+                                                        0.000500 -0.000500 0.000500,
+                                                        -0.000500 0.000500 -0.000500,
+                                                        -0.000500 -0.000500 -0.000500,
+                                                        -0.000500 -0.000500 0.000500,
+                                                        -0.000500 0.000500 0.000500,
+                                                       ]
+                                                    }
+                                                    coordIndex [
+                                                     3, 1, 7, -1,
+                                                     7, 6, 3, -1,
+                                                     5, 4, 0, -1,
+                                                     0, 2, 5, -1,
+                                                     7, 1, 0, -1,
+                                                     0, 4, 7, -1,
+                                                     1, 3, 2, -1,
+                                                     2, 0, 1, -1,
+                                                     3, 6, 5, -1,
+                                                     5, 2, 3, -1,
+                                                     6, 7, 4, -1,
+                                                     4, 5, 6, -1,
+                                                    ]
+                                                    colorIndex [
+                                                     0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                    ]
+                                                 }
+                                              }
+                                           ]
+                                        } #Segment
+                                        DEF link6 Joint {
+                                           jointType "rotate"
+                                           dh [0 0 0 0]
+                                           jointId 5
+                                           jointAxis 0.0 0.0 1.0
+                                           ulimit [6.28319]
+                                           llimit [-6.28319]
+                                           translation 0.000000 0.000000 0.000000
+                                           rotation 0.0 0.0 1.0 0
+                                           children [
+                                              DEF link6_S Segment {
+                                                 centerOfMass 0.0 0.0 0.0
+                                                 mass 1.0
+                                                 momentsOfInertia [ 1.000000e-06 0.0 0.0 0.0 1.000000e-06 0.0 0.0 0.0 1.000000e-06 ]
+                                                 children [
+                                                    DEF gsensor AccelerationSensor { sensorId 0 }
+                                                    DEF gyrometer Gyro { sensorId 0 }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.0 0.0 0.0,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.000500 0.000500 -0.000500,
+                                                              0.000500 0.000500 0.000500,
+                                                              0.000500 -0.000500 -0.000500,
+                                                              0.000500 -0.000500 0.000500,
+                                                              -0.000500 0.000500 -0.000500,
+                                                              -0.000500 -0.000500 -0.000500,
+                                                              -0.000500 -0.000500 0.000500,
+                                                              -0.000500 0.000500 0.000500,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           3, 1, 7, -1,
+                                                           7, 6, 3, -1,
+                                                           5, 4, 0, -1,
+                                                           0, 2, 5, -1,
+                                                           7, 1, 0, -1,
+                                                           0, 4, 7, -1,
+                                                           1, 3, 2, -1,
+                                                           2, 0, 1, -1,
+                                                           3, 6, 5, -1,
+                                                           5, 2, 3, -1,
+                                                           6, 7, 4, -1,
+                                                           4, 5, 6, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.501961 0.501961 0.501961,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.000500 0.000500 0.000500,
+                                                              -0.000500 0.000500 0.000500,
+                                                              -0.000500 -0.000500 0.000500,
+                                                              0.000500 -0.000500 0.000500,
+                                                              -0.000500 0.000500 -0.000500,
+                                                              0.000500 0.000500 -0.000500,
+                                                              0.000500 -0.000500 -0.000500,
+                                                              -0.000500 -0.000500 -0.000500,
+                                                              0.000500 0.000500 0.000500,
+                                                              0.000500 0.000500 -0.000500,
+                                                              -0.000500 0.000500 -0.000500,
+                                                              -0.000500 0.000500 0.000500,
+                                                              0.000500 -0.000500 0.000500,
+                                                              0.000500 -0.000500 -0.000500,
+                                                              0.000500 0.000500 -0.000500,
+                                                              0.000500 0.000500 0.000500,
+                                                              -0.000500 -0.000500 0.000500,
+                                                              -0.000500 -0.000500 -0.000500,
+                                                              0.000500 -0.000500 -0.000500,
+                                                              0.000500 -0.000500 0.000500,
+                                                              -0.000500 0.000500 0.000500,
+                                                              -0.000500 0.000500 -0.000500,
+                                                              -0.000500 -0.000500 -0.000500,
+                                                              -0.000500 -0.000500 0.000500,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           6, 7, 4, -1,
+                                                           4, 5, 6, -1,
+                                                           10, 11, 8, -1,
+                                                           8, 9, 10, -1,
+                                                           14, 15, 12, -1,
+                                                           12, 13, 14, -1,
+                                                           18, 19, 16, -1,
+                                                           16, 17, 18, -1,
+                                                           22, 23, 20, -1,
+                                                           20, 21, 22, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.996094 0.0 0.0,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.140000 0.000000 -0.033333,
+                                                              0.140000 -0.012756 -0.030796,
+                                                              0.140000 -0.023570 -0.023570,
+                                                              0.140000 -0.030796 -0.012756,
+                                                              0.140000 -0.033333 0.000000,
+                                                              0.140000 -0.030796 0.012756,
+                                                              0.140000 -0.023570 0.023570,
+                                                              0.140000 -0.012756 0.030796,
+                                                              0.140000 0.000000 0.033333,
+                                                              0.140000 0.012756 0.030796,
+                                                              0.140000 0.023570 0.023570,
+                                                              0.140000 0.030796 0.012756,
+                                                              0.140000 0.033333 -0.000000,
+                                                              0.140000 0.030796 -0.012756,
+                                                              0.140000 0.023570 -0.023570,
+                                                              0.140000 0.012756 -0.030796,
+                                                              0.140000 -0.012756 -0.030796,
+                                                              0.140000 0.000000 -0.033333,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.000000 -0.033333,
+                                                              0.140000 0.012756 -0.030796,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.012756 -0.030796,
+                                                              0.140000 0.023570 -0.023570,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.023570 -0.023570,
+                                                              0.140000 0.030796 -0.012756,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.030796 -0.012756,
+                                                              0.140000 0.033333 -0.000000,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.033333 -0.000000,
+                                                              0.140000 0.030796 0.012756,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.030796 0.012756,
+                                                              0.140000 0.023570 0.023570,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.023570 0.023570,
+                                                              0.140000 0.012756 0.030796,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.012756 0.030796,
+                                                              0.140000 0.000000 0.033333,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 0.000000 0.033333,
+                                                              0.140000 -0.012756 0.030796,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.012756 0.030796,
+                                                              0.140000 -0.023570 0.023570,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.023570 0.023570,
+                                                              0.140000 -0.030796 0.012756,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.030796 0.012756,
+                                                              0.140000 -0.033333 0.000000,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.033333 0.000000,
+                                                              0.140000 -0.030796 -0.012756,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.030796 -0.012756,
+                                                              0.140000 -0.023570 -0.023570,
+                                                              0.200000 0.000000 0.000000,
+                                                              0.140000 -0.023570 -0.023570,
+                                                              0.140000 -0.012756 -0.030796,
+                                                              0.200000 0.000000 0.000000,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           14, 15, 0, -1,
+                                                           13, 14, 0, -1,
+                                                           12, 13, 0, -1,
+                                                           11, 12, 0, -1,
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           16, 17, 18, -1,
+                                                           19, 20, 21, -1,
+                                                           22, 23, 24, -1,
+                                                           25, 26, 27, -1,
+                                                           28, 29, 30, -1,
+                                                           31, 32, 33, -1,
+                                                           34, 35, 36, -1,
+                                                           37, 38, 39, -1,
+                                                           40, 41, 42, -1,
+                                                           43, 44, 45, -1,
+                                                           46, 47, 48, -1,
+                                                           49, 50, 51, -1,
+                                                           52, 53, 54, -1,
+                                                           55, 56, 57, -1,
+                                                           58, 59, 60, -1,
+                                                           61, 62, 63, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.996094 0.0 0.0,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.140000 -0.008333 -0.014434,
+                                                              0.140000 0.000000 -0.016667,
+                                                              0.140000 0.008333 -0.014434,
+                                                              0.140000 0.014434 -0.008333,
+                                                              0.140000 0.016667 0.000000,
+                                                              0.140000 0.014434 0.008333,
+                                                              0.140000 0.008333 0.014434,
+                                                              0.140000 0.000000 0.016667,
+                                                              0.140000 -0.008333 0.014434,
+                                                              0.140000 -0.014434 0.008333,
+                                                              0.140000 -0.016667 0.000000,
+                                                              0.140000 -0.014434 -0.008333,
+                                                              0.000000 0.000000 -0.016667,
+                                                              0.000000 -0.008333 -0.014434,
+                                                              0.000000 -0.014434 -0.008333,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              -0.000000 -0.014434 0.008333,
+                                                              -0.000000 -0.008333 0.014434,
+                                                              -0.000000 0.000000 0.016667,
+                                                              -0.000000 0.008333 0.014434,
+                                                              -0.000000 0.014434 0.008333,
+                                                              0.000000 0.016667 -0.000000,
+                                                              0.000000 0.014434 -0.008333,
+                                                              0.000000 0.008333 -0.014434,
+                                                              0.140000 -0.008333 -0.014434,
+                                                              0.000000 -0.008333 -0.014434,
+                                                              0.000000 0.000000 -0.016667,
+                                                              0.140000 0.000000 -0.016667,
+                                                              0.140000 -0.014434 -0.008333,
+                                                              0.000000 -0.014434 -0.008333,
+                                                              0.000000 -0.008333 -0.014434,
+                                                              0.140000 -0.008333 -0.014434,
+                                                              0.140000 -0.016667 0.000000,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              0.000000 -0.014434 -0.008333,
+                                                              0.140000 -0.014434 -0.008333,
+                                                              0.140000 -0.014434 0.008333,
+                                                              -0.000000 -0.014434 0.008333,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              0.140000 -0.016667 0.000000,
+                                                              0.140000 -0.008333 0.014434,
+                                                              -0.000000 -0.008333 0.014434,
+                                                              -0.000000 -0.014434 0.008333,
+                                                              0.140000 -0.014434 0.008333,
+                                                              0.140000 0.000000 0.016667,
+                                                              -0.000000 0.000000 0.016667,
+                                                              -0.000000 -0.008333 0.014434,
+                                                              0.140000 -0.008333 0.014434,
+                                                              0.140000 0.008333 0.014434,
+                                                              -0.000000 0.008333 0.014434,
+                                                              -0.000000 0.000000 0.016667,
+                                                              0.140000 0.000000 0.016667,
+                                                              0.140000 0.014434 0.008333,
+                                                              -0.000000 0.014434 0.008333,
+                                                              -0.000000 0.008333 0.014434,
+                                                              0.140000 0.008333 0.014434,
+                                                              0.140000 0.016667 0.000000,
+                                                              0.000000 0.016667 -0.000000,
+                                                              -0.000000 0.014434 0.008333,
+                                                              0.140000 0.014434 0.008333,
+                                                              0.140000 0.014434 -0.008333,
+                                                              0.000000 0.014434 -0.008333,
+                                                              0.000000 0.016667 -0.000000,
+                                                              0.140000 0.016667 0.000000,
+                                                              0.140000 0.008333 -0.014434,
+                                                              0.000000 0.008333 -0.014434,
+                                                              0.000000 0.014434 -0.008333,
+                                                              0.140000 0.014434 -0.008333,
+                                                              0.140000 0.000000 -0.016667,
+                                                              0.000000 0.000000 -0.016667,
+                                                              0.000000 0.008333 -0.014434,
+                                                              0.140000 0.008333 -0.014434,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           22, 23, 12, -1,
+                                                           21, 22, 12, -1,
+                                                           20, 21, 12, -1,
+                                                           19, 20, 12, -1,
+                                                           18, 19, 12, -1,
+                                                           17, 18, 12, -1,
+                                                           16, 17, 12, -1,
+                                                           15, 16, 12, -1,
+                                                           14, 15, 12, -1,
+                                                           12, 13, 14, -1,
+                                                           26, 27, 24, -1,
+                                                           24, 25, 26, -1,
+                                                           30, 31, 28, -1,
+                                                           28, 29, 30, -1,
+                                                           34, 35, 32, -1,
+                                                           32, 33, 34, -1,
+                                                           38, 39, 36, -1,
+                                                           36, 37, 38, -1,
+                                                           42, 43, 40, -1,
+                                                           40, 41, 42, -1,
+                                                           46, 47, 44, -1,
+                                                           44, 45, 46, -1,
+                                                           50, 51, 48, -1,
+                                                           48, 49, 50, -1,
+                                                           54, 55, 52, -1,
+                                                           52, 53, 54, -1,
+                                                           58, 59, 56, -1,
+                                                           56, 57, 58, -1,
+                                                           62, 63, 60, -1,
+                                                           60, 61, 62, -1,
+                                                           66, 67, 64, -1,
+                                                           64, 65, 66, -1,
+                                                           70, 71, 68, -1,
+                                                           68, 69, 70, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.0 0.996094 0.0,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.033333 0.140000 0.000000,
+                                                              0.030796 0.140000 0.012756,
+                                                              0.023570 0.140000 0.023570,
+                                                              0.012756 0.140000 0.030796,
+                                                              -0.000000 0.140000 0.033333,
+                                                              -0.012756 0.140000 0.030796,
+                                                              -0.023570 0.140000 0.023570,
+                                                              -0.030796 0.140000 0.012756,
+                                                              -0.033333 0.140000 -0.000000,
+                                                              -0.030796 0.140000 -0.012756,
+                                                              -0.023570 0.140000 -0.023570,
+                                                              -0.012756 0.140000 -0.030796,
+                                                              0.000000 0.140000 -0.033333,
+                                                              0.012756 0.140000 -0.030796,
+                                                              0.023570 0.140000 -0.023570,
+                                                              0.030796 0.140000 -0.012756,
+                                                              0.030796 0.140000 0.012756,
+                                                              0.033333 0.140000 0.000000,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.033333 0.140000 0.000000,
+                                                              0.030796 0.140000 -0.012756,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.030796 0.140000 -0.012756,
+                                                              0.023570 0.140000 -0.023570,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.023570 0.140000 -0.023570,
+                                                              0.012756 0.140000 -0.030796,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.012756 0.140000 -0.030796,
+                                                              0.000000 0.140000 -0.033333,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.000000 0.140000 -0.033333,
+                                                              -0.012756 0.140000 -0.030796,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.012756 0.140000 -0.030796,
+                                                              -0.023570 0.140000 -0.023570,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.023570 0.140000 -0.023570,
+                                                              -0.030796 0.140000 -0.012756,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.030796 0.140000 -0.012756,
+                                                              -0.033333 0.140000 -0.000000,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.033333 0.140000 -0.000000,
+                                                              -0.030796 0.140000 0.012756,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.030796 0.140000 0.012756,
+                                                              -0.023570 0.140000 0.023570,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.023570 0.140000 0.023570,
+                                                              -0.012756 0.140000 0.030796,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.012756 0.140000 0.030796,
+                                                              -0.000000 0.140000 0.033333,
+                                                              0.000000 0.200000 0.000000,
+                                                              -0.000000 0.140000 0.033333,
+                                                              0.012756 0.140000 0.030796,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.012756 0.140000 0.030796,
+                                                              0.023570 0.140000 0.023570,
+                                                              0.000000 0.200000 0.000000,
+                                                              0.023570 0.140000 0.023570,
+                                                              0.030796 0.140000 0.012756,
+                                                              0.000000 0.200000 0.000000,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           14, 15, 0, -1,
+                                                           13, 14, 0, -1,
+                                                           12, 13, 0, -1,
+                                                           11, 12, 0, -1,
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           16, 17, 18, -1,
+                                                           19, 20, 21, -1,
+                                                           22, 23, 24, -1,
+                                                           25, 26, 27, -1,
+                                                           28, 29, 30, -1,
+                                                           31, 32, 33, -1,
+                                                           34, 35, 36, -1,
+                                                           37, 38, 39, -1,
+                                                           40, 41, 42, -1,
+                                                           43, 44, 45, -1,
+                                                           46, 47, 48, -1,
+                                                           49, 50, 51, -1,
+                                                           52, 53, 54, -1,
+                                                           55, 56, 57, -1,
+                                                           58, 59, 60, -1,
+                                                           61, 62, 63, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.0 0.996094 0.0,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.014434 0.140000 0.008333,
+                                                              0.016667 0.140000 0.000000,
+                                                              0.014434 0.140000 -0.008333,
+                                                              0.008333 0.140000 -0.014434,
+                                                              0.000000 0.140000 -0.016667,
+                                                              -0.008333 0.140000 -0.014434,
+                                                              -0.014434 0.140000 -0.008333,
+                                                              -0.016667 0.140000 0.000000,
+                                                              -0.014434 0.140000 0.008333,
+                                                              -0.008333 0.140000 0.014434,
+                                                              -0.000000 0.140000 0.016667,
+                                                              0.008333 0.140000 0.014434,
+                                                              0.016667 0.000000 -0.000000,
+                                                              0.014434 -0.000000 0.008333,
+                                                              0.008333 -0.000000 0.014434,
+                                                              -0.000000 -0.000000 0.016667,
+                                                              -0.008333 -0.000000 0.014434,
+                                                              -0.014434 -0.000000 0.008333,
+                                                              -0.016667 0.000000 -0.000000,
+                                                              -0.014434 0.000000 -0.008333,
+                                                              -0.008333 0.000000 -0.014434,
+                                                              0.000000 0.000000 -0.016667,
+                                                              0.008333 0.000000 -0.014434,
+                                                              0.014434 0.000000 -0.008333,
+                                                              0.014434 0.140000 0.008333,
+                                                              0.014434 -0.000000 0.008333,
+                                                              0.016667 0.000000 -0.000000,
+                                                              0.016667 0.140000 0.000000,
+                                                              0.008333 0.140000 0.014434,
+                                                              0.008333 -0.000000 0.014434,
+                                                              0.014434 -0.000000 0.008333,
+                                                              0.014434 0.140000 0.008333,
+                                                              -0.000000 0.140000 0.016667,
+                                                              -0.000000 -0.000000 0.016667,
+                                                              0.008333 -0.000000 0.014434,
+                                                              0.008333 0.140000 0.014434,
+                                                              -0.008333 0.140000 0.014434,
+                                                              -0.008333 -0.000000 0.014434,
+                                                              -0.000000 -0.000000 0.016667,
+                                                              -0.000000 0.140000 0.016667,
+                                                              -0.014434 0.140000 0.008333,
+                                                              -0.014434 -0.000000 0.008333,
+                                                              -0.008333 -0.000000 0.014434,
+                                                              -0.008333 0.140000 0.014434,
+                                                              -0.016667 0.140000 0.000000,
+                                                              -0.016667 0.000000 -0.000000,
+                                                              -0.014434 -0.000000 0.008333,
+                                                              -0.014434 0.140000 0.008333,
+                                                              -0.014434 0.140000 -0.008333,
+                                                              -0.014434 0.000000 -0.008333,
+                                                              -0.016667 0.000000 -0.000000,
+                                                              -0.016667 0.140000 0.000000,
+                                                              -0.008333 0.140000 -0.014434,
+                                                              -0.008333 0.000000 -0.014434,
+                                                              -0.014434 0.000000 -0.008333,
+                                                              -0.014434 0.140000 -0.008333,
+                                                              0.000000 0.140000 -0.016667,
+                                                              0.000000 0.000000 -0.016667,
+                                                              -0.008333 0.000000 -0.014434,
+                                                              -0.008333 0.140000 -0.014434,
+                                                              0.008333 0.140000 -0.014434,
+                                                              0.008333 0.000000 -0.014434,
+                                                              0.000000 0.000000 -0.016667,
+                                                              0.000000 0.140000 -0.016667,
+                                                              0.014434 0.140000 -0.008333,
+                                                              0.014434 0.000000 -0.008333,
+                                                              0.008333 0.000000 -0.014434,
+                                                              0.008333 0.140000 -0.014434,
+                                                              0.016667 0.140000 0.000000,
+                                                              0.016667 0.000000 -0.000000,
+                                                              0.014434 0.000000 -0.008333,
+                                                              0.014434 0.140000 -0.008333,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           22, 23, 12, -1,
+                                                           21, 22, 12, -1,
+                                                           20, 21, 12, -1,
+                                                           19, 20, 12, -1,
+                                                           18, 19, 12, -1,
+                                                           17, 18, 12, -1,
+                                                           16, 17, 12, -1,
+                                                           15, 16, 12, -1,
+                                                           14, 15, 12, -1,
+                                                           12, 13, 14, -1,
+                                                           26, 27, 24, -1,
+                                                           24, 25, 26, -1,
+                                                           30, 31, 28, -1,
+                                                           28, 29, 30, -1,
+                                                           34, 35, 32, -1,
+                                                           32, 33, 34, -1,
+                                                           38, 39, 36, -1,
+                                                           36, 37, 38, -1,
+                                                           42, 43, 40, -1,
+                                                           40, 41, 42, -1,
+                                                           46, 47, 44, -1,
+                                                           44, 45, 46, -1,
+                                                           50, 51, 48, -1,
+                                                           48, 49, 50, -1,
+                                                           54, 55, 52, -1,
+                                                           52, 53, 54, -1,
+                                                           58, 59, 56, -1,
+                                                           56, 57, 58, -1,
+                                                           62, 63, 60, -1,
+                                                           60, 61, 62, -1,
+                                                           66, 67, 64, -1,
+                                                           64, 65, 66, -1,
+                                                           70, 71, 68, -1,
+                                                           68, 69, 70, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.0 0.0 0.996094,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.033333 0.000000 0.140000,
+                                                              0.030796 -0.012756 0.140000,
+                                                              0.023570 -0.023570 0.140000,
+                                                              0.012756 -0.030796 0.140000,
+                                                              -0.000000 -0.033333 0.140000,
+                                                              -0.012756 -0.030796 0.140000,
+                                                              -0.023570 -0.023570 0.140000,
+                                                              -0.030796 -0.012756 0.140000,
+                                                              -0.033333 0.000000 0.140000,
+                                                              -0.030796 0.012756 0.140000,
+                                                              -0.023570 0.023570 0.140000,
+                                                              -0.012756 0.030796 0.140000,
+                                                              0.000000 0.033333 0.140000,
+                                                              0.012756 0.030796 0.140000,
+                                                              0.023570 0.023570 0.140000,
+                                                              0.030796 0.012756 0.140000,
+                                                              0.030796 -0.012756 0.140000,
+                                                              0.033333 0.000000 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.033333 0.000000 0.140000,
+                                                              0.030796 0.012756 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.030796 0.012756 0.140000,
+                                                              0.023570 0.023570 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.023570 0.023570 0.140000,
+                                                              0.012756 0.030796 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.012756 0.030796 0.140000,
+                                                              0.000000 0.033333 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.000000 0.033333 0.140000,
+                                                              -0.012756 0.030796 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.012756 0.030796 0.140000,
+                                                              -0.023570 0.023570 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.023570 0.023570 0.140000,
+                                                              -0.030796 0.012756 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.030796 0.012756 0.140000,
+                                                              -0.033333 0.000000 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.033333 0.000000 0.140000,
+                                                              -0.030796 -0.012756 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.030796 -0.012756 0.140000,
+                                                              -0.023570 -0.023570 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.023570 -0.023570 0.140000,
+                                                              -0.012756 -0.030796 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.012756 -0.030796 0.140000,
+                                                              -0.000000 -0.033333 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              -0.000000 -0.033333 0.140000,
+                                                              0.012756 -0.030796 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.012756 -0.030796 0.140000,
+                                                              0.023570 -0.023570 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                              0.023570 -0.023570 0.140000,
+                                                              0.030796 -0.012756 0.140000,
+                                                              0.000000 0.000000 0.200000,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           14, 15, 0, -1,
+                                                           13, 14, 0, -1,
+                                                           12, 13, 0, -1,
+                                                           11, 12, 0, -1,
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           16, 17, 18, -1,
+                                                           19, 20, 21, -1,
+                                                           22, 23, 24, -1,
+                                                           25, 26, 27, -1,
+                                                           28, 29, 30, -1,
+                                                           31, 32, 33, -1,
+                                                           34, 35, 36, -1,
+                                                           37, 38, 39, -1,
+                                                           40, 41, 42, -1,
+                                                           43, 44, 45, -1,
+                                                           46, 47, 48, -1,
+                                                           49, 50, 51, -1,
+                                                           52, 53, 54, -1,
+                                                           55, 56, 57, -1,
+                                                           58, 59, 60, -1,
+                                                           61, 62, 63, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                    Shape {
+                                                       appearance Appearance {
+                                                          material Material {
+                                                          }
+                                                       }
+                                                       geometry DEF link6-FACES IndexedFaceSet {
+                                                          creaseAngle 0.8
+                                                          ccw TRUE
+                                                          solid TRUE
+                                                          colorPerVertex FALSE
+                                                          color Color {
+                                                             color [
+                                                              0.0 0.0 0.996094,
+                                                             ]
+                                                          }
+                                                          coord DEF link6-COORD Coordinate {
+                                                             point[
+                                                              0.014434 -0.008333 0.140000,
+                                                              0.016667 0.000000 0.140000,
+                                                              0.014434 0.008333 0.140000,
+                                                              0.008333 0.014434 0.140000,
+                                                              0.000000 0.016667 0.140000,
+                                                              -0.008333 0.014434 0.140000,
+                                                              -0.014434 0.008333 0.140000,
+                                                              -0.016667 0.000000 0.140000,
+                                                              -0.014434 -0.008333 0.140000,
+                                                              -0.008333 -0.014434 0.140000,
+                                                              -0.000000 -0.016667 0.140000,
+                                                              0.008333 -0.014434 0.140000,
+                                                              0.016667 0.000000 0.000000,
+                                                              0.014434 -0.008333 0.000000,
+                                                              0.008333 -0.014434 0.000000,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              -0.008333 -0.014434 0.000000,
+                                                              -0.014434 -0.008333 0.000000,
+                                                              -0.016667 0.000000 0.000000,
+                                                              -0.014434 0.008333 0.000000,
+                                                              -0.008333 0.014434 0.000000,
+                                                              0.000000 0.016667 0.000000,
+                                                              0.008333 0.014434 0.000000,
+                                                              0.014434 0.008333 0.000000,
+                                                              0.014434 -0.008333 0.140000,
+                                                              0.014434 -0.008333 0.000000,
+                                                              0.016667 0.000000 0.000000,
+                                                              0.016667 0.000000 0.140000,
+                                                              0.008333 -0.014434 0.140000,
+                                                              0.008333 -0.014434 0.000000,
+                                                              0.014434 -0.008333 0.000000,
+                                                              0.014434 -0.008333 0.140000,
+                                                              -0.000000 -0.016667 0.140000,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              0.008333 -0.014434 0.000000,
+                                                              0.008333 -0.014434 0.140000,
+                                                              -0.008333 -0.014434 0.140000,
+                                                              -0.008333 -0.014434 0.000000,
+                                                              -0.000000 -0.016667 0.000000,
+                                                              -0.000000 -0.016667 0.140000,
+                                                              -0.014434 -0.008333 0.140000,
+                                                              -0.014434 -0.008333 0.000000,
+                                                              -0.008333 -0.014434 0.000000,
+                                                              -0.008333 -0.014434 0.140000,
+                                                              -0.016667 0.000000 0.140000,
+                                                              -0.016667 0.000000 0.000000,
+                                                              -0.014434 -0.008333 0.000000,
+                                                              -0.014434 -0.008333 0.140000,
+                                                              -0.014434 0.008333 0.140000,
+                                                              -0.014434 0.008333 0.000000,
+                                                              -0.016667 0.000000 0.000000,
+                                                              -0.016667 0.000000 0.140000,
+                                                              -0.008333 0.014434 0.140000,
+                                                              -0.008333 0.014434 0.000000,
+                                                              -0.014434 0.008333 0.000000,
+                                                              -0.014434 0.008333 0.140000,
+                                                              0.000000 0.016667 0.140000,
+                                                              0.000000 0.016667 0.000000,
+                                                              -0.008333 0.014434 0.000000,
+                                                              -0.008333 0.014434 0.140000,
+                                                              0.008333 0.014434 0.140000,
+                                                              0.008333 0.014434 0.000000,
+                                                              0.000000 0.016667 0.000000,
+                                                              0.000000 0.016667 0.140000,
+                                                              0.014434 0.008333 0.140000,
+                                                              0.014434 0.008333 0.000000,
+                                                              0.008333 0.014434 0.000000,
+                                                              0.008333 0.014434 0.140000,
+                                                              0.016667 0.000000 0.140000,
+                                                              0.016667 0.000000 0.000000,
+                                                              0.014434 0.008333 0.000000,
+                                                              0.014434 0.008333 0.140000,
+                                                             ]
+                                                          }
+                                                          coordIndex [
+                                                           10, 11, 0, -1,
+                                                           9, 10, 0, -1,
+                                                           8, 9, 0, -1,
+                                                           7, 8, 0, -1,
+                                                           6, 7, 0, -1,
+                                                           5, 6, 0, -1,
+                                                           4, 5, 0, -1,
+                                                           3, 4, 0, -1,
+                                                           2, 3, 0, -1,
+                                                           0, 1, 2, -1,
+                                                           22, 23, 12, -1,
+                                                           21, 22, 12, -1,
+                                                           20, 21, 12, -1,
+                                                           19, 20, 12, -1,
+                                                           18, 19, 12, -1,
+                                                           17, 18, 12, -1,
+                                                           16, 17, 12, -1,
+                                                           15, 16, 12, -1,
+                                                           14, 15, 12, -1,
+                                                           12, 13, 14, -1,
+                                                           26, 27, 24, -1,
+                                                           24, 25, 26, -1,
+                                                           30, 31, 28, -1,
+                                                           28, 29, 30, -1,
+                                                           34, 35, 32, -1,
+                                                           32, 33, 34, -1,
+                                                           38, 39, 36, -1,
+                                                           36, 37, 38, -1,
+                                                           42, 43, 40, -1,
+                                                           40, 41, 42, -1,
+                                                           46, 47, 44, -1,
+                                                           44, 45, 46, -1,
+                                                           50, 51, 48, -1,
+                                                           48, 49, 50, -1,
+                                                           54, 55, 52, -1,
+                                                           52, 53, 54, -1,
+                                                           58, 59, 56, -1,
+                                                           56, 57, 58, -1,
+                                                           62, 63, 60, -1,
+                                                           60, 61, 62, -1,
+                                                           66, 67, 64, -1,
+                                                           64, 65, 66, -1,
+                                                           70, 71, 68, -1,
+                                                           68, 69, 70, -1,
+                                                          ]
+                                                          colorIndex [
+                                                           0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                                                          ]
+                                                       }
+                                                    }
+                                                 ]
+                                              } #Segment
+                                           ]
+                                        } #link6
+                                        ,
+                                     ]
+                                  } #link5
+                                  ,
+                               ]
+                            } #link4
+                            ,
+                         ]
+                      } #link3
+                      ,
+                   ]
+                } #link2
+                ,
+             ]
+          } #link1
+          ,
+       ]
+    } #WAIST
+   ] # END of HumanoidBody
+
+   joints [
+    USE WAIST,
+    USE link1,
+    USE link2,
+    USE link3,
+    USE link4,
+    USE link5,
+    USE link6
+   ]
+
+   segments [
+    USE link0_S,
+    USE link1_S,
+    USE link2_S,
+    USE link3_S,
+    USE link4_S,
+    USE link5_S,
+    USE link6_S
+   ]
+
+}

--- a/sample/Sample6dofRobot/Sample6dofRobot.xml.in
+++ b/sample/Sample6dofRobot/Sample6dofRobot.xml.in
@@ -1,0 +1,119 @@
+<grxui>
+ <mode name="Simulation">
+  <item class="com.generalrobotix.ui.item.GrxSimulationItem" name="simulationItem">
+   <property name="integrate" value="true"/>
+   <property name="timeStep" value="0.005"/>
+   <property name="totalTime" value="2000000.0"/>
+   <property name="method" value="EULER"/>
+  </item>
+  <item class="com.generalrobotix.ui.item.GrxRTSItem" name="Sample6dofRobot" select="true">
+   <property name="Sample6dofRobot(Robot)0.period" value="0.005"/>
+   <property name="HGcontroller0.period" value="0.005"/>
+   <property name="HGcontroller0.factory" value="HGcontroller"/>
+   <property name="connection" value="HGcontroller0.qOut:Sample6dofRobot(Robot)0.qRef"/>
+   <property name="connection" value="HGcontroller0.dqOut:Sample6dofRobot(Robot)0.dqRef"/>
+   <property name="connection" value="HGcontroller0.ddqOut:Sample6dofRobot(Robot)0.ddqRef"/>
+  </item>
+  <item class="com.generalrobotix.ui.item.GrxModelItem" name="Sample6dofRobot" url="@CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/Sample6dofRobot/Sample6dofRobot.wrl">
+   <property name="rtcName" value="Sample6dofRobot(Robot)0"/>
+   <property name="inport" value="qRef:JOINT_VALUE"/>
+   <property name="inport" value="dqRef:JOINT_VELOCITY"/>
+   <property name="inport" value="ddqRef:JOINT_ACCELERATION"/>
+   <property name="outport" value="q:JOINT_VALUE"/>
+   <property name="outport" value="tau:JOINT_TORQUE"/>
+   <property name="outport" value="gyrometer:gyrometer:RATE_GYRO_SENSOR"/>
+   <property name="outport" value="gsensor:gsensor:ACCELERATION_SENSOR"/>
+   <property name="WAIST.NumOfAABB" value="1"/>
+   <property name="WAIST.translation" value="0  0  0.25"/>
+   <property name="WAIST.rotation" value="1 0 0 0"/>
+   <property name="WAIST.mode" value="Torque"/>
+   <property name="controller" value="Sample6dofRobot"/>
+   <property name="link1.angle" value="0.0"/>
+   <property name="link1.mode" value="HighGain"/>
+   <property name="link1.NumOfAABB" value="1"/>
+   <property name="link2.angle" value="0.0"/>
+   <property name="link2.mode" value="HighGain"/>
+   <property name="link2.NumOfAABB" value="1"/>
+   <property name="link3.angle" value="0.0"/>
+   <property name="link3.mode" value="HighGain"/>
+   <property name="link3.NumOfAABB" value="1"/>
+   <property name="link4.angle" value="0.0"/>
+   <property name="link4.mode" value="HighGain"/>
+   <property name="link4.NumOfAABB" value="1"/>
+   <property name="link5.angle" value="0.0"/>
+   <property name="link5.mode" value="HighGain"/>
+   <property name="link5.NumOfAABB" value="1"/>
+   <property name="link6.angle" value="0.0"/>
+   <property name="link6.mode" value="HighGain"/>
+   <property name="link6.NumOfAABB" value="1"/>
+  </item>
+  <view class="com.generalrobotix.ui.view.GrxRobotHardwareClientView" name="RobotHardware RTC Client">
+   <property name="robotHost" value="localhost"/>
+   <property name="StateHolderRTC" value="StateHolder0"/>
+   <property name="interval" value="100"/>
+   <property name="RobotHardwareServiceRTC" value="RobotHardware0"/>
+   <property name="robotPort" value="2809"/>
+   <property name="ROBOT" value="Sample6dofRobot"/>
+  </view>
+  <view class="com.generalrobotix.ui.view.Grx3DView" name="3DView">
+   <property name="view.mode" value="Room"/>
+   <property name="showCoM" value="false"/>
+   <property name="showCoMonFloor" value="false"/>
+   <property name="showDistance" value="false"/>
+   <property name="showIntersection" value="false"/>
+   <property name="eyeHomePosition" value="-0.70711 -0 0.70711 2 0.70711 -0 0.70711 2 0 1 0 0.8 0 0 0 1 "/>
+   <property name="showCollision" value="true"/>
+   <property name="showActualState" value="true"/>
+   <property name="showScale" value="true"/>
+  </view>
+  <item class="com.generalrobotix.ui.item.GrxRTSItem" name="longfloor" select="true">
+   <property name="longfloor(Robot)0.period" value="0.005"/>
+   <property name="HGcontroller0.period" value="0.005"/>
+   <property name="HGcontroller0.factory" value="HGcontroller"/>
+   <property name="connection" value="HGcontroller0.qOut:longfloor(Robot)0.qRef"/>
+   <property name="connection" value="HGcontroller0.dqOut:longfloor(Robot)0.dqRef"/>
+   <property name="connection" value="HGcontroller0.ddqOut:longfloor(Robot)0.ddqRef"/>
+  </item>
+  <item class="com.generalrobotix.ui.item.GrxModelItem" name="longfloor" url="@OPENHRP_DIR@/share/OpenHRP-3.1/sample/model/longfloor.wrl">
+   <property name="rtcName" value="longfloor(Robot)0"/>
+   <property name="inport" value="qRef:JOINT_VALUE"/>
+   <property name="inport" value="dqRef:JOINT_VELOCITY"/>
+   <property name="inport" value="ddqRef:JOINT_ACCELERATION"/>
+   <property name="outport" value="q:JOINT_VALUE"/>
+   <property name="outport" value="tau:JOINT_TORQUE"/>
+   <property name="WAIST.NumOfAABB" value="1"/>
+   <property name="WAIST.translation" value="0  0  -0.1"/>
+   <property name="WAIST.rotation" value="1 0 0 0"/>
+  </item>
+  <view class="com.generalrobotix.ui.view.GrxRobotHardwareClientView" name="RobotHardware RTC Client">
+   <property name="robotHost" value="localhost"/>
+   <property name="StateHolderRTC" value="StateHolder0"/>
+   <property name="interval" value="100"/>
+   <property name="RobotHardwareServiceRTC" value="RobotHardware0"/>
+   <property name="robotPort" value="2809"/>
+   <property name="ROBOT" value="longfloor"/>
+  </view>
+  <view class="com.generalrobotix.ui.view.Grx3DView" name="3DView">
+   <property name="view.mode" value="Room"/>
+   <property name="showCoM" value="false"/>
+   <property name="showCoMonFloor" value="false"/>
+   <property name="showDistance" value="false"/>
+   <property name="showIntersection" value="false"/>
+   <property name="eyeHomePosition" value="-0.70711 -0 0.70711 2 0.70711 -0 0.70711 2 0 1 0 0.8 0 0 0 1 "/>
+   <property name="showCollision" value="true"/>
+   <property name="showActualState" value="true"/>
+   <property name="showScale" value="true"/>
+  </view>
+  <item class="com.generalrobotix.ui.item.GrxCollisionPairItem" name="CP#longfloor_#Sample6dofRobot_">
+   <property name="springConstant" value="0 0 0 0 0 0"/>
+   <property name="slidingFriction" value="0.5"/>
+   <property name="jointName2" value=""/>
+   <property name="jointName1" value=""/>
+   <property name="damperConstant" value="0 0 0 0 0 0"/>
+   <property name="objectName2" value="longfloor"/>
+   <property name="objectName1" value="Sample6dofRobot"/>
+   <property name="springDamperModel" value="false"/>
+   <property name="staticFriction" value="0.5"/>
+  </item>
+ </mode>
+</grxui>

--- a/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
+++ b/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
@@ -1,0 +1,65 @@
+#!/usr/bin/env python
+
+try:
+    from hrpsys.hrpsys_config import *
+    import OpenHRP
+except:
+    print "import without hrpsys"
+    import rtm
+    from rtm import *
+    from OpenHRP import *
+    import waitInput
+    from waitInput import *
+    import socket
+    import time
+
+import math
+import matplotlib.pyplot as plt
+
+def init ():
+    global hcf
+    hcf = HrpsysConfigurator()
+    hcf.getRTCList = hcf.getRTCListUnstable
+    hcf.init ("Sample6dofRobot(Robot)0", "@CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/Sample6dofRobot/Sample6dofRobot.wrl")
+
+def test_kf_plot (time): # time [s]
+    hcf.log_svc.clear()
+    hcf.seq_svc.setJointAngles([0,0,0,0,1,0], time*0.5)
+    hcf.seq_svc.waitInterpolation()
+    hcf.seq_svc.setJointAngles([0,0,0,0,0,0], time*0.5)
+    hcf.seq_svc.waitInterpolation()
+    hcf.log_svc.save("/tmp/test-kf-sample6dofrobot-{0}".format(time))
+    kf_ret=[]
+    for line in open("/tmp/test-kf-sample6dofrobot-{0}.kf_rpy".format(time), "r"):
+        kf_ret.append(line.split(" ")[0:-1])
+    seq_ret=[]
+    for line in open("/tmp/test-kf-sample6dofrobot-{0}.sh_qOut".format(time), "r"):
+        seq_ret.append(line.split(" ")[0:-1])
+    initial_sec=int(seq_ret[0][0].split(".")[0])
+    tm_list=map (lambda x : int(x[0].split(".")[0])-initial_sec + float(x[0].split(".")[1]) * 1e-6, seq_ret)
+    plt.plot(tm_list, map(lambda x : 180.0 * float(x[5]) / math.pi, seq_ret))
+    plt.plot(tm_list, map(lambda x : 180.0 * float(x[2]) / math.pi, kf_ret))
+
+def demo():
+    init()
+    hcf.seq_svc.setJointAngles([0,0,0,0,0,0], 2.5)
+    hcf.seq_svc.waitInterpolation()
+
+    # 1. setParameter
+    ret=hcf.kf_svc.SetKalmanFilterParam(0.001, 0.003, 0.03)
+    if ret:
+        print "SetKalmanFilterParam() => OK"
+    ret=hcf.kf_svc.SetKalmanFilterParam(0.001, 0.003, 10)
+    if ret:
+        print "SetKalmanFilterParam() => OK"
+
+    # 2. check log and plot
+    test_kf_plot(2)
+    test_kf_plot(1)
+    test_kf_plot(0.5)
+    plt.xlabel("Time [s]")
+    plt.ylabel("Angle [deg]")
+    plt.legend(("Actual angle (2)", "Estimated angle (2)",
+                "Actual angle (1)", "Estimated angle (1)",
+                "Actual angle (0.5)", "Estimated angle (0.5)"))
+    plt.savefig("/tmp/test-kf-sample6dofrobot-data.eps")


### PR DESCRIPTION
Add sample6dofrobot VRML which has 3 slide joints and 3 rotate joints.
Add example for kalman filter for sample6dofrobot.
This robot can be used for kalman filter tests discussed in https://github.com/fkanehiro/hrpsys-base/pull/218.
