### PR TITLE
Add KalmanFilterParam as struct

### DIFF
--- a/idl/KalmanFilterService.idl
+++ b/idl/KalmanFilterService.idl
@@ -6,6 +6,26 @@ module OpenHRP
 {
   interface KalmanFilterService
   {
-    boolean SetKalmanFilterParam(in double Q_angle, in double Q_rate, in double R_angle);
+    struct KalmanFilterParam
+    {
+      double Q_angle;
+      double Q_rate;
+      double R_angle;
+    };
+
+    /**
+     * @brief Set KalmanFilter parameters
+     * @param i_param is input parameter
+     * @return true if set successfully, false otherwise
+     */
+    boolean setKalmanFilterParam(in KalmanFilterParam i_param);
+
+    /**
+     * @brief Get KalmanFilter parameters
+     * @param i_param is input parameter
+     * @return true if set successfully, false otherwise
+     */
+    boolean getKalmanFilterParam(out KalmanFilterParam i_param);
+
   };
 };

--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -118,22 +118,25 @@ RTC::ReturnCode_t KalmanFilter::onInitialize()
               << std::endl;
   }
 
+  Q_angle = 0.001;
+  Q_rate = 0.003;
+  R_angle = 0.03;
   r_filter.setF(1, -m_dt, 0, 1);
   r_filter.setP(0, 0, 0, 0);
-  r_filter.setQ(0.001*m_dt, 0, 0, 0.003*m_dt);
-  r_filter.setR(0.03);
+  r_filter.setQ(Q_angle*m_dt, 0, 0, Q_rate*m_dt);
+  r_filter.setR(R_angle);
   r_filter.setB(m_dt, 0);
 
   p_filter.setF(1, -m_dt, 0, 1);
   p_filter.setP(0, 0, 0, 0);
-  p_filter.setQ(0.001*m_dt, 0, 0, 0.003*m_dt);
-  p_filter.setR(0.03);
+  p_filter.setQ(Q_angle*m_dt, 0, 0, Q_rate*m_dt);
+  p_filter.setR(R_angle);
   p_filter.setB(m_dt, 0);
 
   y_filter.setF(1, -m_dt, 0, 1);
   y_filter.setP(0, 0, 0, 0);
-  y_filter.setQ(0.001*m_dt, 0, 0, 0.003*m_dt);
-  y_filter.setR(0.03);
+  y_filter.setQ(Q_angle*m_dt, 0, 0, Q_rate*m_dt);
+  y_filter.setR(R_angle);
   y_filter.setB(m_dt, 0);
 
   m_rpy.data.r = 0;
@@ -356,8 +359,12 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
   }
 */
 
-bool KalmanFilter::SetKalmanFilterParam(double Q_angle, double Q_rate, double R_angle) {
+bool KalmanFilter::setKalmanFilterParam(const OpenHRP::KalmanFilterService::KalmanFilterParam& i_param)
+{
 
+    Q_angle = i_param.Q_angle;
+    Q_rate = i_param.Q_rate;
+    R_angle = i_param.R_angle;
     r_filter.setF(1, -m_dt, 0, 1);
     r_filter.setP(0, 0, 0, 0);
     r_filter.setQ(Q_angle*m_dt, 0, 0, Q_rate*m_dt);
@@ -379,6 +386,13 @@ bool KalmanFilter::SetKalmanFilterParam(double Q_angle, double Q_rate, double R_
     return true;
 }
 
+bool KalmanFilter::getKalmanFilterParam(OpenHRP::KalmanFilterService::KalmanFilterParam& i_param)
+{
+  i_param.Q_angle = Q_angle;
+  i_param.Q_rate = Q_rate;
+  i_param.R_angle = R_angle;
+  return true;
+}
 
 extern "C"
 {

--- a/rtc/KalmanFilter/KalmanFilter.h
+++ b/rtc/KalmanFilter/KalmanFilter.h
@@ -336,7 +336,8 @@ public:
   // The action that is invoked when execution context's rate is changed
   // no corresponding operation exists in OpenRTm-aist-0.2.0
   // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
-  bool SetKalmanFilterParam(double Q_angle, double Q_rate, double R_angle);
+  bool setKalmanFilterParam(const OpenHRP::KalmanFilterService::KalmanFilterParam& i_param);
+  bool getKalmanFilterParam(OpenHRP::KalmanFilterService::KalmanFilterParam& i_param);
 
 protected:
   // Configuration variable declaration
@@ -386,7 +387,7 @@ protected:
   // </rtc-template>
 
 private:
-  double m_dt;
+  double m_dt, Q_angle, Q_rate, R_angle;
   KFilter r_filter, p_filter, y_filter;
   EKFilter ekf_filter;
   hrp::BodyPtr m_robot;

--- a/rtc/KalmanFilter/KalmanFilterService_impl.cpp
+++ b/rtc/KalmanFilter/KalmanFilterService_impl.cpp
@@ -11,10 +11,15 @@ KalmanFilterService_impl::~KalmanFilterService_impl()
 {
 }
 
-bool KalmanFilterService_impl::SetKalmanFilterParam(double Q_angle, double Q_rate, double R_angle)
+bool KalmanFilterService_impl::setKalmanFilterParam(const OpenHRP::KalmanFilterService::KalmanFilterParam& i_param)
 {
-	//std::cout << "KalmanFilterService: " << std::endl;
-	return m_kalman->SetKalmanFilterParam(Q_angle, Q_rate, R_angle);
+	return m_kalman->setKalmanFilterParam(i_param);
+}
+
+bool KalmanFilterService_impl::getKalmanFilterParam(OpenHRP::KalmanFilterService::KalmanFilterParam& i_param)
+{
+	i_param = OpenHRP::KalmanFilterService::KalmanFilterParam();
+	return m_kalman->getKalmanFilterParam(i_param);
 }
 
 void KalmanFilterService_impl::kalman(KalmanFilter *i_kalman)

--- a/rtc/KalmanFilter/KalmanFilterService_impl.h
+++ b/rtc/KalmanFilter/KalmanFilterService_impl.h
@@ -21,7 +21,8 @@ public:
 	*/
 	virtual ~KalmanFilterService_impl();
 
-	bool SetKalmanFilterParam(double Q_angle, double Q_rate, double R_angle);
+	bool setKalmanFilterParam(const OpenHRP::KalmanFilterService::KalmanFilterParam& i_param);
+	bool getKalmanFilterParam(OpenHRP::KalmanFilterService::KalmanFilterParam& i_param);
 
 	void kalman(KalmanFilter *i_kalman);
 


### PR DESCRIPTION
引数のパラメータをまとめた、KalmanFilterParamをIDLに追加しました。
KalmanFilterのsetter/getter関数の引数をかえたときに影響のある箇所を減らすための変更で、
AutoBalancer, Stabilzierと同様の方法になっております。

よろしくお願いいたします。
