### PR TITLE
Add joint velocity limitation in SoftErrorLimiter

### DIFF
--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -214,6 +214,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       }
     }
 
+    // Velocity limitation for reference joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
       int servo_state = (m_servoState.data[i][0] & OpenHRP::RobotHardwareService::SERVO_STATE_MASK) >> OpenHRP::RobotHardwareService::SERVO_STATE_SHIFT; // enum SwitchStatus {SWITCH_ON, SWITCH_OFF};
       double qvel = (m_qRef.data[i] - prev_angle[i]) / dt;
@@ -231,6 +232,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       }
     }
 
+    // Position limitation for reference joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
       int servo_state = (m_servoState.data[i][0] & OpenHRP::RobotHardwareService::SERVO_STATE_MASK) >> OpenHRP::RobotHardwareService::SERVO_STATE_SHIFT; // enum SwitchStatus {SWITCH_ON, SWITCH_OFF};
       double error = m_qRef.data[i] - m_qCurrent.data[i];
@@ -274,6 +276,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       prev_angle[i] = m_qRef.data[i];
     }
 
+    // Servo error limitation between reference joint angles and actual joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
       double limit = m_robot->m_servoErrorLimit[i];
       double error = m_qRef.data[i] - m_qCurrent.data[i];
@@ -290,6 +293,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       }
     }
 
+    // Beep sound
     if ( soft_limit_error ) { // play beep
       if ( loop % soft_limit_error_beep_freq == 0 ) start_beep(3136, soft_limit_error_beep_freq*0.8);
     }else if ( position_limit_error || velocity_limit_error ) { // play beep

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.h
@@ -145,6 +145,7 @@ class SoftErrorLimiter
   std::map<std::string, hrp::JointLimitTable> joint_limit_tables;
   unsigned int m_debugLevel;
   int dummy, position_limit_error_beep_freq, soft_limit_error_beep_freq;
+  double dt;
 };
 
 


### PR DESCRIPTION
現行のStableRTCで関節速度が過大になるときにリミットするものがなかったので、
SoftErrorLimiterにlvlimit, uvlimitに応じて関節速度を制限する部分を追加しました。
また、リミット部分が多くなったのでコメント追加等更新をしました。

速度制限はqRef自体のフィードフォワードな制限ということで、ビープ音はposition limitの音と同じにしました。
position limitと速度制限とで別な音にしてもよかったですが、これとは別にcollision detectorでも音を鳴らしたく、速度制限自体を他特別できる音をださなくても良いかと思いました。


マージの際は
https://github.com/fkanehiro/hrpsys-base/pull/457
のマージ後に本PRのマージをしていただけますと幸いです。

よろしくお願いいたします。