### PR TITLE
enable to set reference frame in get{Reference,Current}{Pose,Position,Ro...

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -733,7 +733,7 @@ class HrpsysConfigurator:
     def getJointAngles(self):
         return [x * 180.0 / math.pi for x in self.sh_svc.getCommand().jointRefs]
 
-    def getCurrentPose(self, lname=None):
+    def getCurrentPose(self, lname=None, frame_name=None):
         '''
         @type jointname: str
         @rtype: List of float
@@ -750,12 +750,14 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getCurrentPose(eef_name)))
             raise RuntimeError("need to specify joint name")
+        if frame_name:
+            lname = lname + ':' + frame_name
         pose = self.fk_svc.getCurrentPose(lname)
         if not pose[0]:
             raise RuntimeError("Could not find reference : " + lname)
         return pose[1].data
 
-    def getCurrentPosition(self, lname=None):
+    def getCurrentPosition(self, lname=None, frame_name=None):
         '''
         @type jointname: str
         @rtype: List of float
@@ -766,10 +768,10 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getCurrentPosition(eef_name)))
             raise RuntimeError("need to specify joint name")
-        pose = self.getCurrentPose(lname)
+        pose = self.getCurrentPose(lname, frame_name)
         return [pose[3], pose[7], pose[11]]
 
-    def getCurrentRotation(self, lname):
+    def getCurrentRotation(self, lname, frame_name=None):
         '''
         @type jointname: str
         @rtype: List of float
@@ -784,10 +786,10 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getCurrentRotation(eef_name)))
             raise RuntimeError("need to specify joint name")
-        pose = self.getCurrentPose(lname)
+        pose = self.getCurrentPose(lname, frame_name)
         return [pose[0:3], pose[4:7], pose[8:11]]
 
-    def getCurrentRPY(self, lname):
+    def getCurrentRPY(self, lname, frame_name=None):
         '''
         @type jointname: str
         @rtype: List of float
@@ -800,7 +802,7 @@ class HrpsysConfigurator:
             raise RuntimeError("need to specify joint name")
         return euler_from_matrix(self.getCurrentRotation(lname), 'sxyz')
 
-    def getReferencePose(self, lname):
+    def getReferencePose(self, lname, frame_name=None):
         '''
         This returns reference(commanded) value,
         and getCurrentPose returns current(actual) value
@@ -819,12 +821,14 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getReferencePose(eef_name)))
             raise RuntimeError("need to specify joint name")
+        if frame_name:
+            lname = lname + ':' + frame_name
         pose = self.fk_svc.getReferencePose(lname)
         if not pose[0]:
             raise RuntimeError("Could not find reference : " + lname)
         return pose[1].data
 
-    def getReferencePosition(self, lname):
+    def getReferencePosition(self, lname, frame_name=None):
         '''
         @rtype: List of float
         @return: List of angles (degree) of all joints, in the order defined
@@ -835,10 +839,10 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getReferencePosition(eef_name)))
             raise RuntimeError("need to specify joint name")
-        pose = self.getReferencePose(lname)
+        pose = self.getReferencePose(lname, frame_name)
         return [pose[3], pose[7], pose[11]]
 
-    def getReferenceRotation(self, lname):
+    def getReferenceRotation(self, lname, frame_name=None):
         '''
         This seturns reference(commanded) value,
         and getCurrentRotation returns current(actual) value
@@ -856,10 +860,10 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getReferencePotation(eef_name)))
             raise RuntimeError("need to specify joint name")
-        pose = self.getReferencePose(lname)
+        pose = self.getReferencePose(lname, frame_name)
         return [pose[0:3], pose[4:7], pose[8:11]]
 
-    def getReferenceRPY(self, lname):
+    def getReferenceRPY(self, lname, frame_name=None):
         '''
         This seturns reference(commanded) value,
         and getCurrentRPY returns current(actual) value
@@ -873,7 +877,7 @@ class HrpsysConfigurator:
                 eef_name = item[1][-1]
                 print("{}: {}".format(eef_name, self.getReferenceRPY(eef_name)))
             raise RuntimeError("need to specify joint name")
-        return euler_from_matrix(self.getReferenceRotation(lname), 'sxyz')
+        return euler_from_matrix(self.getReferenceRotation(lname, frame_name), 'sxyz')
 
     def setTargetPose(self, gname, pos, rpy, tm, frame_name=None):
         '''

--- a/rtc/ForwardKinematics/ForwardKinematics.h
+++ b/rtc/ForwardKinematics/ForwardKinematics.h
@@ -102,8 +102,8 @@ class ForwardKinematics
   // no corresponding operation exists in OpenRTm-aist-0.2.0
   // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
 
-  ::CORBA::Boolean getReferencePose(const char* linkname, RTC::TimedDoubleSeq_out pose);
-  ::CORBA::Boolean getCurrentPose(const char* linkname, RTC::TimedDoubleSeq_out pose);
+  ::CORBA::Boolean getReferencePose(const char* linkname, RTC::TimedDoubleSeq_out pose, const char* frame_name);
+  ::CORBA::Boolean getCurrentPose(const char* linkname, RTC::TimedDoubleSeq_out pose, const char* frame_name);
   ::CORBA::Boolean getRelativeCurrentPosition(const char* linknameFrom, const char *linknameTo, const OpenHRP::ForwardKinematicsService::position target, OpenHRP::ForwardKinematicsService::position result);
   ::CORBA::Boolean selectBaseLink(const char* linkname);
   

--- a/rtc/ForwardKinematics/ForwardKinematicsService_impl.cpp
+++ b/rtc/ForwardKinematics/ForwardKinematicsService_impl.cpp
@@ -23,11 +23,21 @@ void ForwardKinematicsService_impl::setComp(ForwardKinematics *i_comp)
 
 ::CORBA::Boolean ForwardKinematicsService_impl::getReferencePose(const char* linkname, RTC::TimedDoubleSeq_out pose)
 {
-    return m_comp->getReferencePose(linkname, pose);
+    char* frame_name = (char *)strrchr(linkname, ':');
+    if ( frame_name ) {
+        ((char *)linkname)[frame_name - linkname] = '\0'; // cut frame_name, linkname[strpos(':')] = 0x00
+        frame_name++; // skip ":"
+    }
+    return m_comp->getReferencePose(linkname, pose, frame_name);
 }
 ::CORBA::Boolean ForwardKinematicsService_impl::getCurrentPose(const char* linkname, RTC::TimedDoubleSeq_out pose)
 {
-    return m_comp->getCurrentPose(linkname, pose);
+    char* frame_name = (char *)strrchr(linkname, ':');
+    if ( frame_name ) {
+        ((char *)linkname)[frame_name - linkname] = '\0'; // cut frame_name, linkname[strpos(':')] = 0x00
+        frame_name++; // skip ":"
+    }
+    return m_comp->getCurrentPose(linkname, pose, frame_name);
 }
 
 ::CORBA::Boolean ForwardKinematicsService_impl::getRelativeCurrentPosition(const char* linknameFrom, const char *linknameTo, const OpenHRP::ForwardKinematicsService::position target, OpenHRP::ForwardKinematicsService::position result)


### PR DESCRIPTION
...tation,RPY}, see #297
# 297で提案されているようにsetTargetPoseと同様にgetReferencePose, getCurrentPoseでも参照フレームを指定できるようにして見ました．

これであっているか自信がない（https://github.com/start-jsk/rtmros_hironx/pull/215 が動くように試行錯誤しただけ）なので，どなたか確認していただけると幸いです．（calcRfromAttlibute等を使わなくていいんだっけ？みたいな話がよくわかっていません）

あと，
https://github.com/start-jsk/rtmros_hironx/issues/212
で従来のgetReferencePose等は何処を参照フレームとして結果をかえしているか？という質問がありますが，これはワールド座標系という答えでいいでしょうか
