### PR TITLE
Add setWrench function for SequencePlayer. Checked with 315.1.10 compati...

### DIFF
--- a/idl/SequencePlayerService.idl
+++ b/idl/SequencePlayerService.idl
@@ -198,5 +198,14 @@ module OpenHRP
      * @return true if set successfully, false otherwise
      */
     boolean setWrenches(in dSequence wrenches, in double tm);
+
+    /**
+     * @brief Interpolate a Wrench. Function returns without waiting for interpolation to finish
+     * @param name Name of interpolated wrench
+     * @param wrench Wrench
+     * @param tm duration
+     * @return true if set successfully, false otherwise
+     */
+    boolean setWrench(in string name, in dSequence wrench, in double tm);
   };
 };

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -436,6 +436,24 @@ bool SequencePlayer::setWrenches(const double *wrenches, double tm)
     return true;
 }
 
+bool SequencePlayer::setWrench(const char* name, const double *wrench, double tm)
+{
+    Guard guard(m_mutex);
+    int idx = -1;
+    for (int i = 0; i < m_wrenches.size(); i++) {
+      hrp::Sensor *s = m_robot->sensor(hrp::Sensor::FORCE, i);
+      if (std::string(s->name) == std::string(name)) {
+        idx = i;
+      }
+    }
+    if (idx == -1) {
+      std::cerr << "[setWrench] " << name << " does not exist" << std::endl;
+      return false;
+    }
+    m_seq->setWrench(idx, wrench, tm);
+    return true;
+}
+
 bool SequencePlayer::setTargetPose(const char* gname, const double *xyz, const double *rpy, double tm, const char* frame_name)
 {
     if ( m_debugLevel > 0 ) {

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -104,6 +104,7 @@ class SequencePlayer
   bool setZmp(const double *zmp, double tm);
   bool setTargetPose(const char* gname, const double *xyz, const double *rpy, double tm, const char* frame_name);
   bool setWrenches(const double *wrenches, double tm);
+  bool setWrench(const char* name, const double *wrench, double tm);
   void loadPattern(const char *basename, double time); 
   void playPattern(const OpenHRP::dSequenceSequence& pos, const OpenHRP::dSequenceSequence& rpy, const OpenHRP::dSequenceSequence& zmp, const OpenHRP::dSequence& tm);
   bool setInterpolationMode(OpenHRP::SequencePlayerService::interpolationMode i_mode_);

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -81,6 +81,11 @@ CORBA::Boolean SequencePlayerService_impl::setWrenches(const dSequence& wrenches
     return m_player->setWrenches(wrenches.get_buffer(), tm);
 }
 
+CORBA::Boolean SequencePlayerService_impl::setWrench(const char* name, const dSequence& wrench, CORBA::Double tm)
+{
+    return m_player->setWrench(name, wrench.get_buffer(), tm);
+}
+
 CORBA::Boolean SequencePlayerService_impl::setTargetPose(const char* gname, const dSequence& xyz, const dSequence& rpy, CORBA::Double tm){
     char* frame_name = (char *)strrchr(gname, ':');
     if ( frame_name ) {

--- a/rtc/SequencePlayer/SequencePlayerService_impl.h
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.h
@@ -25,6 +25,7 @@ public:
   CORBA::Boolean setBaseRpy(const dSequence& rpy, CORBA::Double tm);
   CORBA::Boolean setZmp(const dSequence& zmp, CORBA::Double tm);
   CORBA::Boolean setWrenches(const dSequence& wrenches, CORBA::Double tm);
+  CORBA::Boolean setWrench(const char* name, const dSequence& wrench, CORBA::Double tm);
   CORBA::Boolean setTargetPose(const char* gname, const dSequence& xyz, const dSequence& rpy, CORBA::Double tm);
   CORBA::Boolean isEmpty();
   void loadPattern(const char* basename, CORBA::Double tm);

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -26,6 +26,7 @@ public:
     void setBaseRpy(const double *i_rpy, double i_tm=0.0);
     void setBaseAcc(const double *i_acc, double i_tm=0.0);
     void setWrenches(const double *i_wrenches, double i_tm=0.0);
+    void setWrench(const int idx, const double *i_wrench, double i_tm);
     void playPattern(std::vector<const double*> pos, std::vector<const double*> zmp, std::vector<const double*> rpy, std::vector<double> tm, const double *qInit, unsigned int len);
     //
     bool addJointGroup(const char *gname, const std::vector<int>& indices);
@@ -136,8 +137,9 @@ private:
         double time2remove;
     };
     void pop_back();
-    enum {Q, ZMP, ACC, P, RPY, TQ, WRENCHES, OPTIONAL_DATA, NINTERPOLATOR};
-    interpolator *interpolators[NINTERPOLATOR];
+    enum {Q, ZMP, ACC, P, RPY, TQ, OPTIONAL_DATA, WRENCHES, NINTERPOLATOR_WITHOUT_WRENCHES};
+    size_t NINTERPOLATOR, force_sensor_num;
+    std::vector<interpolator *> interpolators; 
     std::map<std::string, groupInterpolator *> groupInterpolators; 
     int debug_level, m_dof;
 };


### PR DESCRIPTION
SequencePlayerに一個のエンドエフェクタの目標力・モーメントをセットするsetWrenchを追加しました。
https://github.com/fkanehiro/hrpsys-base/pull/395
からsetWrenchの部分のみ抜き出してコミットです。

SequencePlayerのidlが変更になりますが、最後尾追加なのと、
- 315.1.10やこの一個前のバージョンのhrpsys-base
- このコミットを適用したIDLから作ったもの（テストしたのはhrpsys_ros_bridge越しにeuslispから通信）

でテストして、通信できていることを確認していますが、@k-okadaさん、これでOKでしょうか。
（通信できている＝setWrench以外のsetJointAnglesなどのidlにあるサービスポート関数が、エラーなく実行できる）
