### PR TITLE
fix for old OpenHRP3 that uses OpenHRP3 as python module name

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -4,7 +4,12 @@ import os
 import rtm
 
 from rtm import *
-from OpenHRP import *
+import imp
+try:
+    imp.load_module('OpenHRP')
+    from OpenHRP import *
+except:
+    from OpenHRP3 import * # for old OpenHRP3 (3.1.7)
 from hrpsys import *  # load ModelLoader
 
 import socket


### PR DESCRIPTION
https://github.com/fkanehiro/openhrp3/issues/36 以前のプログラムで動くようにするために
この変更が必要な気がします．

％　そもそもなんで，今まで動いていたかよくわからなくなっちゃていますが．．．．