### PR TITLE
Enable to use RMFO on robots without imu.

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -318,9 +318,10 @@ class HrpsysConfigurator:
                              self.abc.port("ref_" + sen.name))
 
         #  actual force sensors
-        if self.rmfo and self.kf:
-            # connectPorts(self.kf.port("rpy"), self.ic.port("rpy"))
-            connectPorts(self.kf.port("rpy"), self.rmfo.port("rpy"))
+        if self.rmfo:
+            if self.kf: # use IMU values if exists
+                # connectPorts(self.kf.port("rpy"), self.ic.port("rpy"))
+                connectPorts(self.kf.port("rpy"), self.rmfo.port("rpy"))
             connectPorts(self.rh.port("q"), self.rmfo.port("qCurrent"))
             for sen in filter(lambda x: x.type == "Force", self.sensors):
                 connectPorts(self.rh.port(sen.name), self.rmfo.port(sen.name))


### PR DESCRIPTION
力センサのオフセット除去するRTCを、IMUなしのロボットでも使える変更です。
- IMUのあるロボットは、力センサ姿勢を姿勢計測値＋実関節角値に基づき計算
- IMUがない場合は、絶対姿勢＝単位行列として動かさないで実関節角値に基づき計算
  という挙動になります。

よろしくお願いいたします。
