### PR TITLE
Use foot edges in calculation of alpha

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -79,6 +79,10 @@ module OpenHRP
       double eefm_pos_margin_time;
       /// Inside foot margine [m]. Distance between foot end effector position and foot inside edge.
       double eefm_leg_inside_margin;
+      /// Front foot margine [m]. Distance between foot end effector position and foot front edge.
+      double eefm_leg_front_margin;
+      /// Rear foot margine [m]. Distance between foot end effector position and foot rear edge.
+      double eefm_leg_rear_margin;
       /// Body attitude control gain [rad/s] (roll, pitch) for EEFM.
       DblArray2 eefm_body_attitude_control_gain;
       /// Time constant for body attitude control [s] (roll, pitch) for EEFM.

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -127,6 +127,22 @@ class Stabilizer
     return (prev_act_force_z[idx] > 25.0);
   };
 
+  inline bool is_inside_foot (const hrp::Vector3& leg_pos, const bool is_lleg)
+  {
+    if (is_lleg) return leg_pos(1) >= -1 * eefm_leg_inside_margin;
+    else return leg_pos(1) <= eefm_leg_inside_margin;
+  };
+
+  inline bool is_front_of_foot (const hrp::Vector3& leg_pos)
+  {
+    return leg_pos(0) >= eefm_leg_front_margin;
+  };
+
+  inline bool is_rear_of_foot (const hrp::Vector3& leg_pos)
+  {
+    return leg_pos(0) <= -1 * eefm_leg_rear_margin;
+  };
+
  protected:
   // Configuration variable declaration
   // <rtc-template block="config_declare">
@@ -244,7 +260,7 @@ class Stabilizer
   double rdx, rdy, rx, ry;
   // EEFM ST
   double eefm_k1[2], eefm_k2[2], eefm_k3[2], eefm_zmp_delay_time_const[2], eefm_body_attitude_control_gain[2], eefm_body_attitude_control_time_const[2];
-  double eefm_rot_damping_gain, eefm_rot_time_const, eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_pos_time_const_swing, eefm_pos_transition_time, eefm_pos_margin_time, eefm_leg_inside_margin, eefm_cogvel_cutoff_freq;
+  double eefm_rot_damping_gain, eefm_rot_time_const, eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_pos_time_const_swing, eefm_pos_transition_time, eefm_pos_margin_time, eefm_leg_inside_margin, eefm_leg_front_margin, eefm_leg_rear_margin, eefm_cogvel_cutoff_freq;
   hrp::Vector3 d_foot_rpy[2], new_refzmp, rel_cog, ref_zmp_aux;
   hrp::Vector3 ref_foot_force[2];
   hrp::Vector3 ref_foot_moment[2];


### PR DESCRIPTION
Stabilzierの足先モーメントなどの分配で、足平前側・後ろ側エッジをつかうようにしました。
よろしくお願いいたします。
