### PR TITLE
Add optional data for seq

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -312,6 +312,7 @@ class HrpsysConfigurator:
         connectPorts(self.seq.port("basePos"), self.sh.port("basePosIn"))
         connectPorts(self.seq.port("baseRpy"), self.sh.port("baseRpyIn"))
         connectPorts(self.seq.port("zmpRef"), self.sh.port("zmpIn"))
+        connectPorts(self.seq.port("optionalData"), self.sh.port("optionalDataIn"))
         connectPorts(self.sh.port("basePosOut"), [self.seq.port("basePosInit"),
                                                   self.fk.port("basePosRef")])
         connectPorts(self.sh.port("baseRpyOut"), [self.seq.port("baseRpyInit"),

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -150,6 +150,8 @@ class SequencePlayer
   OutPort<TimedOrientation3D> m_baseRpyOut;
   std::vector<TimedDoubleSeq> m_wrenches;
   std::vector<OutPort<TimedDoubleSeq> *> m_wrenchesOut;
+  TimedDoubleSeq m_optionalData;
+  OutPort<TimedDoubleSeq> m_optionalDataOut;
 
   
   // </rtc-template>
@@ -179,6 +181,7 @@ class SequencePlayer
   std::string m_gname;
   unsigned int m_debugLevel;
   int dummy;
+  size_t optional_data_dim;
   coil::Mutex m_mutex;
   double m_error_pos, m_error_rot;
   short m_iteration;

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -13,7 +13,7 @@ using namespace hrp;
 class seqplay
 {
 public:
-    seqplay(unsigned int i_dof, double i_dt, unsigned int i_fnum = 0);
+    seqplay(unsigned int i_dof, double i_dt, unsigned int i_fnum = 0, unsigned int optional_data_dim = 1);
     ~seqplay();
     //
     bool isEmpty() const;
@@ -41,14 +41,14 @@ public:
     void loadPattern(const char *i_basename, double i_tm);
     void clear(double i_timeLimit=0);
     void get(double *o_q, double *o_zmp, double *o_accel,
-	     double *o_basePos, double *o_baseRpy, double *o_tq, double *o_wrenches);
+	     double *o_basePos, double *o_baseRpy, double *o_tq, double *o_wrenches, double *o_optional_data);
     void go(const double *i_q, const double *i_zmp, const double *i_acc,
-            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, double i_time, 
+            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data, double i_time, 
             bool immediate=true);
     void go(const double *i_q, const double *i_zmp, const double *i_acc,
-            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches,
+            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data,
 	    const double *ii_q, const double *ii_zmp, const double *ii_acc,
-            const double *ii_p, const double *ii_rpy, const double *ii_tq, const double *ii_wrenches,
+            const double *ii_p, const double *ii_rpy, const double *ii_tq, const double *ii_wrenches, const double *ii_optional_data,
             double i_time, bool immediate=true);
     void sync();
     bool setInterpolationMode(interpolator::interpolation_mode i_mode_);
@@ -136,7 +136,7 @@ private:
         double time2remove;
     };
     void pop_back();
-    enum {Q, ZMP, ACC, P, RPY, TQ, WRENCHES, NINTERPOLATOR};
+    enum {Q, ZMP, ACC, P, RPY, TQ, WRENCHES, OPTIONAL_DATA, NINTERPOLATOR};
     interpolator *interpolators[NINTERPOLATOR];
     std::map<std::string, groupInterpolator *> groupInterpolators; 
     int debug_level, m_dof;

--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -41,6 +41,7 @@ StateHolder::StateHolder(RTC::Manager* manager)
     m_basePosIn("basePosIn", m_basePos),
     m_baseRpyIn("baseRpyIn", m_baseRpy),
     m_zmpIn("zmpIn", m_zmp),
+    m_optionalDataIn("optionalDataIn", m_optionalData),
     m_qOut("qOut", m_q),
     m_tqOut("tqOut", m_tq),
     m_basePosOut("basePosOut", m_basePos),
@@ -48,6 +49,7 @@ StateHolder::StateHolder(RTC::Manager* manager)
     m_baseTformOut("baseTformOut", m_baseTform),
     m_basePoseOut("basePoseOut", m_basePose),
     m_zmpOut("zmpOut", m_zmp),
+    m_optionalDataOut("optionalDataOut", m_optionalData),
     m_StateHolderServicePort("StateHolderService"),
     m_TimeKeeperServicePort("TimeKeeperService"),
     // </rtc-template>
@@ -85,6 +87,7 @@ RTC::ReturnCode_t StateHolder::onInitialize()
     addInPort("basePosIn", m_basePosIn);
     addInPort("baseRpyIn", m_baseRpyIn);
     addInPort("zmpIn", m_zmpIn);
+    addInPort("optionalDataIn", m_optionalDataIn);
   
   // Set OutPort buffer
     addOutPort("qOut", m_qOut);
@@ -94,6 +97,7 @@ RTC::ReturnCode_t StateHolder::onInitialize()
     addOutPort("baseTformOut", m_baseTformOut);
     addOutPort("basePoseOut", m_basePoseOut);
     addOutPort("zmpOut", m_zmpOut);
+    addOutPort("optionalDataOut", m_optionalDataOut);
   
   // Set service provider to Ports
   m_StateHolderServicePort.registerProvider("service0", "StateHolderService", m_service0);
@@ -250,6 +254,10 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
         m_zmpIn.read();
     }
 
+    if (m_optionalDataIn.isNew()){
+        m_optionalDataIn.read();
+    }
+
     for (size_t i = 0; i < m_wrenchesIn.size(); i++) {
       if ( m_wrenchesIn[i]->isNew() ) {
         m_wrenchesIn[i]->read();
@@ -292,6 +300,7 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
     m_baseRpyOut.write();
     m_zmpOut.write();
     m_basePoseOut.write();
+    m_optionalDataOut.write();
     for (size_t i = 0; i < m_wrenchesOut.size(); i++) {
       m_wrenchesOut[i]->write();
     }

--- a/rtc/StateHolder/StateHolder.h
+++ b/rtc/StateHolder/StateHolder.h
@@ -114,6 +114,8 @@ class StateHolder
   InPort<TimedOrientation3D> m_baseRpyIn;
   InPort<TimedPoint3D> m_zmpIn;
   std::vector<InPort<TimedDoubleSeq> *> m_wrenchesIn;
+  TimedDoubleSeq m_optionalData;
+  InPort<TimedDoubleSeq> m_optionalDataIn;
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
@@ -138,6 +140,7 @@ class StateHolder
   OutPort<TimedPose3D> m_basePoseOut;
   OutPort<TimedPoint3D> m_zmpOut;
   std::vector<OutPort<TimedDoubleSeq> *> m_wrenchesOut;
+  OutPort<TimedDoubleSeq> m_optionalDataOut;
 
   // </rtc-template>
 

--- a/test/test_SequencePlayer.cpp
+++ b/test/test_SequencePlayer.cpp
@@ -46,10 +46,10 @@ public:
     }
 
     void testSetAngles(double *av) {
-      double q[9], zmp[3], acc[3], pos[3], rpy[3], tq[9], wrenches[6];
+      double q[9], zmp[3], acc[3], pos[3], rpy[3], tq[9], wrenches[6], optional_data[3];
 
         while (!m_seq->isEmpty()) {
-          m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches);
+          m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches, optional_data);
             for (int i = 0; i < 9; i++ ) {
                 // check if no over shoot
                 //std::cerr << i << " " << q[i] << " " << av[i] << std::endl;
@@ -83,7 +83,7 @@ TEST_F(test_SequencePlayer, setJointAnglesContiniously) {
     int loop = 10;
     double av[9] = {0,1,2,3,4,5,6,7,8}, av_old[9] = {0,0,0,0,0,0,0,0,0};
     double q[9], q_old[9], tq[9];
-    double zmp[3], acc[3], pos[3], rpy[3], wrenches[6];
+    double zmp[3], acc[3], pos[3], rpy[3], wrenches[6], optional_data[3];
 
     m_seq->setJointAngles(av, 1);
     while (!m_seq->isEmpty()) {
@@ -98,7 +98,7 @@ TEST_F(test_SequencePlayer, setJointAnglesContiniously) {
             loop--;
         }
         for (int i = 0; i < 9; i++ ) { q_old[i] = q[i]; }
-        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches);
+        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches, optional_data);
         for (int i = 0; i < 9; i++ ) {
             // check velocity
             //std::cerr << i << " " << av_old[i] << " " << q[i] << " " << av[i] << " " << (q[i] - q_old[i])/m_dt << std::endl;
@@ -133,8 +133,8 @@ TEST_F(test_SequencePlayer, playPattern) {
     m_seq->playPattern(avs, rpy, zmp, tm, qInit, 9);
     while (!m_seq->isEmpty()) {
         for (int i = 0; i < 9; i++ ) { q_old[i] = q[i]; }
-        double zmp[3], acc[3], pos[3], rpy[3], wrenches[6];
-        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches);
+        double zmp[3], acc[3], pos[3], rpy[3], wrenches[6], optional_data[3];
+        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches, optional_data);
         for (int i = 0; i < 9; i++ ) {
             // check velocity
             double vel = fabs(q[i] - q_old[i])/m_dt;
@@ -185,7 +185,7 @@ TEST_P(test_SequencePlayerOfGroup, setJointAnglesContiniously) {
     int loop = 10;
     double av[9] = {0,1,2,3,4,5,6,7,8}, av_old[9] = {0,0,0,0,0,0,0,0,0};
     double q[9], q_old[9], tq[9];
-    double zmp[3], acc[3], pos[3], rpy[3], wrenches[6];
+    double zmp[3], acc[3], pos[3], rpy[3], wrenches[6], optional_data[3];
 
     std::vector<int> indices = GetParam();
     std::cout << "indices";
@@ -216,7 +216,7 @@ TEST_P(test_SequencePlayerOfGroup, setJointAnglesContiniously) {
             loop--;
         }
         for (int i = 0; i < 9; i++ ) { q_old[i] = q[i]; }
-        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches);
+        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches, optional_data);
         for (int i = 0; i < 9; i++ ) {
             // check velocity
             //std::cerr << i << " " << av_old[i] << " " << q[i] << " " << av[i] << " " << (q[i] - q_old[i])/m_dt << std::endl;
@@ -279,8 +279,8 @@ TEST_P(test_SequencePlayerOfGroup, playPattern) {
     //m_seq->playPatternOfGroup("test", avs, tm, qInit, 9);
     while (!m_seq->isEmpty()) {
         for (int i = 0; i < 9; i++ ) { q_old[i] = q[i]; }
-        double zmp[3], acc[3], pos[3], rpy[3], wrenches[6];
-        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches);
+        double zmp[3], acc[3], pos[3], rpy[3], wrenches[6], optional_data[3];
+        m_seq->get(q, zmp, acc, pos, rpy, tq, wrenches, optional_data);
         for (int i = 0; i < 9; i++ ) {
             // check velocity
             double vel = fabs(q[i] - q_old[i])/m_dt;


### PR DESCRIPTION
google codeの時代に
https://github.com/fkanehiro/hrpsys-base/issues/190
でpatchを送っておりましたものを、PRにしました。

loadPatternなどで制御系のパラメータ（遊脚時間、ゲイン、、、etc）を一緒に補間する機能追加となります。
google codeのpatchとの変更点としては、idlに変更があったのを変更なくしました。（APIを壊さないため）

ご検討いただけますと幸いです。
