### PR TITLE
Use basePose in kinemtics only simulation

### DIFF
--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -150,6 +150,15 @@ void BodyRTC::createInPort(const std::string &config)
         if (getJointList(this, elements, joints) && joints.size() == 1){
             m_inports.push_back(
                 new AbsTransformInPortHandler(this, name.c_str(), joints[0]));
+        } else if (elements.size() == 1) {
+            hrp::Link *l=this->link(elements[0]);
+            if (l){
+                m_inports.push_back(
+                                     new AbsTransformInPortHandler(this, name.c_str(), l));
+                return;
+            }
+            std::cerr << "can't find a link(or a sensor)(" << elements[0] << ")" 
+                      << std::endl;
         }
     }else if(type == "ABS_VELOCITY"){
         std::vector<hrp::Link *> joints;

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -267,6 +267,11 @@ class HrpsysConfigurator:
                 else:
                     connectPorts(tmp_contollers[-1].port("q"), self.hgc.port("qIn"))
                     connectPorts(self.hgc.port("qOut"), self.rh.port("qRef"))
+                    if rtm.findPort(self.rh.ref, "basePoseRef"):
+                        if self.abc:
+                            connectPorts(self.abc.port("basePoseOut"), self.rh.port("basePoseRef"))
+                        else:
+                            connectPorts(self.sh.port("basePoseOut"), self.rh.port("basePoseRef"))
             else:
                 connectPorts(tmp_contollers[-1].port("q"), self.rh.port("qRef"))
         else:
@@ -276,6 +281,11 @@ class HrpsysConfigurator:
                 else:
                     connectPorts(self.sh.port("qOut"), self.hgc.port("qIn"))
                     connectPorts(self.hgc.port("qOut"), self.rh.port("qRef"))
+                    if rtm.findPort(self.rh.ref, "basePoseRef"):
+                        if self.abc:
+                            connectPorts(self.abc.port("basePoseOut"), self.rh.port("basePoseRef"))
+                        else:
+                            connectPorts(self.sh.port("basePoseOut"), self.rh.port("basePoseRef"))
             else:
                 connectPorts(self.sh.port("qOut"), self.rh.port("qRef"))
 

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -53,6 +53,7 @@ AutoBalancer::AutoBalancer(RTC::Manager* manager)
       m_basePosOut("basePosOut", m_basePos),
       m_baseRpyOut("baseRpyOut", m_baseRpy),
       m_baseTformOut("baseTformOut", m_baseTform),
+      m_basePoseOut("basePoseOut", m_basePose),
       m_accRefOut("accRef", m_accRef),
       m_contactStatesOut("contactStates", m_contactStates),
       m_controlSwingSupportTimeOut("controlSwingSupportTime", m_controlSwingSupportTime),
@@ -91,6 +92,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     addOutPort("basePosOut", m_basePosOut);
     addOutPort("baseRpyOut", m_baseRpyOut);
     addOutPort("baseTformOut", m_baseTformOut);
+    addOutPort("basePoseOut", m_basePoseOut);
     addOutPort("accRef", m_accRefOut);
     addOutPort("contactStates", m_contactStatesOut);
     addOutPort("controlSwingSupportTime", m_controlSwingSupportTimeOut);
@@ -434,6 +436,14 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
       tform_arr[2] = m_basePos.data.z;
       hrp::setMatrix33ToRowMajorArray(ref_baseRot, tform_arr, 3);
       m_baseTform.tm = m_qRef.tm;
+      // basePose
+      m_basePose.data.position.x = m_basePos.data.x;
+      m_basePose.data.position.y = m_basePos.data.y;
+      m_basePose.data.position.z = m_basePos.data.z;
+      m_basePose.data.orientation.r = m_baseRpy.data.r;
+      m_basePose.data.orientation.p = m_baseRpy.data.p;
+      m_basePose.data.orientation.y = m_baseRpy.data.y;
+      m_basePose.tm = m_qRef.tm;
       // zmp
       m_zmp.data.x = rel_ref_zmp(0);
       m_zmp.data.y = rel_ref_zmp(1);
@@ -448,6 +458,7 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
     m_basePosOut.write();
     m_baseRpyOut.write();
     m_baseTformOut.write();
+    m_basePoseOut.write();
     m_zmpOut.write();
     m_cogOut.write();
 

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -135,6 +135,8 @@ class AutoBalancer
   OutPort<TimedOrientation3D> m_baseRpyOut;
   TimedDoubleSeq m_baseTform;
   OutPort<TimedDoubleSeq> m_baseTformOut;
+  TimedPose3D m_basePose;
+  OutPort<TimedPose3D> m_basePoseOut;
   TimedAcceleration3D m_accRef;
   OutPort<TimedAcceleration3D> m_accRefOut;
   TimedBooleanSeq m_contactStates;

--- a/util/ProjectGenerator/ProjectGenerator.cpp
+++ b/util/ProjectGenerator/ProjectGenerator.cpp
@@ -167,6 +167,9 @@ int main (int argc, char** argv)
           xmlTextWriterWriteProperty(writer, "inport", "qRef:JOINT_VALUE");
           xmlTextWriterWriteProperty(writer, "inport", "dqRef:JOINT_VELOCITY");
           xmlTextWriterWriteProperty(writer, "inport", "ddqRef:JOINT_ACCELERATION");
+          if (integrate == "false") { // For kinematics only simultion
+              xmlTextWriterWriteProperty(writer, "inport", "basePoseRef:"+body->rootLink()->name+":ABS_TRANSFORM");
+          }
         } else {
           xmlTextWriterWriteProperty(writer, "inport", "tauRef:JOINT_TORQUE");
         }


### PR DESCRIPTION
kinematics onlyモードのシミュレーション時(integrateがfalseの時)に、関節角度指令値だけでなく
ルートリンク位置姿勢指令値も反映させるようにしました。

よろしくお願いいたします。