### PR TITLE
(hrpsys_config, DataLogger) : Add DataLogger logging for servoState port

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -664,6 +664,7 @@ class HrpsysConfigurator:
         if self.rh != None:
             self.connectLoggerPort(self.rh, 'emergencySignal',
                                    'emergencySignal')
+            self.connectLoggerPort(self.rh, 'servoState')
         for sen in filter(lambda x: x.type == "Force", self.sensors):
             self.connectLoggerPort(self.seq, sen.name + "Ref")
             self.connectLoggerPort(self.sh, sen.name + "Out")

--- a/rtc/DataLogger/DataLogger.cpp
+++ b/rtc/DataLogger/DataLogger.cpp
@@ -68,6 +68,15 @@ void printData(std::ostream& os, const RTC::Orientation3D& data)
     os << data.r << " " << data.p << " " << data.y << " ";
 }
 
+template<class T>
+std::ostream& operator<<(std::ostream& os, const _CORBA_Unbounded_Sequence<T > & data)
+{
+  for (unsigned int j=0; j<data.length(); j++){
+    os << data[j] << " ";
+  }
+  return os;
+}
+
 template <class T>
 void printData(std::ostream& os, const T& data)
 {
@@ -282,6 +291,13 @@ bool DataLogger::add(const char *i_type, const char *i_name)
       }
   }else if (strcmp(i_type, "TimedLongSeq")==0){
       LoggerPort<TimedLongSeq> *lp = new LoggerPort<TimedLongSeq>(i_name);
+      new_port = lp;
+      if (!addInPort(i_name, lp->port())) {
+          resumeLogging();
+          return false;
+      }
+  }else if (strcmp(i_type, "TimedLongSeqSeq")==0){
+      LoggerPort<OpenHRP::TimedLongSeqSeq> *lp = new LoggerPort<OpenHRP::TimedLongSeqSeq>(i_name);
       new_port = lp;
       if (!addInPort(i_name, lp->port())) {
           resumeLogging();

--- a/rtc/DataLogger/DataLogger.h
+++ b/rtc/DataLogger/DataLogger.h
@@ -20,6 +20,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
+#include "HRPDataTypes.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">


### PR DESCRIPTION
DataLoggerで、RobotHardwareのservoStateをロギングしたいと考えており、PRを作ってみました。
- servoStateはTimedLongSeqSeqとなります。
  本PRでは、sequenceのsequenceを、フラットなsequenceとしてprintDataするようにしておりますが、いかがでしょうか。
- printDataがTimedLongSeqSeqをサポートするように、_CORBA_Unbounded_Sequenceの出力演算子をオーバーロードするようにしてみました。（他の方法では、HRPDataType.idlを更新してAPIをbreakするかもしれなかったため)。  

よろしくお願いいたします。
