### PR TITLE
Print in current value and max value in ThermoLimiter alart

### DIFF
--- a/rtc/ThermoLimiter/ThermoLimiter.cpp
+++ b/rtc/ThermoLimiter/ThermoLimiter.cpp
@@ -336,11 +336,7 @@ double ThermoLimiter::calcEmergencyRatio(RTC::TimedDoubleSeq &current, hrp::dvec
     for (int i = 0; i < current.data.length(); i++) {
       double tmpEmergencyRatio = std::abs(current.data[i] / max[i]);
       if (tmpEmergencyRatio > alarmRatio) {
-        std::cerr << prefix << "[" << m_robot->joint(i)->name << "]" << " is over " << alarmRatio << " of the limit.";
-        if (m_debugLevel > 0) {
-          std::cerr << ": " << current.data[i] << ">" << max[i];
-        }
-        std::cerr << std::endl;
+          std::cerr << prefix << "[" << m_robot->joint(i)->name << "]" << " is over " << alarmRatio << " of the limit (" << current.data[i] << "/" << max[i] << ")" << std::endl;
       }
       if (maxEmergencyRatio < tmpEmergencyRatio) {
         maxEmergencyRatio = tmpEmergencyRatio;


### PR DESCRIPTION
ThermoLimiterのしきい値越えのメッセージで、比率だけでなく値とmax値もprintするようにしました。

よろしくお願いいたします。