### PR TITLE
Fix initialize f value and this will solve divergence of rare pattern generation

### DIFF
--- a/rtc/AutoBalancer/PreviewController.cpp
+++ b/rtc/AutoBalancer/PreviewController.cpp
@@ -30,6 +30,7 @@ void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr)
 void preview_control::calc_f()
 {
   f.resize(delay+1);
+  f(0)=0;
   Eigen::Matrix<double, 1, 1> fa;
   hrp::Matrix33 gsi(hrp::Matrix33::Identity());
   for (size_t i = 0; i < delay; i++) {
@@ -56,6 +57,7 @@ void preview_control::calc_x_k()
 void extended_preview_control::calc_f()
 {
   f.resize(delay + 1);
+  f(0)=0;
   Eigen::Matrix<double, 1, 1> fa;
   Eigen::Matrix<double, 4, 4> gsi(Eigen::Matrix<double, 4, 4>::Identity());
   Eigen::Matrix<double, 4, 1> qt(riccati.Q * riccati.c.transpose());


### PR DESCRIPTION
goPosなどで歩行パターンが時々発散することがありましたが（20-50回に一回）
変数が初期化されない箇所がありましたので修正しました。

1000回ちかくテストしても大丈夫でしたので、時々発散する原因はここのみで、このPRで治ったように思います。

よろしくお願いいたします。