### PR TITLE
Update st eefm calculation

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -28,6 +28,8 @@ module OpenHRP
       DblArray2 eefm_k1;
       DblArray2 eefm_k2;
       DblArray2 eefm_k3;
+      DblArray2 eefm_zmp_delay_time_const;
+      DblArray2 eefm_ref_zmp_aux;
       double eefm_rot_damping_gain;
       double eefm_rot_time_const;
       double eefm_pos_damping_gain;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -228,9 +228,9 @@ class Stabilizer
   double k_run_b[2], d_run_b[2];
   double rdx, rdy, rx, ry;
   // EEFM ST
-  double eefm_k1[2], eefm_k2[2], eefm_k3[2];
+  double eefm_k1[2], eefm_k2[2], eefm_k3[2], eefm_zmp_delay_time_const[2];
   double eefm_rot_damping_gain, eefm_rot_time_const, eefm_pos_damping_gain, eefm_pos_time_const;
-  hrp::Vector3 d_foot_rpy[2], new_refzmp, rel_cog;
+  hrp::Vector3 d_foot_rpy[2], new_refzmp, rel_cog, ref_zmp_aux;
   hrp::Vector3 ref_foot_force[2];
   hrp::Vector3 ref_foot_moment[2];
   double zctrl, total_mass, f_zctrl[2];


### PR DESCRIPTION
Stabilizerを修正しました。
よろしくお願いいたします。
- Rotate robot around COG in rpy control
- Add LPF for ground contact checking
- Support rotational walking by fixing ref force and ref moment coordinates
- Fix transition between st ON mode and st OFF mode
- Fix idl to specify zmp delay time constant and auxiliary zmp input for system identification  
  This commit includes StabilizerService.idl change.
