### PR TITLE
(hrpsys_config.py) Update python comments

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -456,7 +456,7 @@ class HrpsysConfigurator:
     # public method to configure all RTCs to be activated on rtcd
     def getRTCList(self):
         '''
-        @rtype: list of list of str
+        @rtype: list of list
         @return: List of available components. Each element consists of a list
                  of abbreviated and full names of the component.
         '''
@@ -482,7 +482,7 @@ class HrpsysConfigurator:
     # public method to configure all RTCs to be activated on rtcd which includes unstable RTCs
     def getRTCListUnstable(self):
         '''
-        @rtype: list of list of str
+        @rtype: list of list
         @return: List of available unstable components. Each element consists
                  of a list of abbreviated and full names of the component.
         '''


### PR DESCRIPTION
`hrpsys_config.py`のdocstringの一部に誤りを発見したため、加筆修正しました。
また、`@type abc: [int]`といった記法は`@type abc: list of int`に統一させていただいています。こうすることで、一部IDEでは正しくtype hintingしてくれるようになります。 

コメント部分のみへの修正なため、プログラム実行への副作用はないものと思われます。ご不都合なければマージしてください。
