### PR TITLE
Connect ports of first input object.

### DIFF
--- a/util/ProjectGenerator/ProjectGenerator.cpp
+++ b/util/ProjectGenerator/ProjectGenerator.cpp
@@ -141,14 +141,18 @@ int main (int argc, char** argv)
         if (use_highgain_mode) {
           xmlTextWriterWriteProperty(writer, "HGcontroller0.period", dt);
           xmlTextWriterWriteProperty(writer, "HGcontroller0.factory", "HGcontroller");
-          xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.qOut:"+name+"(Robot)0.qRef");
-          xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.dqOut:"+name+"(Robot)0.dqRef");
-          xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.ddqOut:"+name+"(Robot)0.ddqRef");
+          if (it==inputs.begin()) {
+            xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.qOut:"+name+"(Robot)0.qRef");
+            xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.dqOut:"+name+"(Robot)0.dqRef");
+            xmlTextWriterWriteProperty(writer, "connection", "HGcontroller0.ddqOut:"+name+"(Robot)0.ddqRef");
+          }
         } else {
           xmlTextWriterWriteProperty(writer, "PDcontroller0.period", dt);
           xmlTextWriterWriteProperty(writer, "PDcontroller0.factory", "PDcontroller");
-          xmlTextWriterWriteProperty(writer, "connection", "PDcontroller0.torque:"+name+"(Robot)0.tauRef");
-          xmlTextWriterWriteProperty(writer, "connection", ""+name+"(Robot)0.q:PDcontroller0.angle");
+          if (it==inputs.begin()) {
+            xmlTextWriterWriteProperty(writer, "connection", "PDcontroller0.torque:"+name+"(Robot)0.tauRef");
+            xmlTextWriterWriteProperty(writer, "connection", ""+name+"(Robot)0.q:PDcontroller0.angle");
+          }
         }
 	xmlTextWriterEndElement(writer); // item
 


### PR DESCRIPTION
ProjectGeneratorで生成されるプロジェクトファイルで、HGcontroller, PDcontroller
などにロボットのモデル以外の環境モデル（longfloorなど）ともポートのconnectionがなされており、
またその結果PDcontrollerなどで適切にロボットの関節指令値が実行されませんでした
（なぜかHGcontrollerではうごいてましたが。。。）

https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_tools/launch/_gen_project.launch#L19
のようにProjectGeneratorの１個目でロボットを、2個目以降で環境モデル等をセットする使い方をしているので、
１個目のモデルにはconnectionをはって、２個目以降は接続しないようにしました。

よろしくお願いいたします。
