### PR TITLE
Set m_enable as false by default

### DIFF
--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -67,7 +67,7 @@ CollisionDetector::CollisionDetector(RTC::Manager* manager)
       m_window(&m_scene, &m_log),
 #endif // USE_HRPSYSUTIL
       m_debugLevel(0),
-      m_enable(true),
+      m_enable(false),
       dummy(0)
 {
     m_service0.collision(this);

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -191,7 +191,7 @@ class CollisionDetector
   double i_dt;
   int default_recover_time;
   unsigned int m_debugLevel;
-  bool m_enable;
+  bool m_enable, m_is_overwrite_jointangles;
   OpenHRP::CollisionDetectorService::CollisionState m_state;
 };
 


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/431
で報告させていただいたことに関連しまして、デフォルトでCollisionDetectorをdisableにしました。

最初の起動時に干渉している場合、m_lastsafe_postureがセットされないうちに干渉計さんのループにはいり、干渉状態から抜け出せないためです。

@k-okadaさん
デフォルトの挙動がかわりますが、こちらでよろしいでしょうか。
