### PR TITLE
Calculate LPF parameter based on controller time step dt and enable to set cut-off frequency from IDL.

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -83,6 +83,8 @@ module OpenHRP
       DblArray2 eefm_body_attitude_control_gain;
       /// Time constant for body attitude control [s] (roll, pitch) for EEFM.
       DblArray2 eefm_body_attitude_control_time_const;
+      /// Cutoff frequency of LPF in calculation of COG velocity [Hz]
+      double eefm_cogvel_cutoff_freq;
       // common
       STAlgorithm st_algorithm;
       ControllerMode controller_mode;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -250,7 +250,7 @@ class Stabilizer
   double rdx, rdy, rx, ry;
   // EEFM ST
   double eefm_k1[2], eefm_k2[2], eefm_k3[2], eefm_zmp_delay_time_const[2], eefm_body_attitude_control_gain[2], eefm_body_attitude_control_time_const[2];
-  double eefm_rot_damping_gain, eefm_rot_time_const, eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_pos_time_const_swing, eefm_pos_transition_time, eefm_pos_margin_time, eefm_leg_inside_margin;
+  double eefm_rot_damping_gain, eefm_rot_time_const, eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_pos_time_const_swing, eefm_pos_transition_time, eefm_pos_margin_time, eefm_leg_inside_margin, eefm_cogvel_cutoff_freq;
   hrp::Vector3 d_foot_rpy[2], new_refzmp, rel_cog, ref_zmp_aux;
   hrp::Vector3 ref_foot_force[2];
   hrp::Vector3 ref_foot_moment[2];


### PR DESCRIPTION
重心速度のLPFを、サンプリングタイムなどで計算するようにして、dtがちがうロボットでも挙動が同じになるようにしました。
よろしくお願いいたします。
