### PR TITLE
add nozawa's patches

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -127,6 +127,11 @@ module OpenHRP
       sequence<DblSequence3, 2> default_zmp_offsets;
       double move_base_gain;
       ControllerMode controller_mode;
+      boolean graspless_manip_mode;
+      string graspless_manip_arm;
+      DblArray3 graspless_manip_p_gain;
+      DblArray3 graspless_manip_reference_trans_pos;
+      DblArray4 graspless_manip_reference_trans_rot;
     };
 
     /**

--- a/lib/util/Hrpsys.h
+++ b/lib/util/Hrpsys.h
@@ -27,4 +27,7 @@ using std::fclose;
 using std::fflush;
 using std::toupper;
 using std::copysign;
+using std::atof;
+using std::atan2;
+using std::sqrt;
 #endif

--- a/lib/util/Hrpsys.h
+++ b/lib/util/Hrpsys.h
@@ -28,6 +28,8 @@ using std::fflush;
 using std::toupper;
 using std::copysign;
 using std::atof;
+using std::sin;
+using std::cos;
 using std::atan2;
 using std::sqrt;
 #endif

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -1460,6 +1460,8 @@ tds.data[4:7], tds.data[8:11]], 'sxyz'))
         Check whether servo control has been turned on.
         @param jname str: Name of a link (that can be obtained by "hiro.Groups"
                       as lists of groups).
+                      When jname = 'all' or 'any' => If all joints are servoOn, return True, otherwise, return False.
+                      When jname = 'some' => If some joint is servoOn, return True, otherwise return False.
         @return bool: True if servo is on
         '''
         if self.simulation_mode:
@@ -1471,13 +1473,20 @@ tds.data[4:7], tds.data[8:11]], 'sxyz'))
                     # print self.configurator_name, 's = ', s
                     if (s[0] & 2) == 0:
                         return False
+                return True
+            elif jname.lower() == 'some':
+                for s in s_s:
+                    # print self.configurator_name, 's = ', s
+                    if (s[0] & 2) != 0:
+                        return True
+                return False
             else:
                 jid = eval('self.' + jname)
                 print self.configurator_name, s_s[jid]
                 if s_s[jid][0] & 1 == 0:
                     return False
-            return True
-        return False
+                else:
+                    return True
 
     def flat2Groups(self, flatList):
         '''!@brief

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -254,6 +254,10 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     leg_names.push_back("rleg");
     leg_names.push_back("lleg");
 
+    graspless_manip_mode = false;
+    graspless_manip_arm = "arms";
+    graspless_manip_p_gain = hrp::Vector3::Zero();
+
     return RTC::RTC_OK;
 }
 
@@ -589,6 +593,20 @@ void AutoBalancer::getTargetParameters()
         tmp_foot_mid_pos += tmpikp.target_link->p + tmpikp.target_link->R * tmpikp.localPos + tmpikp.target_link->R * tmpikp.localR * default_zmp_offsets[i];
     }
     tmp_foot_mid_pos *= 0.5;
+
+    //
+    {
+        if ( gg_is_walking && gg->get_gp_count() == static_cast<size_t>(gg->get_default_step_time()/(2*m_dt))-1) {
+            hrp::Vector3 vel_htc(calc_vel_from_hand_error(tmp_fix_coords));
+            gg->set_offset_velocity_param(vel_htc(0), vel_htc(1) ,vel_htc(2));
+        }//  else {
+        //     if ( gg_is_walking && gg->get_gp_count() == static_cast<size_t>(gg->get_default_step_time()/(2*m_dt))-1) {
+        //         gg->set_offset_velocity_param(0,0,0);
+        //     }
+        // }
+    }
+
+    //
 
     hrp::Vector3 tmp_ref_cog(m_robot->calcCM());
     if (gg_is_walking) {
@@ -968,11 +986,26 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
     for (size_t j = 0; j < 3; j++)
       default_zmp_offsets_array[i*3+j] = i_param.default_zmp_offsets[i][j];
   zmp_interpolator->go(default_zmp_offsets_array, zmp_interpolate_time, true);
+  graspless_manip_mode = i_param.graspless_manip_mode;
+  graspless_manip_arm = std::string(i_param.graspless_manip_arm);
+  for (size_t j = 0; j < 3; j++)
+      graspless_manip_p_gain[j] = i_param.graspless_manip_p_gain[j];
+  for (size_t j = 0; j < 3; j++)
+      graspless_manip_reference_trans_coords.pos[j] = i_param.graspless_manip_reference_trans_pos[j];
+  graspless_manip_reference_trans_coords.rot = (Eigen::Quaternion<double>(i_param.graspless_manip_reference_trans_rot[0],
+                                                                          i_param.graspless_manip_reference_trans_rot[1],
+                                                                          i_param.graspless_manip_reference_trans_rot[2],
+                                                                          i_param.graspless_manip_reference_trans_rot[3]).normalized().toRotationMatrix()); // rtc: (x, y, z, w) but eigen: (w, x, y, z)
   std::cerr << "[" << m_profile.instance_name << "] setAutoBalancerParam" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   move_base_gain = " << move_base_gain << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   default_zmp_offsets = "
             << default_zmp_offsets_array[0] << " " << default_zmp_offsets_array[1] << " " << default_zmp_offsets_array[2] << " "
             << default_zmp_offsets_array[3] << " " << default_zmp_offsets_array[4] << " " << default_zmp_offsets_array[5] << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_mode = " << graspless_manip_mode << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_arm = " << graspless_manip_arm << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_p_gain = " << graspless_manip_p_gain.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_reference_trans_pos = " << graspless_manip_reference_trans_coords.pos.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_reference_trans_rot = " << graspless_manip_reference_trans_coords.rot.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
   return true;
 };
 
@@ -989,6 +1022,17 @@ bool AutoBalancer::getAutoBalancerParam(OpenHRP::AutoBalancerService::AutoBalanc
   case MODE_SYNC_TO_ABC: i_param.controller_mode = OpenHRP::AutoBalancerService::MODE_SYNC_TO_ABC; break;
   default: break;
   }
+  i_param.graspless_manip_mode = graspless_manip_mode;
+  i_param.graspless_manip_arm = graspless_manip_arm.c_str();
+  for (size_t j = 0; j < 3; j++)
+      i_param.graspless_manip_p_gain[j] = graspless_manip_p_gain[j];
+  for (size_t j = 0; j < 3; j++)
+      i_param.graspless_manip_reference_trans_pos[j] = graspless_manip_reference_trans_coords.pos[j];
+  Eigen::Quaternion<double> qt(graspless_manip_reference_trans_coords.rot);
+  i_param.graspless_manip_reference_trans_rot[0] = qt.w();
+  i_param.graspless_manip_reference_trans_rot[1] = qt.x();
+  i_param.graspless_manip_reference_trans_rot[2] = qt.y();
+  i_param.graspless_manip_reference_trans_rot[3] = qt.z();
   return true;
 };
 
@@ -1074,6 +1118,51 @@ void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point,
     sb_point(j) = nume(j) / denom(j);
   }
   sb_point(2) = ref_com_height;
+};
+
+#ifndef rad2deg
+#define rad2deg(rad) (rad * 180 / M_PI)
+#endif
+#ifndef deg2rad
+#define deg2rad(deg) (deg * M_PI / 180)
+#endif
+
+hrp::Vector3 AutoBalancer::calc_vel_from_hand_error (const coordinates& tmp_fix_coords)
+{
+  if (graspless_manip_mode) {
+    hrp::Vector3 dp,dr;
+    coordinates ref_hand_coords(gg->get_dst_foot_midcoords()), act_hand_coords;
+    ref_hand_coords.transform(graspless_manip_reference_trans_coords); // desired arm coords
+    hrp::Vector3 foot_pos(gg->get_dst_foot_midcoords().pos);
+    if ( graspless_manip_arm == "arms" ) {
+      // act_hand_coords.pos = (target_coords["rarm"].pos + target_coords["larm"].pos) / 2.0;
+      // vector3 cur_y(target_coords["larm"].pos - target_coords["rarm"].pos);
+      // cur_y(2) = 0;
+      // alias(cur_y) = normalize(cur_y);
+      // vector3 ref_y(ref_hand_coords.axis(AXIS_Y));
+      // ref_y(2) = 0;
+      // alias(ref_y) = normalize(ref_y);
+      // dr = 0,0,((vector3(cross(ref_y, cur_y))(2) > 0 ? 1.0 : -1.0) * std::acos(dot(ref_y, cur_y))); // fix for rotation
+    } else {
+      ABCIKparam& tmpikp = ikp[graspless_manip_arm];
+      act_hand_coords = rats::coordinates(tmpikp.target_p0 + tmpikp.target_r0 * tmpikp.localPos,
+                                          tmpikp.target_r0 * tmpikp.localR);
+      rats::difference_rotation(dr, ref_hand_coords.rot, act_hand_coords.rot);
+      dr(0) = 0; dr(1) = 0;
+    }
+    dp = act_hand_coords.pos - ref_hand_coords.pos
+        + dr.cross(hrp::Vector3(foot_pos - act_hand_coords.pos));
+    dp(2) = 0;
+    hrp::Matrix33 foot_mt(gg->get_dst_foot_midcoords().rot.transpose());
+    //alias(dp) = foot_mt * dp;
+    hrp::Vector3 dp2 = foot_mt * dp;
+    //alias(dr) = foot_mt * dr;
+    return hrp::Vector3(graspless_manip_p_gain[0] * dp2(0)/gg->get_default_step_time(),
+                        graspless_manip_p_gain[1] * dp2(1)/gg->get_default_step_time(),
+                        graspless_manip_p_gain[2] * rad2deg(dr(2))/gg->get_default_step_time());
+  } else {
+    return hrp::Vector3::Zero();
+  }
 };
 
 //

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -187,6 +187,7 @@ class AutoBalancer
   // static balance point offsetting
   void static_balance_point_proc_one(hrp::Vector3& tmp_input_sbp, const double ref_com_height);
   void calc_static_balance_point_from_forces(hrp::Vector3& sb_point, const hrp::Vector3& tmpcog, const double ref_com_height, std::vector<hrp::Vector3>& tmp_forces);
+  hrp::Vector3 calc_vel_from_hand_error (const rats::coordinates& tmp_fix_coords);
 
   // for gg
   typedef boost::shared_ptr<rats::gait_generator> ggPtr;
@@ -222,6 +223,10 @@ class AutoBalancer
   unsigned int m_debugLevel;
   bool is_legged_robot;
   int loop;
+  bool graspless_manip_mode;
+  std::string graspless_manip_arm;
+  hrp::Vector3 graspless_manip_p_gain;
+  rats::coordinates graspless_manip_reference_trans_coords;
 };
 
 

--- a/rtc/CollisionDetector/CMakeLists.txt
+++ b/rtc/CollisionDetector/CMakeLists.txt
@@ -1,10 +1,10 @@
 set(seq_dir ${PROJECT_SOURCE_DIR}/rtc/SequencePlayer)
 if (USE_HRPSYSUTIL)
-  set(comp_sources ${seq_dir}/interpolator.cpp CollisionDetector.cpp CollisionDetectorService_impl.cpp GLscene.cpp VclipLinkPair.cpp)
+  set(comp_sources ${seq_dir}/interpolator.cpp CollisionDetector.cpp CollisionDetectorService_impl.cpp GLscene.cpp VclipLinkPair.cpp ../SoftErrorLimiter/beep.cpp)
   add_definitions(-DUSE_HRPSYSUTIL)
 else()
   # BVutil.cpp can be used without hrpsysUtil dependencies
-  set(comp_sources ${seq_dir}/interpolator.cpp CollisionDetector.cpp CollisionDetectorService_impl.cpp VclipLinkPair.cpp ../../lib/util/BVutil.cpp)
+  set(comp_sources ${seq_dir}/interpolator.cpp CollisionDetector.cpp CollisionDetectorService_impl.cpp VclipLinkPair.cpp ../../lib/util/BVutil.cpp ../SoftErrorLimiter/beep.cpp)
   set(libs hrpModel-3.1 hrpCollision-3.1 hrpsysBaseStub)
 endif()
 set(vclip_dir vclip_1.0/)

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -192,6 +192,7 @@ class CollisionDetector
   int default_recover_time;
   unsigned int m_debugLevel;
   bool m_enable;
+  int collision_beep_freq, collision_beep_count;
   OpenHRP::CollisionDetectorService::CollisionState m_state;
 };
 

--- a/rtc/KalmanFilter/RPYKalmanFilter.h
+++ b/rtc/KalmanFilter/RPYKalmanFilter.h
@@ -97,7 +97,7 @@ public:
       // x[1] = m_rate.data.avx; // rate ( rad/sec, AngularVelocity, gyro, stable/drift )
       // use kalman filter with imaginary data
       hrp::Vector3 gyro2 = gyro;
-#if 0
+#if 1
       double roll = r_filter.getx()[0];
       double pitch = p_filter.getx()[0];
       double yaw = y_filter.getx()[0];

--- a/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
+++ b/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
@@ -8,6 +8,7 @@
  */
 
 
+#include <stdio.h>
 #include <fstream>
 #include "RPYKalmanFilter.h"
 #include "EKFilter.h"

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.h
@@ -144,7 +144,7 @@ class SoftErrorLimiter
   boost::shared_ptr<robot> m_robot;
   std::map<std::string, hrp::JointLimitTable> joint_limit_tables;
   unsigned int m_debugLevel;
-  int dummy, position_limit_error_beep_freq, soft_limit_error_beep_freq;
+  int dummy, position_limit_error_beep_freq, soft_limit_error_beep_freq, debug_print_freq;
   double dt;
 };
 

--- a/rtc/ThermoLimiter/ThermoLimiter.cpp
+++ b/rtc/ThermoLimiter/ThermoLimiter.cpp
@@ -163,6 +163,7 @@ RTC::ReturnCode_t ThermoLimiter::onInitialize()
 
   // allocate memory for outPorts
   m_tauMaxOut.data.length(m_robot->numJoints());
+  m_debug_print_freq = static_cast<int>(0.1/m_dt); // once per 0.1 [s]
   
   return RTC::RTC_OK;
 }
@@ -335,7 +336,7 @@ double ThermoLimiter::calcEmergencyRatio(RTC::TimedDoubleSeq &current, hrp::dvec
   if (current.data.length() == max.size()) { // estimate same dimension
     for (int i = 0; i < current.data.length(); i++) {
       double tmpEmergencyRatio = std::abs(current.data[i] / max[i]);
-      if (tmpEmergencyRatio > alarmRatio) {
+      if (tmpEmergencyRatio > alarmRatio && m_loop % m_debug_print_freq == 0) {
           std::cerr << prefix << "[" << m_robot->joint(i)->name << "]" << " is over " << alarmRatio << " of the limit (" << current.data[i] << "/" << max[i] << ")" << std::endl;
       }
       if (maxEmergencyRatio < tmpEmergencyRatio) {

--- a/rtc/ThermoLimiter/ThermoLimiter.h
+++ b/rtc/ThermoLimiter/ThermoLimiter.h
@@ -142,7 +142,7 @@ class ThermoLimiter
  private:
   double m_dt;
   long long m_loop;
-  unsigned int m_debugLevel;
+  unsigned int m_debugLevel, m_debug_print_freq;
   double m_alarmRatio;
   hrp::dvector m_motorTemperatureLimit;
   hrp::BodyPtr m_robot;


### PR DESCRIPTION
including #496, #492, #491, #489, #487, #484, #476, ~~#458~~
-  Check leg name alternation
- Add graspless manip mode, in which foot steps are modified based on hand modification
- Reduce debug print message from SoftErrorLimiter (once per 0.02[s])
- Reduce ThermoLimiter debug print (once per 0.1[s])
- Use RPY-fixed linear KF by default
- Add graspless manip mode, in which foot steps are modified based on hand  modification
- Add 'some' argument for isServoOn and update documentation
- Add beep sound for CollisionDetector
-  Remove force_offset and moment_offset in RMFO because these are replaced by removeforcesensoroffsetwithmassoffset in RobotHardware
- Add removeForceSensorOffsetWithMassOffset for zero-setting by adding offsets from mass properties influence