### PR TITLE
fix for old pcl

### DIFF
--- a/rtc/DataLogger/CMakeLists.txt
+++ b/rtc/DataLogger/CMakeLists.txt
@@ -8,7 +8,7 @@ add_executable(DataLoggerComp DataLoggerComp.cpp ${comp_sources})
 target_link_libraries(DataLoggerComp ${libs})
 
 find_package(PCL)
-if (PCL_FOUND AND ${PCL_VERSION_MINOR} GREATER 6)
+if (PCL_FOUND AND "${PCL_VERSION_MINOR}" GREATER 6)
   include_directories(${PCL_INCLUDE_DIRS})
   link_directories(${PCL_LIBRARY_DIRS})
   add_executable(PointCloudLogViewer PointCloudLogViewer)


### PR DESCRIPTION
- current cmake file will not work on newer cmake, this raise error before precise..

```
CMake Error at rtc/DataLogger/CMakeLists.txt:11 (if):
  if given arguments:

    "PCL_FOUND" "AND" "GREATER" "6"

  Unknown arguments specified


-- Configuring incomplete, errors occurred!
```
