### PR TITLE
32bitマシンでのvclipの挙動の修正

### DIFF
--- a/rtc/CollisionDetector/CMakeLists.txt
+++ b/rtc/CollisionDetector/CMakeLists.txt
@@ -4,6 +4,11 @@ set(vclip_dir vclip_1.0/)
 set(vclip_sources ${vclip_dir}/src/vclip.C ${vclip_dir}/src/PolyTree.C ${vclip_dir}/src/mv.C)
 
 add_definitions(-DQHULL)
+if(NOT (${CMAKE_SYSTEM_PROCESSOR} MATCHES amd64* OR
+      ${CMAKE_SYSTEM_PROCESSOR} MATCHES x86_64*) )
+## only for 32bit system
+set_source_files_properties(${vclip_sources} PROPERTIES COMPILE_FLAGS -ffloat-store)
+endif()
 include_directories(${LIBXML2_INCLUDE_DIR} ${QHULL_INCLUDE_DIR} ${seq_dir} ${vclip_dir}/include)
 add_library(CollisionDetector SHARED ${comp_sources} ${vclip_sources})
 target_link_libraries(CollisionDetector hrpsysUtil ${QHULL_LIBRARIES})

--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -207,6 +207,7 @@ RTC::ReturnCode_t CollisionDetector::onActivated(RTC::UniqueId ec_id)
 
     if ( prop["collision_loop"] != "" ) {
         coil::stringTo(m_collision_loop, prop["collision_loop"].c_str());
+        std::cerr << "set collision_loop: " << m_collision_loop << std::endl;
     }
     if ( m_use_viewer ) {
       m_scene.addBody(m_robot);


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/49 ここで議論されている問題ですが、
-ffloat-storeをつけると解決することがわかりました。
vmware上での検証では、vclip cycle detected!  は出なくなっています。
