### PR TITLE
Interpolate sync velocity ratio

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -374,14 +374,13 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
       }
       // transition
       if (!is_transition_interpolator_empty) {
-        double tmp_ratio = transition_interpolator_ratio;
-        // tmp_ratio 0=>1 : IDLE => ABC
-        // tmp_ratio 1=>0 : ABC => IDLE
-        ref_basePos = (1-tmp_ratio) * input_basePos + tmp_ratio * m_robot->rootLink()->p;
-        rel_ref_zmp = (1-tmp_ratio) * input_zmp + tmp_ratio * rel_ref_zmp;
-        rats::mid_rot(ref_baseRot, tmp_ratio, input_baseRot, m_robot->rootLink()->R);
+        // transition_interpolator_ratio 0=>1 : IDLE => ABC
+        // transition_interpolator_ratio 1=>0 : ABC => IDLE
+        ref_basePos = (1-transition_interpolator_ratio) * input_basePos + transition_interpolator_ratio * m_robot->rootLink()->p;
+        rel_ref_zmp = (1-transition_interpolator_ratio) * input_zmp + transition_interpolator_ratio * rel_ref_zmp;
+        rats::mid_rot(ref_baseRot, transition_interpolator_ratio, input_baseRot, m_robot->rootLink()->R);
         for ( int i = 0; i < m_robot->numJoints(); i++ ) {
-          m_robot->joint(i)->q = (1-tmp_ratio) * m_qRef.data[i] + tmp_ratio * m_robot->joint(i)->q;
+          m_robot->joint(i)->q = (1-transition_interpolator_ratio) * m_qRef.data[i] + transition_interpolator_ratio * m_robot->joint(i)->q;
         }
       } else {
         ref_basePos = m_robot->rootLink()->p;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -208,7 +208,7 @@ class AutoBalancer
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
 
-  double zmp_interpolate_time;
+  double zmp_interpolate_time, transition_interpolator_ratio;
   interpolator *zmp_interpolator;
   interpolator *transition_interpolator;
   hrp::Vector3 input_zmp, input_basePos;


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/460で速度制限がはいりましたが、
今までのコードで速度制限にかかっておりワーニングがでる箇所がありましたので、でないように修正しました。
挙動はほぼかわらないと思います。

具体的にはモード遷移時に、IKでといた結果に遷移の比率（0,1）をかけていましたが、
この中でといているIK部分で過大な速度がでるとワーニングがでます。
最終出力関節角度は遷移比率がかかってて過大な速度がでてないですが、
内部のIK部分でもワーニングがでないようにしました

よろしくお願いいたします。
