### PR TITLE
Fix order of end effector according to ForceSensor order

### DIFF
--- a/sample/SampleRobot/SampleRobot.conf.in
+++ b/sample/SampleRobot/SampleRobot.conf.in
@@ -3,6 +3,6 @@ dt: @CONTROLLER_TIME@
 
 abc_leg_offset: 0,0.09,0
 abc_stride_parameter: 0.15,0.05,10
-end_effectors: rarm,RARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708, larm,LARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0,
+end_effectors: lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, larm,LARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708, rarm,RARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708,
 
 pdgains_sim.file_name: @CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/SampleRobot/SampleRobot.PDgain.dat


### PR DESCRIPTION
SampleRobotのサンプルの、confに書いてあるエンドエフェクタの順番をForceSensorのIDの順にしました。
この変更で挙動は変わりませんが、特に別な順番である必要もなく同じ順番の方がわかりやすいためです。

よろしくお願いいたします。
