### PR TITLE
update KalmanFilter. KF -> EKF and RPY -> Quaternion

### DIFF
--- a/rtc/KalmanFilter/KalmanFilter.h
+++ b/rtc/KalmanFilter/KalmanFilter.h
@@ -21,61 +21,189 @@
 
 #include <hrpUtil/EigenTypes.h>
 namespace hrp{
-    typedef Eigen::Vector2d Vector2;
-    typedef Eigen::Matrix2d Matrix22;
+  typedef Eigen::Vector2d Vector2;
+  typedef Eigen::Matrix2d Matrix22;
 }
 
 class KFilter {
 public:
   KFilter() {
-      F(0,0) = 1; F(0,1) =-0.005;
-      F(1,0) = 0; F(1,1) =    1;
-
-      P(0,0) = 0; P(0,1) =    0;
-      P(1,0) = 0; P(1,1) =    0;
-
-      Q(0,0) = 0.001 * 0.005; Q(0,1) = 0.000 * 0.005;
-      Q(1,0) = 0.000 * 0.005; Q(1,1) = 0.003 * 0.005;
-
-      R = 0.03;
-
-      B(0) = 0.005; B(1) = 0;
-
-      H(0,0) = 1; H(0,1) = 0;
-
-      x(0) = 0; x(1) = 0;
-
-      I = hrp::dmatrix::Identity(2,2);
+    x << 1, 0, 0, 0, 0, 0, 0;
+    P = Eigen::Matrix<double, 7, 7>::Identity() * 5;
+    Q = Eigen::Matrix<double, 7, 7>::Identity();
+    Q.block<4, 4>(0, 0) *= 0.1;
+    Q.block<3, 3>(4, 4) *= 0.001;
+    R = Eigen::Matrix<double, 3, 3>::Zero();
+    R(0, 0) = 4;
+    R(1, 1) = 4;
+    R(2, 2) = 2;
+    g_vec = Eigen::Vector3d(0.0, 0.0, 9.80665);
   }
-  void setF(double _f0, double _f1, double _f2, double _f3) { F(0,0) = _f0; F(0,1) = _f1; F(1,0) = _f2; F(1,1) = _f3;}
-  void setP(double _p0, double _p1, double _p2, double _p3) { P(0,0) = _p0; P(0,1) = _p1; P(1,0) = _p2; P(1,1) = _p3;}
-  void setQ(double _q0, double _q1, double _q2, double _q3) { Q(0,0) = _q0; Q(0,1) = _q1; Q(1,0) = _q2; Q(1,1) = _q3;}
-  void setR(double _R) { R = _R; }
-  void setB(double _b0, double _b1) { B[0] = _b0; B[1] = _b1; }
-  hrp::Vector2 &getx() { return x; }
-  void update(double u, double z) {
-      // Predicted (a priori) state estimate
-      x = F * x + B * u;
-      // Predicted (a priori) estimate covariance
-      P = F * P * F.transpose() + Q;
-      //
-      // Innovation or measurement residual
-      double y = z - H * x;
-      // Innovation (or residual) covariance
-      double S = H * P * H.transpose() + R;
-      // Optimal Kalman gain
-      K = P * H.transpose() / S;
-      // Updated (a posteriori) state estimate
-      x = x + K * y;
-      // Updated (a posteriori) estimate covariance
-      P = (I - K * H) * P;
+
+  Eigen::Matrix<double, 7, 1> getx() { return x; }
+
+  Eigen::Matrix<double, 3, 1> accelerationToRpy(const double& acc_x, const double& acc_y, const double& acc_z) {
+    /*
+     * acc = \dot{v} + w \times v + R^T g;
+     * -> R^T g = acc - \dot{v} + w \times v;
+     * -> R^T g = acc;
+     * -> acc_x = -sinb g, acc_y = sina cosb g, acc_z = cosa cosb g;
+     */
+    double roll = atan2(acc_y, acc_z);
+    double pitch = atan2(-acc_x, sqrt(acc_y * acc_y + acc_z * acc_z));
+    double yaw = 0;             /* cannot be defined only by acceleration */
+    Eigen::Vector3d rpy = Eigen::Vector3d(roll, pitch, yaw);
+    return rpy;
   }
+
+  Eigen::Matrix<double, 4, 4> calcOmega(const Eigen::Vector3d& w) {
+    /* \dot{q} = \frac{1}{2} omega q */
+    Eigen::Matrix<double, 4, 4> omega;
+    omega <<
+      0, -w[0], -w[1], -w[2],
+      w[0],     0,  w[2], -w[1],
+      w[1], -w[2],     0,  w[0],
+      w[2],  w[1], -w[0],     0;
+    return omega;
+  }
+
+  Eigen::Matrix<double, 7, 1> calcPredictedState(Eigen::Matrix<double, 4, 1> q,
+                                                 Eigen::Vector3d gyro,
+                                                 Eigen::Vector3d drift,
+                                                 const double& dt) {
+    /* x_a_priori = f(x, u) */
+    Eigen::Matrix<double, 7, 1> ret;
+    Eigen::Matrix<double, 4, 1> q_a_priori;
+    Eigen::Vector3d gyro_compensated = gyro - drift;
+    q_a_priori = q + dt / 2 * calcOmega(gyro_compensated) * q;
+    ret.block<4, 1>(0, 0) = q_a_priori;
+    ret.block<3, 1>(4, 0) = drift;
+    return ret;
+  }
+
+  Eigen::Matrix<double, 7, 7> calcF(Eigen::Matrix<double, 4, 1> q,
+                                    const Eigen::Vector3d& gyro,
+                                    Eigen::Vector3d drift,
+                                    const double& dt) {
+    Eigen::Matrix<double, 7, 7> F;
+    Eigen::Vector3d gyro_compensated = gyro - drift;
+    F.block<4, 4>(0, 0) =
+      Eigen::Matrix<double, 4, 4>::Identity() + dt / 2 * calcOmega(gyro_compensated);
+    F.block<4, 3>(0, 4) <<
+      dt / 2 * q[1],   dt / 2 * q[2],   dt / 2 * q[3],
+      - dt / 2 * q[0],   dt / 2 * q[3], - dt / 2 * q[2],
+      - dt / 2 * q[3], - dt / 2 * q[0],   dt / 2 * q[1],
+      dt / 2 * q[2], - dt / 2 * q[1], - dt / 2 * q[0];
+    F.block<3, 4>(0, 4) = Eigen::Matrix<double, 3, 4>::Zero();
+    F.block<3, 3>(4, 4) = Eigen::Matrix<double, 3, 3>::Identity();
+    return F;
+  }
+
+  Eigen::Matrix<double, 7, 7> calcPredictedCovariance(Eigen::Matrix<double, 7, 7> F) {
+    /* P_a_priori = F P F^T + Q */
+    return F * P * F.transpose() + Q;
+  }
+
+  Eigen::Vector3d calcAcc(Eigen::Matrix<double, 4, 1> q,
+                          const Eigen::Vector3d& vel_ref,
+                          const Eigen::Vector3d& acc_ref,
+                          const Eigen::Vector3d& angular_rate_ref) {
+    /* acc = \dot{v} + w \times v + R^T g; */
+    Eigen::Quaternion<double> q_tmp = Eigen::Quaternion<double>(q[0], q[1], q[2], q[3]);
+    Eigen::Vector3d acc =
+      acc_ref + angular_rate_ref.cross(vel_ref) +
+      q_tmp.toRotationMatrix().transpose() * g_vec;
+    /* 
+     * Eigen::Vector3d hoge;
+     * hoge <<
+     *   -2 * q_tmp2.w() * q_tmp2.y() + 2 * q_tmp2.x() * q_tmp2.z(),
+     *   2 * q_tmp2.w() * q_tmp2.x() + 2 * q_tmp2.y() * q_tmp2.z(),
+     *   q_tmp2.w() * q_tmp2.w()  - q_tmp2.x() * q_tmp2.x() - q_tmp2.y() * q_tmp2.y() + q_tmp2.z() * q_tmp2.z();
+     * hoge *= g_vec[2];
+     * std::cerr << "diff 2" << std::endl << acc - hoge << std::endl;
+     */
+    return acc;
+  }
+
+  Eigen::Matrix<double, 3, 7> calcH(Eigen::Matrix<double, 4, 1> q) {
+    Eigen::Matrix<double, 3, 7> H;
+    double w = q[0], x = q[1], y = q[2], z = q[3];
+    /* 
+     * H <<
+     *   2 * y,  2 * z,  2 * w,  2 * x, 0, 0, 0,
+     *   -2 * x, -2 * w,  2 * z,  2 * y, 0, 0, 0,
+     *   2 * w, -2 * x, -2 * y,  2 * z, 0, 0, 0;
+     * H *= g_vec[2];
+     */
+    H <<
+      -y,  z, -w, x, 0, 0, 0,
+       x,  w,  z, y, 0, 0, 0,
+       w, -x, -y, z, 0, 0, 0;
+    H *= 2 * g_vec[2];
+    return H;
+  }
+
+  Eigen::Vector3d calcMeasurementResidual(const Eigen::Vector3d& acc_measured,
+                                          const Eigen::Vector3d& vel_ref,
+                                          const Eigen::Vector3d& acc_ref,
+                                          const Eigen::Vector3d& angular_rate_ref,
+                                          Eigen::Matrix<double, 4, 1> q) {
+    /* y = z - h(x) */
+    Eigen::Vector3d y = acc_measured - calcAcc(q, vel_ref, acc_ref, angular_rate_ref);
+    /* 
+     * std::cerr << "acc_measured" << std::endl << acc_measured << std::endl;
+     * std::cerr << "calc acc" << std::endl << calcAcc(q, vel_ref, acc_ref, angular_rate_ref) << std::endl;
+     */
+    std::cerr << "diff" << std::endl << y << std::endl;
+    return y;
+  }
+
+
+  void prediction(const Eigen::Vector3d& u, const double& dt) {
+    Eigen::Matrix<double, 4, 1> q = x.block<4, 1>(0, 0);
+    Eigen::Vector3d drift = x.block<3, 1>(4, 0);
+    Eigen::Matrix<double, 7, 7> F = calcF(q, u, drift, dt);
+    x_a_priori = calcPredictedState(q, u, drift, dt);
+    P_a_priori = calcPredictedCovariance(F);
+  }
+
+  void correction(const Eigen::Vector3d& z,
+                  const Eigen::Vector3d& vel_ref,
+                  const Eigen::Vector3d& acc_ref,
+                  const Eigen::Vector3d& angular_rate_ref) {
+    Eigen::Matrix<double, 4, 1> q_a_priori = x_a_priori.block<4, 1>(0, 0).normalized();
+    Eigen::Matrix<double, 3, 7> H;
+    Eigen::Matrix<double, 3, 3> S;
+    Eigen::Matrix<double, 7, 3> K;
+    Eigen::Vector3d y;
+    /* need to normalize q_a_priori ? */
+    y = calcMeasurementResidual(z, vel_ref, acc_ref, angular_rate_ref, q_a_priori);
+    H = calcH(q_a_priori);
+    S = H * P_a_priori * H.transpose() + R;
+    K = P_a_priori * H.transpose() * S.inverse();
+    Eigen::Matrix<double, 7, 1> x_tmp = x_a_priori + K * y;
+    x = x_tmp.normalized();
+    P = (Eigen::Matrix<double, 7, 7>::Identity() - K * H) * P_a_priori;
+  }
+
+  void printAll() {
+    std::cerr << "x" << std::endl << x << std::endl;
+    std::cerr << "x_a_priori" << std::endl << x_a_priori << std::endl;
+    std::cerr << "P" << std::endl << P << std::endl << std::endl;
+    std::cerr << "P_a_priori" << std::endl << P_a_priori << std::endl << std::endl;
+    /*
+     * std::cerr << "Q" << std::endl << Q << std::endl << std::endl;
+     * std::cerr << "R" << std::endl << R << std::endl << std::endl;
+     */
+  }
+
 private:
-  hrp::Matrix22 P, Q, I, F;
-  Eigen::Matrix<double, 1, 2> H;
-  hrp::Vector2 B, K;
-  hrp::Vector2 x;
-  double R;
+  Eigen::Matrix<double, 7, 1> x, x_a_priori;
+  Eigen::Matrix<double, 7, 7> P, P_a_priori;
+  Eigen::Matrix<double, 7, 7> Q;
+  Eigen::Matrix<double, 3, 3> R;
+  /* static const Eigen::Vector3d g_vec = Eigen::Vector3d(0.0, 0.0, 9.80665); */
+  Eigen::Vector3d g_vec;
 };
 
 // Service implementation headers
@@ -93,11 +221,11 @@ using namespace RTC;
 
 /**
    \brief sample RT component which has one data input port and one data output port
- */
+*/
 class KalmanFilter
   : public RTC::DataFlowComponentBase
 {
- public:
+public:
   /**
      \brief Constructor
      \param manager pointer to the Manager
@@ -155,10 +283,9 @@ class KalmanFilter
   // The action that is invoked when execution context's rate is changed
   // no corresponding operation exists in OpenRTm-aist-0.2.0
   // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
-
   bool SetKalmanFilterParam(double Q_angle, double Q_rate, double R_angle);
 
- protected:
+protected:
   // Configuration variable declaration
   // <rtc-template block="config_declare">
   
@@ -205,9 +332,9 @@ class KalmanFilter
   
   // </rtc-template>
 
- private:
+private:
   double m_dt;
-  KFilter r_filter, p_filter, y_filter;
+  KFilter ekf_filter;
   hrp::BodyPtr m_robot;
   hrp::Matrix33 m_sensorR;
   unsigned int m_debugLevel;


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/295 で書いた
- 内部でRPYを使っている
- 直立姿勢周りでの近似 

を直そうと思い，KalmanFilter.cpp/hを
- Quaternionを使う
- ExtendedKalmanFilterにする

というように変えてみました．

これにより， https://github.com/start-jsk/rtmros_tutorials/pull/76 のテストプログラムにて，

``` lisp
(main :deflection-ypr-angle (float-vector 0 (/ pi 18) 0) :wrt :local :init-ypr-angle (float-vector 0 (/ pi 2) 0) :time 1500)
```

の動作が
![i](https://cloud.githubusercontent.com/assets/4509039/3870651/ddae2426-20d7-11e4-8751-40f56e928576.png)
だったのが
![ii](https://cloud.githubusercontent.com/assets/4509039/3870653/e3aa6f42-20d7-11e4-8788-0c3ed095b918.png)
になり，

``` lisp
(main :deflection-ypr-angle (float-vector 0 (/ pi 6) 0) :wrt :local :init-ypr-angle (float-vector 0 0 (/ -pi 2)) :time 1500)
```

の動作が
![j](https://cloud.githubusercontent.com/assets/4509039/3870656/f0190d42-20d7-11e4-96ff-b7cb2c710c88.png)
だったのが
![jj](https://cloud.githubusercontent.com/assets/4509039/3870657/f526e96c-20d7-11e4-80bb-0f51fe75e3f2.png)
になりました．
