### PR TITLE
use rtc.ref.exit()

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -213,7 +213,8 @@ class RTCmanager:
     # \param self this object
     # \param name name of RT component instance
     def delete(self, name):
-        ref = self.ref.delete_component(name)
+        # ref = self.ref.delete_component(name)
+        ref = findRTC(name).ref.exit() # delte_component did not actually kill component, so use rtc.exit https://github.com/fkanehiro/hrpsys-base/pull/512#issuecomment-80430387
         if ref == RTC_OK:
             return True
         else:


### PR DESCRIPTION
delete_component() is not enough, use rtc.ref.exit()
see https://github.com/fkanehiro/hrpsys-base/pull/512#issuecomment-80430387

- [rtm.py] use rtc.ref.exit after delete_components  https://github.com/fkanehiro/hrpsys-base/pull/512#issuecomment-80430387