### PR TITLE
Add DRC testbed terrain VRMLs (JP block version and US block version)

### DIFF
--- a/sample/environments/CMakeLists.txt
+++ b/sample/environments/CMakeLists.txt
@@ -1,4 +1,6 @@
 install(FILES 
   TerrainFloor.wrl
+  DRCTestbedTerrainUSBlock.wrl
+  DRCTestbedTerrainJPBlock.wrl
   DESTINATION share/hrpsys/samples/environments)
 

--- a/sample/environments/DRCTestbedTerrainJPBlock.wrl
+++ b/sample/environments/DRCTestbedTerrainJPBlock.wrl
@@ -1,0 +1,8694 @@
+#VRML V2.0 utf8
+
+# Produced by EusLisp 9.11(f542489 1.0.3 66193) for Linux64 created on W540-nozawa(Thu Mar 19 17:30:45 JST 2015)
+# Date: Thu Mar 19 18:34:15 2015
+
+
+PROTO Joint [
+ exposedField     SFVec3f      center              0 0 0
+ exposedField     MFNode       children            []
+ exposedField     MFFloat      llimit              []
+ exposedField     SFRotation   limitOrientation    0 0 1 0
+ exposedField     SFString     name                ""
+ exposedField     SFRotation   rotation            0 0 1 0
+ exposedField     SFVec3f      scale               1 1 1
+ exposedField     SFRotation   scaleOrientation    0 0 1 0
+ exposedField     MFFloat      stiffness           [ 0 0 0 ]
+ exposedField     SFVec3f      translation         0 0 0
+ exposedField     MFFloat      ulimit              []
+ exposedField     MFFloat      dh                  [0 0 0 0]
+ exposedField     SFString     jointType           ""
+ exposedField     SFInt32      jointId             -1
+ exposedField     SFVec3f     jointAxis           0 0 1
+]
+{
+   Transform {
+      center           IS center
+      children         IS children
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+   }
+}
+
+PROTO Segment [
+ field           SFVec3f     bboxCenter        0 0 0
+ field           SFVec3f     bboxSize          -1 -1 -1
+ exposedField    SFVec3f     centerOfMass      0 0 0
+ exposedField    MFNode      children          [ ]
+ exposedField    SFNode      coord             NULL
+ exposedField    MFNode      displacers        [ ]
+ exposedField    SFFloat     mass              0
+ exposedField    MFFloat     momentsOfInertia  [ 0 0 0 0 0 0 0 0 0 ]
+ exposedField    SFString    name              ""
+ eventIn         MFNode      addChildren
+ eventIn         MFNode      removeChildren
+]
+{
+   Group {
+      addChildren    IS addChildren
+      bboxCenter     IS bboxCenter
+      bboxSize       IS bboxSize
+      children       IS children
+      removeChildren IS removeChildren
+   }
+}
+
+
+PROTO Humanoid [
+ field           SFVec3f    bboxCenter            0 0 0
+ field           SFVec3f    bboxSize              -1 -1 -1
+ exposedField    SFVec3f    center                0 0 0
+ exposedField    MFNode     humanoidBody          [ ]
+ exposedField    MFString   info                  [ ]
+ exposedField    MFNode     joints                [ ]
+ exposedField    SFString   name                  ""
+ exposedField    SFRotation rotation              0 0 1 0
+ exposedField    SFVec3f    scale                 1 1 1
+ exposedField    SFRotation scaleOrientation      0 0 1 0
+ exposedField    MFNode     segments              [ ]
+ exposedField    MFNode     sites                 [ ]
+ exposedField    SFVec3f    translation           0 0 0
+ exposedField    SFString   version               "1.1"
+ exposedField    MFNode     viewpoints            [ ]
+]
+{
+   Transform {
+      bboxCenter       IS bboxCenter
+      bboxSize         IS bboxSize
+      center           IS center
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+      children [
+         Group {
+            children IS viewpoints
+         }
+         Group {
+            children IS humanoidBody
+         }
+      ]
+   }
+}
+
+
+PROTO VisionSensor [
+  exposedField SFVec3f    translation       0 0 0
+  exposedField SFRotation rotation              0 0 1 0
+  #exposedField SFRotation orientation       0 0 1 0
+  exposedField SFFloat    fieldOfView       0.785398
+  exposedField SFString   name              ""
+  exposedField SFFloat    frontClipDistance 0.01
+  exposedField SFFloat    backClipDistance  10.0
+  exposedField SFString   type              "NONE"
+  exposedField SFInt32    sensorId          -1
+  exposedField SFInt32    width             320  # 
+  exposedField SFInt32    height            240  # 
+  #exposedField MFNode       children            [] # for me
+]
+{
+  Transform {
+    rotation         IS rotation
+    translation      IS translation
+    #children IS children # for me
+  }
+}
+
+
+PROTO ForceSensor [
+  exposedField SFVec3f maxForce -1 -1 -1
+  exposedField SFVec3f maxTorque -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO Gyro [
+  exposedField SFVec3f maxAngularVelocity -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO AccelerationSensor [
+  exposedField SFVec3f maxAcceleration -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO PressureSensor [
+  exposedField SFFloat maxPressure -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+
+NavigationInfo {
+   avatarSize    0.5
+   headlight     TRUE
+   type  ["EXAMINE", "ANY"]
+}
+Viewpoint {
+   position    3 0 0.835
+   orientation 0.5770 0.5775 0.5775 2.0935
+}
+DEF DRCTestbedTerrainJPBlock Humanoid {
+   humanoidBody [
+    DEF WAIST Joint {
+       jointType "fixed"
+       dh [0 0 0 0]
+       translation 0.000000 0.000000 0.000000
+       rotation 0.0 0.0 1.0 0
+       children [
+          DEF ROOT-LINK_S Segment {
+             centerOfMass 0.0 0.0 0.0
+             mass 0.001
+             momentsOfInertia [ 1.000000e-09 0.0 0.0 0.0 1.000000e-09 0.0 0.0 0.0 1.000000e-09 ]
+             children [
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 2.190000 0.164365,
+                          2.583257 2.190000 0.120365,
+                          2.561257 2.190000 0.038262,
+                          2.397050 2.190000 0.082261,
+                          2.607767 2.190000 0.147444,
+                          2.568944 2.190000 0.002556,
+                          2.192233 2.190000 0.103495,
+                          2.231056 2.190000 0.248384,
+                          2.231056 2.000000 0.248384,
+                          2.607767 2.000000 0.147444,
+                          2.568944 2.000000 0.002556,
+                          2.192233 2.000000 0.103495,
+                          2.397050 2.000000 0.082261,
+                          2.561257 2.000000 0.038262,
+                          2.583257 2.000000 0.120365,
+                          2.419049 2.000000 0.164365,
+                          2.238743 2.190000 0.212678,
+                          2.238743 2.000000 0.212678,
+                          2.402950 2.190000 0.168678,
+                          2.402950 2.000000 0.168678,
+                          2.380951 2.000000 0.086575,
+                          2.216743 2.000000 0.130574,
+                          2.216743 2.190000 0.130574,
+                          2.380951 2.190000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 2.000000 0.164365,
+                          2.583257 2.000000 0.120365,
+                          2.561257 2.000000 0.038262,
+                          2.397050 2.000000 0.082261,
+                          2.607767 2.000000 0.147444,
+                          2.568944 2.000000 0.002556,
+                          2.192233 2.000000 0.103495,
+                          2.231056 2.000000 0.248384,
+                          2.231056 1.810000 0.248384,
+                          2.607767 1.810000 0.147444,
+                          2.568944 1.810000 0.002556,
+                          2.192233 1.810000 0.103495,
+                          2.397050 1.810000 0.082261,
+                          2.561257 1.810000 0.038262,
+                          2.583257 1.810000 0.120365,
+                          2.419049 1.810000 0.164365,
+                          2.238743 2.000000 0.212678,
+                          2.238743 1.810000 0.212678,
+                          2.402950 2.000000 0.168678,
+                          2.402950 1.810000 0.168678,
+                          2.380951 1.810000 0.086575,
+                          2.216743 1.810000 0.130574,
+                          2.216743 2.000000 0.130574,
+                          2.380951 2.000000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.295000 2.195000 0.000000,
+                          2.295000 2.195000 0.090000,
+                          2.295000 1.805000 0.000000,
+                          2.295000 1.805000 0.090000,
+                          2.205000 2.195000 0.000000,
+                          2.205000 1.805000 0.000000,
+                          2.205000 1.805000 0.090000,
+                          2.205000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.590000 1.580951 0.164365,
+                          2.590000 1.416743 0.120365,
+                          2.590000 1.438743 0.038262,
+                          2.590000 1.602950 0.082261,
+                          2.590000 1.392233 0.147444,
+                          2.590000 1.431056 0.002556,
+                          2.590000 1.807767 0.103495,
+                          2.590000 1.768944 0.248384,
+                          2.400000 1.768944 0.248384,
+                          2.400000 1.392233 0.147444,
+                          2.400000 1.431056 0.002556,
+                          2.400000 1.807767 0.103495,
+                          2.400000 1.602950 0.082261,
+                          2.400000 1.438743 0.038262,
+                          2.400000 1.416743 0.120365,
+                          2.400000 1.580951 0.164365,
+                          2.590000 1.761257 0.212678,
+                          2.400000 1.761257 0.212678,
+                          2.590000 1.597050 0.168678,
+                          2.400000 1.597050 0.168678,
+                          2.400000 1.619049 0.086575,
+                          2.400000 1.783257 0.130574,
+                          2.590000 1.783257 0.130574,
+                          2.590000 1.619049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 1.580951 0.164365,
+                          2.400000 1.416743 0.120365,
+                          2.400000 1.438743 0.038262,
+                          2.400000 1.602950 0.082261,
+                          2.400000 1.392233 0.147444,
+                          2.400000 1.431056 0.002556,
+                          2.400000 1.807767 0.103495,
+                          2.400000 1.768944 0.248384,
+                          2.210000 1.768944 0.248384,
+                          2.210000 1.392233 0.147444,
+                          2.210000 1.431056 0.002556,
+                          2.210000 1.807767 0.103495,
+                          2.210000 1.602950 0.082261,
+                          2.210000 1.438743 0.038262,
+                          2.210000 1.416743 0.120365,
+                          2.210000 1.580951 0.164365,
+                          2.400000 1.761257 0.212678,
+                          2.210000 1.761257 0.212678,
+                          2.400000 1.597050 0.168678,
+                          2.210000 1.597050 0.168678,
+                          2.210000 1.619049 0.086575,
+                          2.210000 1.783257 0.130574,
+                          2.400000 1.783257 0.130574,
+                          2.400000 1.619049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 1.705000 -0.000000,
+                          2.595000 1.705000 0.090000,
+                          2.205000 1.705000 -0.000000,
+                          2.205000 1.705000 0.090000,
+                          2.595000 1.795000 -0.000000,
+                          2.205000 1.795000 -0.000000,
+                          2.205000 1.795000 0.090000,
+                          2.595000 1.795000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.380951 1.010000 0.164365,
+                          2.216743 1.010000 0.120365,
+                          2.238743 1.010000 0.038262,
+                          2.402950 1.010000 0.082261,
+                          2.192233 1.010000 0.147444,
+                          2.231056 1.010000 0.002556,
+                          2.607767 1.010000 0.103495,
+                          2.568944 1.010000 0.248384,
+                          2.568944 1.200000 0.248384,
+                          2.192233 1.200000 0.147444,
+                          2.231056 1.200000 0.002556,
+                          2.607767 1.200000 0.103495,
+                          2.402950 1.200000 0.082261,
+                          2.238743 1.200000 0.038262,
+                          2.216743 1.200000 0.120365,
+                          2.380951 1.200000 0.164365,
+                          2.561257 1.010000 0.212678,
+                          2.561257 1.200000 0.212678,
+                          2.397050 1.010000 0.168678,
+                          2.397050 1.200000 0.168678,
+                          2.419049 1.200000 0.086575,
+                          2.583257 1.200000 0.130574,
+                          2.583257 1.010000 0.130574,
+                          2.419049 1.010000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.380951 1.200000 0.164365,
+                          2.216743 1.200000 0.120365,
+                          2.238743 1.200000 0.038262,
+                          2.402950 1.200000 0.082261,
+                          2.192233 1.200000 0.147444,
+                          2.231056 1.200000 0.002556,
+                          2.607767 1.200000 0.103495,
+                          2.568944 1.200000 0.248384,
+                          2.568944 1.390000 0.248384,
+                          2.192233 1.390000 0.147444,
+                          2.231056 1.390000 0.002556,
+                          2.607767 1.390000 0.103495,
+                          2.402950 1.390000 0.082261,
+                          2.238743 1.390000 0.038262,
+                          2.216743 1.390000 0.120365,
+                          2.380951 1.390000 0.164365,
+                          2.561257 1.200000 0.212678,
+                          2.561257 1.390000 0.212678,
+                          2.397050 1.200000 0.168678,
+                          2.397050 1.390000 0.168678,
+                          2.419049 1.390000 0.086575,
+                          2.583257 1.390000 0.130574,
+                          2.583257 1.200000 0.130574,
+                          2.419049 1.200000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.505000 1.005000 0.000000,
+                          2.505000 1.005000 0.090000,
+                          2.505000 1.395000 0.000000,
+                          2.505000 1.395000 0.090000,
+                          2.595000 1.005000 0.000000,
+                          2.595000 1.395000 0.000000,
+                          2.595000 1.395000 0.090000,
+                          2.595000 1.005000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.210000 0.819049 0.164365,
+                          2.210000 0.983257 0.120365,
+                          2.210000 0.961257 0.038262,
+                          2.210000 0.797050 0.082261,
+                          2.210000 1.007767 0.147444,
+                          2.210000 0.968944 0.002556,
+                          2.210000 0.592233 0.103495,
+                          2.210000 0.631056 0.248384,
+                          2.400000 0.631056 0.248384,
+                          2.400000 1.007767 0.147444,
+                          2.400000 0.968944 0.002556,
+                          2.400000 0.592233 0.103495,
+                          2.400000 0.797050 0.082261,
+                          2.400000 0.961257 0.038262,
+                          2.400000 0.983257 0.120365,
+                          2.400000 0.819049 0.164365,
+                          2.210000 0.638743 0.212678,
+                          2.400000 0.638743 0.212678,
+                          2.210000 0.802950 0.168678,
+                          2.400000 0.802950 0.168678,
+                          2.400000 0.780951 0.086575,
+                          2.400000 0.616743 0.130574,
+                          2.210000 0.616743 0.130574,
+                          2.210000 0.780951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 0.819049 0.164365,
+                          2.400000 0.983257 0.120365,
+                          2.400000 0.961257 0.038262,
+                          2.400000 0.797050 0.082261,
+                          2.400000 1.007767 0.147444,
+                          2.400000 0.968944 0.002556,
+                          2.400000 0.592233 0.103495,
+                          2.400000 0.631056 0.248384,
+                          2.590000 0.631056 0.248384,
+                          2.590000 1.007767 0.147444,
+                          2.590000 0.968944 0.002556,
+                          2.590000 0.592233 0.103495,
+                          2.590000 0.797050 0.082261,
+                          2.590000 0.961257 0.038262,
+                          2.590000 0.983257 0.120365,
+                          2.590000 0.819049 0.164365,
+                          2.400000 0.638743 0.212678,
+                          2.590000 0.638743 0.212678,
+                          2.400000 0.802950 0.168678,
+                          2.590000 0.802950 0.168678,
+                          2.590000 0.780951 0.086575,
+                          2.590000 0.616743 0.130574,
+                          2.400000 0.616743 0.130574,
+                          2.400000 0.780951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.205000 0.695000 0.000000,
+                          2.205000 0.695000 0.090000,
+                          2.595000 0.695000 0.000000,
+                          2.595000 0.695000 0.090000,
+                          2.205000 0.605000 0.000000,
+                          2.595000 0.605000 0.000000,
+                          2.595000 0.605000 0.090000,
+                          2.205000 0.605000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 0.590000 0.164365,
+                          2.583257 0.590000 0.120365,
+                          2.561257 0.590000 0.038262,
+                          2.397050 0.590000 0.082261,
+                          2.607767 0.590000 0.147444,
+                          2.568944 0.590000 0.002556,
+                          2.192233 0.590000 0.103495,
+                          2.231056 0.590000 0.248384,
+                          2.231056 0.400000 0.248384,
+                          2.607767 0.400000 0.147444,
+                          2.568944 0.400000 0.002556,
+                          2.192233 0.400000 0.103495,
+                          2.397050 0.400000 0.082261,
+                          2.561257 0.400000 0.038262,
+                          2.583257 0.400000 0.120365,
+                          2.419049 0.400000 0.164365,
+                          2.238743 0.590000 0.212678,
+                          2.238743 0.400000 0.212678,
+                          2.402950 0.590000 0.168678,
+                          2.402950 0.400000 0.168678,
+                          2.380951 0.400000 0.086575,
+                          2.216743 0.400000 0.130574,
+                          2.216743 0.590000 0.130574,
+                          2.380951 0.590000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 0.400000 0.164365,
+                          2.583257 0.400000 0.120365,
+                          2.561257 0.400000 0.038262,
+                          2.397050 0.400000 0.082261,
+                          2.607767 0.400000 0.147444,
+                          2.568944 0.400000 0.002556,
+                          2.192233 0.400000 0.103495,
+                          2.231056 0.400000 0.248384,
+                          2.231056 0.210000 0.248384,
+                          2.607767 0.210000 0.147444,
+                          2.568944 0.210000 0.002556,
+                          2.192233 0.210000 0.103495,
+                          2.397050 0.210000 0.082261,
+                          2.561257 0.210000 0.038262,
+                          2.583257 0.210000 0.120365,
+                          2.419049 0.210000 0.164365,
+                          2.238743 0.400000 0.212678,
+                          2.238743 0.210000 0.212678,
+                          2.402950 0.400000 0.168678,
+                          2.402950 0.210000 0.168678,
+                          2.380951 0.210000 0.086575,
+                          2.216743 0.210000 0.130574,
+                          2.216743 0.400000 0.130574,
+                          2.380951 0.400000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.295000 0.595000 0.000000,
+                          2.295000 0.595000 0.090000,
+                          2.295000 0.205000 0.000000,
+                          2.295000 0.205000 0.090000,
+                          2.205000 0.595000 0.000000,
+                          2.205000 0.205000 0.000000,
+                          2.205000 0.205000 0.090000,
+                          2.205000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.590000 -0.019049 0.164365,
+                          2.590000 -0.183257 0.120365,
+                          2.590000 -0.161257 0.038262,
+                          2.590000 0.002950 0.082261,
+                          2.590000 -0.207767 0.147444,
+                          2.590000 -0.168944 0.002556,
+                          2.590000 0.207767 0.103495,
+                          2.590000 0.168944 0.248384,
+                          2.400000 0.168944 0.248384,
+                          2.400000 -0.207767 0.147444,
+                          2.400000 -0.168944 0.002556,
+                          2.400000 0.207767 0.103495,
+                          2.400000 0.002950 0.082261,
+                          2.400000 -0.161257 0.038262,
+                          2.400000 -0.183257 0.120365,
+                          2.400000 -0.019049 0.164365,
+                          2.590000 0.161257 0.212678,
+                          2.400000 0.161257 0.212678,
+                          2.590000 -0.002950 0.168678,
+                          2.400000 -0.002950 0.168678,
+                          2.400000 0.019049 0.086575,
+                          2.400000 0.183257 0.130574,
+                          2.590000 0.183257 0.130574,
+                          2.590000 0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 -0.019049 0.164365,
+                          2.400000 -0.183257 0.120365,
+                          2.400000 -0.161257 0.038262,
+                          2.400000 0.002950 0.082261,
+                          2.400000 -0.207767 0.147444,
+                          2.400000 -0.168944 0.002556,
+                          2.400000 0.207767 0.103495,
+                          2.400000 0.168944 0.248384,
+                          2.210000 0.168944 0.248384,
+                          2.210000 -0.207767 0.147444,
+                          2.210000 -0.168944 0.002556,
+                          2.210000 0.207767 0.103495,
+                          2.210000 0.002950 0.082261,
+                          2.210000 -0.161257 0.038262,
+                          2.210000 -0.183257 0.120365,
+                          2.210000 -0.019049 0.164365,
+                          2.400000 0.161257 0.212678,
+                          2.210000 0.161257 0.212678,
+                          2.400000 -0.002950 0.168678,
+                          2.210000 -0.002950 0.168678,
+                          2.210000 0.019049 0.086575,
+                          2.210000 0.183257 0.130574,
+                          2.400000 0.183257 0.130574,
+                          2.400000 0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 0.105000 -0.000000,
+                          2.595000 0.105000 0.090000,
+                          2.205000 0.105000 -0.000000,
+                          2.205000 0.105000 0.090000,
+                          2.595000 0.195000 -0.000000,
+                          2.205000 0.195000 -0.000000,
+                          2.205000 0.195000 0.090000,
+                          2.595000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.190000 1.980951 0.314365,
+                          2.190000 1.816743 0.270365,
+                          2.190000 1.838743 0.188262,
+                          2.190000 2.002950 0.232261,
+                          2.190000 1.792233 0.297444,
+                          2.190000 1.831056 0.152556,
+                          2.190000 2.207767 0.253495,
+                          2.190000 2.168944 0.398384,
+                          2.000000 2.168944 0.398384,
+                          2.000000 1.792233 0.297444,
+                          2.000000 1.831056 0.152556,
+                          2.000000 2.207767 0.253495,
+                          2.000000 2.002950 0.232261,
+                          2.000000 1.838743 0.188262,
+                          2.000000 1.816743 0.270365,
+                          2.000000 1.980951 0.314365,
+                          2.190000 2.161257 0.362678,
+                          2.000000 2.161257 0.362678,
+                          2.190000 1.997050 0.318678,
+                          2.000000 1.997050 0.318678,
+                          2.000000 2.019049 0.236575,
+                          2.000000 2.183257 0.280574,
+                          2.190000 2.183257 0.280574,
+                          2.190000 2.019049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 1.980951 0.314365,
+                          2.000000 1.816743 0.270365,
+                          2.000000 1.838743 0.188262,
+                          2.000000 2.002950 0.232261,
+                          2.000000 1.792233 0.297444,
+                          2.000000 1.831056 0.152556,
+                          2.000000 2.207767 0.253495,
+                          2.000000 2.168944 0.398384,
+                          1.810000 2.168944 0.398384,
+                          1.810000 1.792233 0.297444,
+                          1.810000 1.831056 0.152556,
+                          1.810000 2.207767 0.253495,
+                          1.810000 2.002950 0.232261,
+                          1.810000 1.838743 0.188262,
+                          1.810000 1.816743 0.270365,
+                          1.810000 1.980951 0.314365,
+                          2.000000 2.161257 0.362678,
+                          1.810000 2.161257 0.362678,
+                          2.000000 1.997050 0.318678,
+                          1.810000 1.997050 0.318678,
+                          1.810000 2.019049 0.236575,
+                          1.810000 2.183257 0.280574,
+                          2.000000 2.183257 0.280574,
+                          2.000000 2.019049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 2.105000 0.150000,
+                          2.195000 2.105000 0.240000,
+                          1.805000 2.105000 0.150000,
+                          1.805000 2.105000 0.240000,
+                          2.195000 2.195000 0.150000,
+                          1.805000 2.195000 0.150000,
+                          1.805000 2.195000 0.240000,
+                          2.195000 2.195000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 1.410000 0.314365,
+                          1.816743 1.410000 0.270365,
+                          1.838743 1.410000 0.188262,
+                          2.002950 1.410000 0.232261,
+                          1.792233 1.410000 0.297444,
+                          1.831056 1.410000 0.152556,
+                          2.207767 1.410000 0.253495,
+                          2.168944 1.410000 0.398384,
+                          2.168944 1.600000 0.398384,
+                          1.792233 1.600000 0.297444,
+                          1.831056 1.600000 0.152556,
+                          2.207767 1.600000 0.253495,
+                          2.002950 1.600000 0.232261,
+                          1.838743 1.600000 0.188262,
+                          1.816743 1.600000 0.270365,
+                          1.980951 1.600000 0.314365,
+                          2.161257 1.410000 0.362678,
+                          2.161257 1.600000 0.362678,
+                          1.997050 1.410000 0.318678,
+                          1.997050 1.600000 0.318678,
+                          2.019049 1.600000 0.236575,
+                          2.183257 1.600000 0.280574,
+                          2.183257 1.410000 0.280574,
+                          2.019049 1.410000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 1.600000 0.314365,
+                          1.816743 1.600000 0.270365,
+                          1.838743 1.600000 0.188262,
+                          2.002950 1.600000 0.232261,
+                          1.792233 1.600000 0.297444,
+                          1.831056 1.600000 0.152556,
+                          2.207767 1.600000 0.253495,
+                          2.168944 1.600000 0.398384,
+                          2.168944 1.790000 0.398384,
+                          1.792233 1.790000 0.297444,
+                          1.831056 1.790000 0.152556,
+                          2.207767 1.790000 0.253495,
+                          2.002950 1.790000 0.232261,
+                          1.838743 1.790000 0.188262,
+                          1.816743 1.790000 0.270365,
+                          1.980951 1.790000 0.314365,
+                          2.161257 1.600000 0.362678,
+                          2.161257 1.790000 0.362678,
+                          1.997050 1.600000 0.318678,
+                          1.997050 1.790000 0.318678,
+                          2.019049 1.790000 0.236575,
+                          2.183257 1.790000 0.280574,
+                          2.183257 1.600000 0.280574,
+                          2.019049 1.600000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 1.405000 0.150000,
+                          2.105000 1.405000 0.240000,
+                          2.105000 1.795000 0.150000,
+                          2.105000 1.795000 0.240000,
+                          2.195000 1.405000 0.150000,
+                          2.195000 1.795000 0.150000,
+                          2.195000 1.795000 0.240000,
+                          2.195000 1.405000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.810000 1.219049 0.314365,
+                          1.810000 1.383257 0.270365,
+                          1.810000 1.361257 0.188262,
+                          1.810000 1.197050 0.232261,
+                          1.810000 1.407767 0.297444,
+                          1.810000 1.368944 0.152556,
+                          1.810000 0.992233 0.253495,
+                          1.810000 1.031056 0.398384,
+                          2.000000 1.031056 0.398384,
+                          2.000000 1.407767 0.297444,
+                          2.000000 1.368944 0.152556,
+                          2.000000 0.992233 0.253495,
+                          2.000000 1.197050 0.232261,
+                          2.000000 1.361257 0.188262,
+                          2.000000 1.383257 0.270365,
+                          2.000000 1.219049 0.314365,
+                          1.810000 1.038743 0.362678,
+                          2.000000 1.038743 0.362678,
+                          1.810000 1.202950 0.318678,
+                          2.000000 1.202950 0.318678,
+                          2.000000 1.180951 0.236575,
+                          2.000000 1.016743 0.280574,
+                          1.810000 1.016743 0.280574,
+                          1.810000 1.180951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 1.219049 0.314365,
+                          2.000000 1.383257 0.270365,
+                          2.000000 1.361257 0.188262,
+                          2.000000 1.197050 0.232261,
+                          2.000000 1.407767 0.297444,
+                          2.000000 1.368944 0.152556,
+                          2.000000 0.992233 0.253495,
+                          2.000000 1.031056 0.398384,
+                          2.190000 1.031056 0.398384,
+                          2.190000 1.407767 0.297444,
+                          2.190000 1.368944 0.152556,
+                          2.190000 0.992233 0.253495,
+                          2.190000 1.197050 0.232261,
+                          2.190000 1.361257 0.188262,
+                          2.190000 1.383257 0.270365,
+                          2.190000 1.219049 0.314365,
+                          2.000000 1.038743 0.362678,
+                          2.190000 1.038743 0.362678,
+                          2.000000 1.202950 0.318678,
+                          2.190000 1.202950 0.318678,
+                          2.190000 1.180951 0.236575,
+                          2.190000 1.016743 0.280574,
+                          2.000000 1.016743 0.280574,
+                          2.000000 1.180951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.805000 1.095000 0.150000,
+                          1.805000 1.095000 0.240000,
+                          2.195000 1.095000 0.150000,
+                          2.195000 1.095000 0.240000,
+                          1.805000 1.005000 0.150000,
+                          2.195000 1.005000 0.150000,
+                          2.195000 1.005000 0.240000,
+                          1.805000 1.005000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.019049 0.990000 0.314365,
+                          2.183257 0.990000 0.270365,
+                          2.161257 0.990000 0.188262,
+                          1.997050 0.990000 0.232261,
+                          2.207767 0.990000 0.297444,
+                          2.168944 0.990000 0.152556,
+                          1.792233 0.990000 0.253495,
+                          1.831056 0.990000 0.398384,
+                          1.831056 0.800000 0.398384,
+                          2.207767 0.800000 0.297444,
+                          2.168944 0.800000 0.152556,
+                          1.792233 0.800000 0.253495,
+                          1.997050 0.800000 0.232261,
+                          2.161257 0.800000 0.188262,
+                          2.183257 0.800000 0.270365,
+                          2.019049 0.800000 0.314365,
+                          1.838743 0.990000 0.362678,
+                          1.838743 0.800000 0.362678,
+                          2.002950 0.990000 0.318678,
+                          2.002950 0.800000 0.318678,
+                          1.980951 0.800000 0.236575,
+                          1.816743 0.800000 0.280574,
+                          1.816743 0.990000 0.280574,
+                          1.980951 0.990000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.019049 0.800000 0.314365,
+                          2.183257 0.800000 0.270365,
+                          2.161257 0.800000 0.188262,
+                          1.997050 0.800000 0.232261,
+                          2.207767 0.800000 0.297444,
+                          2.168944 0.800000 0.152556,
+                          1.792233 0.800000 0.253495,
+                          1.831056 0.800000 0.398384,
+                          1.831056 0.610000 0.398384,
+                          2.207767 0.610000 0.297444,
+                          2.168944 0.610000 0.152556,
+                          1.792233 0.610000 0.253495,
+                          1.997050 0.610000 0.232261,
+                          2.161257 0.610000 0.188262,
+                          2.183257 0.610000 0.270365,
+                          2.019049 0.610000 0.314365,
+                          1.838743 0.800000 0.362678,
+                          1.838743 0.610000 0.362678,
+                          2.002950 0.800000 0.318678,
+                          2.002950 0.610000 0.318678,
+                          1.980951 0.610000 0.236575,
+                          1.816743 0.610000 0.280574,
+                          1.816743 0.800000 0.280574,
+                          1.980951 0.800000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.895000 0.995000 0.150000,
+                          1.895000 0.995000 0.240000,
+                          1.895000 0.605000 0.150000,
+                          1.895000 0.605000 0.240000,
+                          1.805000 0.995000 0.150000,
+                          1.805000 0.605000 0.150000,
+                          1.805000 0.605000 0.240000,
+                          1.805000 0.995000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.190000 0.380951 0.314365,
+                          2.190000 0.216743 0.270365,
+                          2.190000 0.238743 0.188262,
+                          2.190000 0.402950 0.232261,
+                          2.190000 0.192233 0.297444,
+                          2.190000 0.231056 0.152556,
+                          2.190000 0.607767 0.253495,
+                          2.190000 0.568944 0.398384,
+                          2.000000 0.568944 0.398384,
+                          2.000000 0.192233 0.297444,
+                          2.000000 0.231056 0.152556,
+                          2.000000 0.607767 0.253495,
+                          2.000000 0.402950 0.232261,
+                          2.000000 0.238743 0.188262,
+                          2.000000 0.216743 0.270365,
+                          2.000000 0.380951 0.314365,
+                          2.190000 0.561257 0.362678,
+                          2.000000 0.561257 0.362678,
+                          2.190000 0.397050 0.318678,
+                          2.000000 0.397050 0.318678,
+                          2.000000 0.419049 0.236575,
+                          2.000000 0.583257 0.280574,
+                          2.190000 0.583257 0.280574,
+                          2.190000 0.419049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 0.380951 0.314365,
+                          2.000000 0.216743 0.270365,
+                          2.000000 0.238743 0.188262,
+                          2.000000 0.402950 0.232261,
+                          2.000000 0.192233 0.297444,
+                          2.000000 0.231056 0.152556,
+                          2.000000 0.607767 0.253495,
+                          2.000000 0.568944 0.398384,
+                          1.810000 0.568944 0.398384,
+                          1.810000 0.192233 0.297444,
+                          1.810000 0.231056 0.152556,
+                          1.810000 0.607767 0.253495,
+                          1.810000 0.402950 0.232261,
+                          1.810000 0.238743 0.188262,
+                          1.810000 0.216743 0.270365,
+                          1.810000 0.380951 0.314365,
+                          2.000000 0.561257 0.362678,
+                          1.810000 0.561257 0.362678,
+                          2.000000 0.397050 0.318678,
+                          1.810000 0.397050 0.318678,
+                          1.810000 0.419049 0.236575,
+                          1.810000 0.583257 0.280574,
+                          2.000000 0.583257 0.280574,
+                          2.000000 0.419049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 0.505000 0.150000,
+                          2.195000 0.505000 0.240000,
+                          1.805000 0.505000 0.150000,
+                          1.805000 0.505000 0.240000,
+                          2.195000 0.595000 0.150000,
+                          1.805000 0.595000 0.150000,
+                          1.805000 0.595000 0.240000,
+                          2.195000 0.595000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 -0.190000 0.314365,
+                          1.816743 -0.190000 0.270365,
+                          1.838743 -0.190000 0.188262,
+                          2.002950 -0.190000 0.232261,
+                          1.792233 -0.190000 0.297444,
+                          1.831056 -0.190000 0.152556,
+                          2.207767 -0.190000 0.253495,
+                          2.168944 -0.190000 0.398384,
+                          2.168944 -0.000000 0.398384,
+                          1.792233 0.000000 0.297444,
+                          1.831056 0.000000 0.152556,
+                          2.207767 -0.000000 0.253495,
+                          2.002950 0.000000 0.232261,
+                          1.838743 -0.000000 0.188262,
+                          1.816743 -0.000000 0.270365,
+                          1.980951 0.000000 0.314365,
+                          2.161257 -0.190000 0.362678,
+                          2.161257 -0.000000 0.362678,
+                          1.997050 -0.190000 0.318678,
+                          1.997050 -0.000000 0.318678,
+                          2.019049 -0.000000 0.236575,
+                          2.183257 -0.000000 0.280574,
+                          2.183257 -0.190000 0.280574,
+                          2.019049 -0.190000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 0.000000 0.314365,
+                          1.816743 0.000000 0.270365,
+                          1.838743 0.000000 0.188262,
+                          2.002950 0.000000 0.232261,
+                          1.792233 0.000000 0.297444,
+                          1.831056 0.000000 0.152556,
+                          2.207767 -0.000000 0.253495,
+                          2.168944 -0.000000 0.398384,
+                          2.168944 0.190000 0.398384,
+                          1.792233 0.190000 0.297444,
+                          1.831056 0.190000 0.152556,
+                          2.207767 0.190000 0.253495,
+                          2.002950 0.190000 0.232261,
+                          1.838743 0.190000 0.188262,
+                          1.816743 0.190000 0.270365,
+                          1.980951 0.190000 0.314365,
+                          2.161257 0.000000 0.362678,
+                          2.161257 0.190000 0.362678,
+                          1.997050 -0.000000 0.318678,
+                          1.997050 0.190000 0.318678,
+                          2.019049 0.190000 0.236575,
+                          2.183257 0.190000 0.280574,
+                          2.183257 0.000000 0.280574,
+                          2.019049 -0.000000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 -0.195000 0.150000,
+                          2.105000 -0.195000 0.240000,
+                          2.105000 0.195000 0.150000,
+                          2.105000 0.195000 0.240000,
+                          2.195000 -0.195000 0.150000,
+                          2.195000 0.195000 0.150000,
+                          2.195000 0.195000 0.240000,
+                          2.195000 -0.195000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 1.810000 0.314365,
+                          1.416743 1.810000 0.270365,
+                          1.438743 1.810000 0.188262,
+                          1.602950 1.810000 0.232261,
+                          1.392233 1.810000 0.297444,
+                          1.431056 1.810000 0.152556,
+                          1.807767 1.810000 0.253495,
+                          1.768944 1.810000 0.398384,
+                          1.768944 2.000000 0.398384,
+                          1.392233 2.000000 0.297444,
+                          1.431056 2.000000 0.152556,
+                          1.807767 2.000000 0.253495,
+                          1.602950 2.000000 0.232261,
+                          1.438743 2.000000 0.188262,
+                          1.416743 2.000000 0.270365,
+                          1.580951 2.000000 0.314365,
+                          1.761257 1.810000 0.362678,
+                          1.761257 2.000000 0.362678,
+                          1.597050 1.810000 0.318678,
+                          1.597050 2.000000 0.318678,
+                          1.619049 2.000000 0.236575,
+                          1.783257 2.000000 0.280574,
+                          1.783257 1.810000 0.280574,
+                          1.619049 1.810000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 2.000000 0.314365,
+                          1.416743 2.000000 0.270365,
+                          1.438743 2.000000 0.188262,
+                          1.602950 2.000000 0.232261,
+                          1.392233 2.000000 0.297444,
+                          1.431056 2.000000 0.152556,
+                          1.807767 2.000000 0.253495,
+                          1.768944 2.000000 0.398384,
+                          1.768944 2.190000 0.398384,
+                          1.392233 2.190000 0.297444,
+                          1.431056 2.190000 0.152556,
+                          1.807767 2.190000 0.253495,
+                          1.602950 2.190000 0.232261,
+                          1.438743 2.190000 0.188262,
+                          1.416743 2.190000 0.270365,
+                          1.580951 2.190000 0.314365,
+                          1.761257 2.000000 0.362678,
+                          1.761257 2.190000 0.362678,
+                          1.597050 2.000000 0.318678,
+                          1.597050 2.190000 0.318678,
+                          1.619049 2.190000 0.236575,
+                          1.783257 2.190000 0.280574,
+                          1.783257 2.000000 0.280574,
+                          1.619049 2.000000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.705000 1.805000 0.150000,
+                          1.705000 1.805000 0.240000,
+                          1.705000 2.195000 0.150000,
+                          1.705000 2.195000 0.240000,
+                          1.795000 1.805000 0.150000,
+                          1.795000 2.195000 0.150000,
+                          1.795000 2.195000 0.240000,
+                          1.795000 1.805000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.410000 1.619049 0.464365,
+                          1.410000 1.783257 0.420365,
+                          1.410000 1.761257 0.338262,
+                          1.410000 1.597050 0.382261,
+                          1.410000 1.807767 0.447444,
+                          1.410000 1.768944 0.302556,
+                          1.410000 1.392233 0.403495,
+                          1.410000 1.431056 0.548384,
+                          1.600000 1.431056 0.548384,
+                          1.600000 1.807767 0.447444,
+                          1.600000 1.768944 0.302556,
+                          1.600000 1.392233 0.403495,
+                          1.600000 1.597050 0.382261,
+                          1.600000 1.761257 0.338262,
+                          1.600000 1.783257 0.420365,
+                          1.600000 1.619049 0.464365,
+                          1.410000 1.438743 0.512678,
+                          1.600000 1.438743 0.512678,
+                          1.410000 1.602950 0.468678,
+                          1.600000 1.602950 0.468678,
+                          1.600000 1.580951 0.386575,
+                          1.600000 1.416743 0.430574,
+                          1.410000 1.416743 0.430574,
+                          1.410000 1.580951 0.386575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 1.619049 0.464365,
+                          1.600000 1.783257 0.420365,
+                          1.600000 1.761257 0.338262,
+                          1.600000 1.597050 0.382261,
+                          1.600000 1.807767 0.447444,
+                          1.600000 1.768944 0.302556,
+                          1.600000 1.392233 0.403495,
+                          1.600000 1.431056 0.548384,
+                          1.790000 1.431056 0.548384,
+                          1.790000 1.807767 0.447444,
+                          1.790000 1.768944 0.302556,
+                          1.790000 1.392233 0.403495,
+                          1.790000 1.597050 0.382261,
+                          1.790000 1.761257 0.338262,
+                          1.790000 1.783257 0.420365,
+                          1.790000 1.619049 0.464365,
+                          1.600000 1.438743 0.512678,
+                          1.790000 1.438743 0.512678,
+                          1.600000 1.602950 0.468678,
+                          1.790000 1.602950 0.468678,
+                          1.790000 1.580951 0.386575,
+                          1.790000 1.416743 0.430574,
+                          1.600000 1.416743 0.430574,
+                          1.600000 1.580951 0.386575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 1.495000 0.300000,
+                          1.405000 1.495000 0.390000,
+                          1.795000 1.495000 0.300000,
+                          1.795000 1.495000 0.390000,
+                          1.405000 1.405000 0.300000,
+                          1.795000 1.405000 0.300000,
+                          1.795000 1.405000 0.390000,
+                          1.405000 1.405000 0.390000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.619049 1.390000 0.314365,
+                          1.783257 1.390000 0.270365,
+                          1.761257 1.390000 0.188262,
+                          1.597050 1.390000 0.232261,
+                          1.807767 1.390000 0.297444,
+                          1.768944 1.390000 0.152556,
+                          1.392233 1.390000 0.253495,
+                          1.431056 1.390000 0.398384,
+                          1.431056 1.200000 0.398384,
+                          1.807767 1.200000 0.297444,
+                          1.768944 1.200000 0.152556,
+                          1.392233 1.200000 0.253495,
+                          1.597050 1.200000 0.232261,
+                          1.761257 1.200000 0.188262,
+                          1.783257 1.200000 0.270365,
+                          1.619049 1.200000 0.314365,
+                          1.438743 1.390000 0.362678,
+                          1.438743 1.200000 0.362678,
+                          1.602950 1.390000 0.318678,
+                          1.602950 1.200000 0.318678,
+                          1.580951 1.200000 0.236575,
+                          1.416743 1.200000 0.280574,
+                          1.416743 1.390000 0.280574,
+                          1.580951 1.390000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.619049 1.200000 0.314365,
+                          1.783257 1.200000 0.270365,
+                          1.761257 1.200000 0.188262,
+                          1.597050 1.200000 0.232261,
+                          1.807767 1.200000 0.297444,
+                          1.768944 1.200000 0.152556,
+                          1.392233 1.200000 0.253495,
+                          1.431056 1.200000 0.398384,
+                          1.431056 1.010000 0.398384,
+                          1.807767 1.010000 0.297444,
+                          1.768944 1.010000 0.152556,
+                          1.392233 1.010000 0.253495,
+                          1.597050 1.010000 0.232261,
+                          1.761257 1.010000 0.188262,
+                          1.783257 1.010000 0.270365,
+                          1.619049 1.010000 0.314365,
+                          1.438743 1.200000 0.362678,
+                          1.438743 1.010000 0.362678,
+                          1.602950 1.200000 0.318678,
+                          1.602950 1.010000 0.318678,
+                          1.580951 1.010000 0.236575,
+                          1.416743 1.010000 0.280574,
+                          1.416743 1.200000 0.280574,
+                          1.580951 1.200000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.495000 1.395000 0.150000,
+                          1.495000 1.395000 0.240000,
+                          1.495000 1.005000 0.150000,
+                          1.495000 1.005000 0.240000,
+                          1.405000 1.395000 0.150000,
+                          1.405000 1.005000 0.150000,
+                          1.405000 1.005000 0.240000,
+                          1.405000 1.395000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.790000 0.780951 0.314365,
+                          1.790000 0.616743 0.270365,
+                          1.790000 0.638743 0.188262,
+                          1.790000 0.802950 0.232261,
+                          1.790000 0.592233 0.297444,
+                          1.790000 0.631056 0.152556,
+                          1.790000 1.007767 0.253495,
+                          1.790000 0.968944 0.398384,
+                          1.600000 0.968944 0.398384,
+                          1.600000 0.592233 0.297444,
+                          1.600000 0.631056 0.152556,
+                          1.600000 1.007767 0.253495,
+                          1.600000 0.802950 0.232261,
+                          1.600000 0.638743 0.188262,
+                          1.600000 0.616743 0.270365,
+                          1.600000 0.780951 0.314365,
+                          1.790000 0.961257 0.362678,
+                          1.600000 0.961257 0.362678,
+                          1.790000 0.797050 0.318678,
+                          1.600000 0.797050 0.318678,
+                          1.600000 0.819049 0.236575,
+                          1.600000 0.983257 0.280574,
+                          1.790000 0.983257 0.280574,
+                          1.790000 0.819049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 0.780951 0.314365,
+                          1.600000 0.616743 0.270365,
+                          1.600000 0.638743 0.188262,
+                          1.600000 0.802950 0.232261,
+                          1.600000 0.592233 0.297444,
+                          1.600000 0.631056 0.152556,
+                          1.600000 1.007767 0.253495,
+                          1.600000 0.968944 0.398384,
+                          1.410000 0.968944 0.398384,
+                          1.410000 0.592233 0.297444,
+                          1.410000 0.631056 0.152556,
+                          1.410000 1.007767 0.253495,
+                          1.410000 0.802950 0.232261,
+                          1.410000 0.638743 0.188262,
+                          1.410000 0.616743 0.270365,
+                          1.410000 0.780951 0.314365,
+                          1.600000 0.961257 0.362678,
+                          1.410000 0.961257 0.362678,
+                          1.600000 0.797050 0.318678,
+                          1.410000 0.797050 0.318678,
+                          1.410000 0.819049 0.236575,
+                          1.410000 0.983257 0.280574,
+                          1.600000 0.983257 0.280574,
+                          1.600000 0.819049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.795000 0.905000 0.150000,
+                          1.795000 0.905000 0.240000,
+                          1.405000 0.905000 0.150000,
+                          1.405000 0.905000 0.240000,
+                          1.795000 0.995000 0.150000,
+                          1.405000 0.995000 0.150000,
+                          1.405000 0.995000 0.240000,
+                          1.795000 0.995000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 0.210000 0.464365,
+                          1.416743 0.210000 0.420365,
+                          1.438743 0.210000 0.338262,
+                          1.602950 0.210000 0.382261,
+                          1.392233 0.210000 0.447444,
+                          1.431056 0.210000 0.302556,
+                          1.807767 0.210000 0.403495,
+                          1.768944 0.210000 0.548384,
+                          1.768944 0.400000 0.548384,
+                          1.392233 0.400000 0.447444,
+                          1.431056 0.400000 0.302556,
+                          1.807767 0.400000 0.403495,
+                          1.602950 0.400000 0.382261,
+                          1.438743 0.400000 0.338262,
+                          1.416743 0.400000 0.420365,
+                          1.580951 0.400000 0.464365,
+                          1.761257 0.210000 0.512678,
+                          1.761257 0.400000 0.512678,
+                          1.597050 0.210000 0.468678,
+                          1.597050 0.400000 0.468678,
+                          1.619049 0.400000 0.386575,
+                          1.783257 0.400000 0.430574,
+                          1.783257 0.210000 0.430574,
+                          1.619049 0.210000 0.386575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 0.400000 0.464365,
+                          1.416743 0.400000 0.420365,
+                          1.438743 0.400000 0.338262,
+                          1.602950 0.400000 0.382261,
+                          1.392233 0.400000 0.447444,
+                          1.431056 0.400000 0.302556,
+                          1.807767 0.400000 0.403495,
+                          1.768944 0.400000 0.548384,
+                          1.768944 0.590000 0.548384,
+                          1.392233 0.590000 0.447444,
+                          1.431056 0.590000 0.302556,
+                          1.807767 0.590000 0.403495,
+                          1.602950 0.590000 0.382261,
+                          1.438743 0.590000 0.338262,
+                          1.416743 0.590000 0.420365,
+                          1.580951 0.590000 0.464365,
+                          1.761257 0.400000 0.512678,
+                          1.761257 0.590000 0.512678,
+                          1.597050 0.400000 0.468678,
+                          1.597050 0.590000 0.468678,
+                          1.619049 0.590000 0.386575,
+                          1.783257 0.590000 0.430574,
+                          1.783257 0.400000 0.430574,
+                          1.619049 0.400000 0.386575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.705000 0.205000 0.300000,
+                          1.705000 0.205000 0.390000,
+                          1.705000 0.595000 0.300000,
+                          1.705000 0.595000 0.390000,
+                          1.795000 0.205000 0.300000,
+                          1.795000 0.595000 0.300000,
+                          1.795000 0.595000 0.390000,
+                          1.795000 0.205000 0.390000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.410000 0.019049 0.314365,
+                          1.410000 0.183257 0.270365,
+                          1.410000 0.161257 0.188262,
+                          1.410000 -0.002950 0.232261,
+                          1.410000 0.207767 0.297444,
+                          1.410000 0.168944 0.152556,
+                          1.410000 -0.207767 0.253495,
+                          1.410000 -0.168944 0.398384,
+                          1.600000 -0.168944 0.398384,
+                          1.600000 0.207767 0.297444,
+                          1.600000 0.168944 0.152556,
+                          1.600000 -0.207767 0.253495,
+                          1.600000 -0.002950 0.232261,
+                          1.600000 0.161257 0.188262,
+                          1.600000 0.183257 0.270365,
+                          1.600000 0.019049 0.314365,
+                          1.410000 -0.161257 0.362678,
+                          1.600000 -0.161257 0.362678,
+                          1.410000 0.002950 0.318678,
+                          1.600000 0.002950 0.318678,
+                          1.600000 -0.019049 0.236575,
+                          1.600000 -0.183257 0.280574,
+                          1.410000 -0.183257 0.280574,
+                          1.410000 -0.019049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 0.019049 0.314365,
+                          1.600000 0.183257 0.270365,
+                          1.600000 0.161257 0.188262,
+                          1.600000 -0.002950 0.232261,
+                          1.600000 0.207767 0.297444,
+                          1.600000 0.168944 0.152556,
+                          1.600000 -0.207767 0.253495,
+                          1.600000 -0.168944 0.398384,
+                          1.790000 -0.168944 0.398384,
+                          1.790000 0.207767 0.297444,
+                          1.790000 0.168944 0.152556,
+                          1.790000 -0.207767 0.253495,
+                          1.790000 -0.002950 0.232261,
+                          1.790000 0.161257 0.188262,
+                          1.790000 0.183257 0.270365,
+                          1.790000 0.019049 0.314365,
+                          1.600000 -0.161257 0.362678,
+                          1.790000 -0.161257 0.362678,
+                          1.600000 0.002950 0.318678,
+                          1.790000 0.002950 0.318678,
+                          1.790000 -0.019049 0.236575,
+                          1.790000 -0.183257 0.280574,
+                          1.600000 -0.183257 0.280574,
+                          1.600000 -0.019049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 -0.105000 0.150000,
+                          1.405000 -0.105000 0.240000,
+                          1.795000 -0.105000 0.150000,
+                          1.795000 -0.105000 0.240000,
+                          1.405000 -0.195000 0.150000,
+                          1.795000 -0.195000 0.150000,
+                          1.795000 -0.195000 0.240000,
+                          1.405000 -0.195000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.010000 2.019049 0.164365,
+                          1.010000 2.183257 0.120365,
+                          1.010000 2.161257 0.038262,
+                          1.010000 1.997050 0.082261,
+                          1.010000 2.207767 0.147444,
+                          1.010000 2.168944 0.002556,
+                          1.010000 1.792233 0.103495,
+                          1.010000 1.831056 0.248384,
+                          1.200000 1.831056 0.248384,
+                          1.200000 2.207767 0.147444,
+                          1.200000 2.168944 0.002556,
+                          1.200000 1.792233 0.103495,
+                          1.200000 1.997050 0.082261,
+                          1.200000 2.161257 0.038262,
+                          1.200000 2.183257 0.120365,
+                          1.200000 2.019049 0.164365,
+                          1.010000 1.838743 0.212678,
+                          1.200000 1.838743 0.212678,
+                          1.010000 2.002950 0.168678,
+                          1.200000 2.002950 0.168678,
+                          1.200000 1.980951 0.086575,
+                          1.200000 1.816743 0.130574,
+                          1.010000 1.816743 0.130574,
+                          1.010000 1.980951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 2.019049 0.164365,
+                          1.200000 2.183257 0.120365,
+                          1.200000 2.161257 0.038262,
+                          1.200000 1.997050 0.082261,
+                          1.200000 2.207767 0.147444,
+                          1.200000 2.168944 0.002556,
+                          1.200000 1.792233 0.103495,
+                          1.200000 1.831056 0.248384,
+                          1.390000 1.831056 0.248384,
+                          1.390000 2.207767 0.147444,
+                          1.390000 2.168944 0.002556,
+                          1.390000 1.792233 0.103495,
+                          1.390000 1.997050 0.082261,
+                          1.390000 2.161257 0.038262,
+                          1.390000 2.183257 0.120365,
+                          1.390000 2.019049 0.164365,
+                          1.200000 1.838743 0.212678,
+                          1.390000 1.838743 0.212678,
+                          1.200000 2.002950 0.168678,
+                          1.390000 2.002950 0.168678,
+                          1.390000 1.980951 0.086575,
+                          1.390000 1.816743 0.130574,
+                          1.200000 1.816743 0.130574,
+                          1.200000 1.980951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 1.895000 0.000000,
+                          1.005000 1.895000 0.090000,
+                          1.395000 1.895000 0.000000,
+                          1.395000 1.895000 0.090000,
+                          1.005000 1.805000 0.000000,
+                          1.395000 1.805000 0.000000,
+                          1.395000 1.805000 0.090000,
+                          1.005000 1.805000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 1.790000 0.314365,
+                          1.383257 1.790000 0.270365,
+                          1.361257 1.790000 0.188262,
+                          1.197050 1.790000 0.232261,
+                          1.407767 1.790000 0.297444,
+                          1.368944 1.790000 0.152556,
+                          0.992233 1.790000 0.253495,
+                          1.031056 1.790000 0.398384,
+                          1.031056 1.600000 0.398384,
+                          1.407767 1.600000 0.297444,
+                          1.368944 1.600000 0.152556,
+                          0.992233 1.600000 0.253495,
+                          1.197050 1.600000 0.232261,
+                          1.361257 1.600000 0.188262,
+                          1.383257 1.600000 0.270365,
+                          1.219049 1.600000 0.314365,
+                          1.038743 1.790000 0.362678,
+                          1.038743 1.600000 0.362678,
+                          1.202950 1.790000 0.318678,
+                          1.202950 1.600000 0.318678,
+                          1.180951 1.600000 0.236575,
+                          1.016743 1.600000 0.280574,
+                          1.016743 1.790000 0.280574,
+                          1.180951 1.790000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 1.600000 0.314365,
+                          1.383257 1.600000 0.270365,
+                          1.361257 1.600000 0.188262,
+                          1.197050 1.600000 0.232261,
+                          1.407767 1.600000 0.297444,
+                          1.368944 1.600000 0.152556,
+                          0.992233 1.600000 0.253495,
+                          1.031056 1.600000 0.398384,
+                          1.031056 1.410000 0.398384,
+                          1.407767 1.410000 0.297444,
+                          1.368944 1.410000 0.152556,
+                          0.992233 1.410000 0.253495,
+                          1.197050 1.410000 0.232261,
+                          1.361257 1.410000 0.188262,
+                          1.383257 1.410000 0.270365,
+                          1.219049 1.410000 0.314365,
+                          1.038743 1.600000 0.362678,
+                          1.038743 1.410000 0.362678,
+                          1.202950 1.600000 0.318678,
+                          1.202950 1.410000 0.318678,
+                          1.180951 1.410000 0.236575,
+                          1.016743 1.410000 0.280574,
+                          1.016743 1.600000 0.280574,
+                          1.180951 1.600000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.095000 1.795000 0.150000,
+                          1.095000 1.795000 0.240000,
+                          1.095000 1.405000 0.150000,
+                          1.095000 1.405000 0.240000,
+                          1.005000 1.795000 0.150000,
+                          1.005000 1.405000 0.150000,
+                          1.005000 1.405000 0.240000,
+                          1.005000 1.795000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.390000 1.180951 0.314365,
+                          1.390000 1.016743 0.270365,
+                          1.390000 1.038743 0.188262,
+                          1.390000 1.202950 0.232261,
+                          1.390000 0.992233 0.297444,
+                          1.390000 1.031056 0.152556,
+                          1.390000 1.407767 0.253495,
+                          1.390000 1.368944 0.398384,
+                          1.200000 1.368944 0.398384,
+                          1.200000 0.992233 0.297444,
+                          1.200000 1.031056 0.152556,
+                          1.200000 1.407767 0.253495,
+                          1.200000 1.202950 0.232261,
+                          1.200000 1.038743 0.188262,
+                          1.200000 1.016743 0.270365,
+                          1.200000 1.180951 0.314365,
+                          1.390000 1.361257 0.362678,
+                          1.200000 1.361257 0.362678,
+                          1.390000 1.197050 0.318678,
+                          1.200000 1.197050 0.318678,
+                          1.200000 1.219049 0.236575,
+                          1.200000 1.383257 0.280574,
+                          1.390000 1.383257 0.280574,
+                          1.390000 1.219049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 1.180951 0.314365,
+                          1.200000 1.016743 0.270365,
+                          1.200000 1.038743 0.188262,
+                          1.200000 1.202950 0.232261,
+                          1.200000 0.992233 0.297444,
+                          1.200000 1.031056 0.152556,
+                          1.200000 1.407767 0.253495,
+                          1.200000 1.368944 0.398384,
+                          1.010000 1.368944 0.398384,
+                          1.010000 0.992233 0.297444,
+                          1.010000 1.031056 0.152556,
+                          1.010000 1.407767 0.253495,
+                          1.010000 1.202950 0.232261,
+                          1.010000 1.038743 0.188262,
+                          1.010000 1.016743 0.270365,
+                          1.010000 1.180951 0.314365,
+                          1.200000 1.361257 0.362678,
+                          1.010000 1.361257 0.362678,
+                          1.200000 1.197050 0.318678,
+                          1.010000 1.197050 0.318678,
+                          1.010000 1.219049 0.236575,
+                          1.010000 1.383257 0.280574,
+                          1.200000 1.383257 0.280574,
+                          1.200000 1.219049 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.395000 1.305000 0.150000,
+                          1.395000 1.305000 0.240000,
+                          1.005000 1.305000 0.150000,
+                          1.005000 1.305000 0.240000,
+                          1.395000 1.395000 0.150000,
+                          1.005000 1.395000 0.150000,
+                          1.005000 1.395000 0.240000,
+                          1.395000 1.395000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.180951 0.610000 0.314365,
+                          1.016743 0.610000 0.270365,
+                          1.038743 0.610000 0.188262,
+                          1.202950 0.610000 0.232261,
+                          0.992233 0.610000 0.297444,
+                          1.031056 0.610000 0.152556,
+                          1.407767 0.610000 0.253495,
+                          1.368944 0.610000 0.398384,
+                          1.368944 0.800000 0.398384,
+                          0.992233 0.800000 0.297444,
+                          1.031056 0.800000 0.152556,
+                          1.407767 0.800000 0.253495,
+                          1.202950 0.800000 0.232261,
+                          1.038743 0.800000 0.188262,
+                          1.016743 0.800000 0.270365,
+                          1.180951 0.800000 0.314365,
+                          1.361257 0.610000 0.362678,
+                          1.361257 0.800000 0.362678,
+                          1.197050 0.610000 0.318678,
+                          1.197050 0.800000 0.318678,
+                          1.219049 0.800000 0.236575,
+                          1.383257 0.800000 0.280574,
+                          1.383257 0.610000 0.280574,
+                          1.219049 0.610000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.180951 0.800000 0.314365,
+                          1.016743 0.800000 0.270365,
+                          1.038743 0.800000 0.188262,
+                          1.202950 0.800000 0.232261,
+                          0.992233 0.800000 0.297444,
+                          1.031056 0.800000 0.152556,
+                          1.407767 0.800000 0.253495,
+                          1.368944 0.800000 0.398384,
+                          1.368944 0.990000 0.398384,
+                          0.992233 0.990000 0.297444,
+                          1.031056 0.990000 0.152556,
+                          1.407767 0.990000 0.253495,
+                          1.202950 0.990000 0.232261,
+                          1.038743 0.990000 0.188262,
+                          1.016743 0.990000 0.270365,
+                          1.180951 0.990000 0.314365,
+                          1.361257 0.800000 0.362678,
+                          1.361257 0.990000 0.362678,
+                          1.197050 0.800000 0.318678,
+                          1.197050 0.990000 0.318678,
+                          1.219049 0.990000 0.236575,
+                          1.383257 0.990000 0.280574,
+                          1.383257 0.800000 0.280574,
+                          1.219049 0.800000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.305000 0.605000 0.150000,
+                          1.305000 0.605000 0.240000,
+                          1.305000 0.995000 0.150000,
+                          1.305000 0.995000 0.240000,
+                          1.395000 0.605000 0.150000,
+                          1.395000 0.995000 0.150000,
+                          1.395000 0.995000 0.240000,
+                          1.395000 0.605000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.010000 0.419049 0.314365,
+                          1.010000 0.583257 0.270365,
+                          1.010000 0.561257 0.188262,
+                          1.010000 0.397050 0.232261,
+                          1.010000 0.607767 0.297444,
+                          1.010000 0.568944 0.152556,
+                          1.010000 0.192233 0.253495,
+                          1.010000 0.231056 0.398384,
+                          1.200000 0.231056 0.398384,
+                          1.200000 0.607767 0.297444,
+                          1.200000 0.568944 0.152556,
+                          1.200000 0.192233 0.253495,
+                          1.200000 0.397050 0.232261,
+                          1.200000 0.561257 0.188262,
+                          1.200000 0.583257 0.270365,
+                          1.200000 0.419049 0.314365,
+                          1.010000 0.238743 0.362678,
+                          1.200000 0.238743 0.362678,
+                          1.010000 0.402950 0.318678,
+                          1.200000 0.402950 0.318678,
+                          1.200000 0.380951 0.236575,
+                          1.200000 0.216743 0.280574,
+                          1.010000 0.216743 0.280574,
+                          1.010000 0.380951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 0.419049 0.314365,
+                          1.200000 0.583257 0.270365,
+                          1.200000 0.561257 0.188262,
+                          1.200000 0.397050 0.232261,
+                          1.200000 0.607767 0.297444,
+                          1.200000 0.568944 0.152556,
+                          1.200000 0.192233 0.253495,
+                          1.200000 0.231056 0.398384,
+                          1.390000 0.231056 0.398384,
+                          1.390000 0.607767 0.297444,
+                          1.390000 0.568944 0.152556,
+                          1.390000 0.192233 0.253495,
+                          1.390000 0.397050 0.232261,
+                          1.390000 0.561257 0.188262,
+                          1.390000 0.583257 0.270365,
+                          1.390000 0.419049 0.314365,
+                          1.200000 0.238743 0.362678,
+                          1.390000 0.238743 0.362678,
+                          1.200000 0.402950 0.318678,
+                          1.390000 0.402950 0.318678,
+                          1.390000 0.380951 0.236575,
+                          1.390000 0.216743 0.280574,
+                          1.200000 0.216743 0.280574,
+                          1.200000 0.380951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 0.295000 0.150000,
+                          1.005000 0.295000 0.240000,
+                          1.395000 0.295000 0.150000,
+                          1.395000 0.295000 0.240000,
+                          1.005000 0.205000 0.150000,
+                          1.395000 0.205000 0.150000,
+                          1.395000 0.205000 0.240000,
+                          1.005000 0.205000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 0.190000 0.164365,
+                          1.383257 0.190000 0.120365,
+                          1.361257 0.190000 0.038262,
+                          1.197050 0.190000 0.082261,
+                          1.407767 0.190000 0.147444,
+                          1.368944 0.190000 0.002556,
+                          0.992233 0.190000 0.103495,
+                          1.031056 0.190000 0.248384,
+                          1.031056 0.000000 0.248384,
+                          1.407767 0.000000 0.147444,
+                          1.368944 0.000000 0.002556,
+                          0.992233 0.000000 0.103495,
+                          1.197050 0.000000 0.082261,
+                          1.361257 0.000000 0.038262,
+                          1.383257 0.000000 0.120365,
+                          1.219049 0.000000 0.164365,
+                          1.038743 0.190000 0.212678,
+                          1.038743 0.000000 0.212678,
+                          1.202950 0.190000 0.168678,
+                          1.202950 0.000000 0.168678,
+                          1.180951 0.000000 0.086575,
+                          1.016743 0.000000 0.130574,
+                          1.016743 0.190000 0.130574,
+                          1.180951 0.190000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 -0.000000 0.164365,
+                          1.383257 0.000000 0.120365,
+                          1.361257 0.000000 0.038262,
+                          1.197050 -0.000000 0.082261,
+                          1.407767 0.000000 0.147444,
+                          1.368944 0.000000 0.002556,
+                          0.992233 0.000000 0.103495,
+                          1.031056 0.000000 0.248384,
+                          1.031056 -0.190000 0.248384,
+                          1.407767 -0.190000 0.147444,
+                          1.368944 -0.190000 0.002556,
+                          0.992233 -0.190000 0.103495,
+                          1.197050 -0.190000 0.082261,
+                          1.361257 -0.190000 0.038262,
+                          1.383257 -0.190000 0.120365,
+                          1.219049 -0.190000 0.164365,
+                          1.038743 -0.000000 0.212678,
+                          1.038743 -0.190000 0.212678,
+                          1.202950 0.000000 0.168678,
+                          1.202950 -0.190000 0.168678,
+                          1.180951 -0.190000 0.086575,
+                          1.016743 -0.190000 0.130574,
+                          1.016743 -0.000000 0.130574,
+                          1.180951 0.000000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.095000 0.195000 0.000000,
+                          1.095000 0.195000 0.090000,
+                          1.095000 -0.195000 0.000000,
+                          1.095000 -0.195000 0.090000,
+                          1.005000 0.195000 0.000000,
+                          1.005000 -0.195000 0.000000,
+                          1.005000 -0.195000 0.090000,
+                          1.005000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 2.190000 0.164365,
+                          0.983257 2.190000 0.120365,
+                          0.961257 2.190000 0.038262,
+                          0.797050 2.190000 0.082261,
+                          1.007767 2.190000 0.147444,
+                          0.968944 2.190000 0.002556,
+                          0.592233 2.190000 0.103495,
+                          0.631056 2.190000 0.248384,
+                          0.631056 2.000000 0.248384,
+                          1.007767 2.000000 0.147444,
+                          0.968944 2.000000 0.002556,
+                          0.592233 2.000000 0.103495,
+                          0.797050 2.000000 0.082261,
+                          0.961257 2.000000 0.038262,
+                          0.983257 2.000000 0.120365,
+                          0.819049 2.000000 0.164365,
+                          0.638743 2.190000 0.212678,
+                          0.638743 2.000000 0.212678,
+                          0.802950 2.190000 0.168678,
+                          0.802950 2.000000 0.168678,
+                          0.780951 2.000000 0.086575,
+                          0.616743 2.000000 0.130574,
+                          0.616743 2.190000 0.130574,
+                          0.780951 2.190000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 2.000000 0.164365,
+                          0.983257 2.000000 0.120365,
+                          0.961257 2.000000 0.038262,
+                          0.797050 2.000000 0.082261,
+                          1.007767 2.000000 0.147444,
+                          0.968944 2.000000 0.002556,
+                          0.592233 2.000000 0.103495,
+                          0.631056 2.000000 0.248384,
+                          0.631056 1.810000 0.248384,
+                          1.007767 1.810000 0.147444,
+                          0.968944 1.810000 0.002556,
+                          0.592233 1.810000 0.103495,
+                          0.797050 1.810000 0.082261,
+                          0.961257 1.810000 0.038262,
+                          0.983257 1.810000 0.120365,
+                          0.819049 1.810000 0.164365,
+                          0.638743 2.000000 0.212678,
+                          0.638743 1.810000 0.212678,
+                          0.802950 2.000000 0.168678,
+                          0.802950 1.810000 0.168678,
+                          0.780951 1.810000 0.086575,
+                          0.616743 1.810000 0.130574,
+                          0.616743 2.000000 0.130574,
+                          0.780951 2.000000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.695000 2.195000 0.000000,
+                          0.695000 2.195000 0.090000,
+                          0.695000 1.805000 0.000000,
+                          0.695000 1.805000 0.090000,
+                          0.605000 2.195000 0.000000,
+                          0.605000 1.805000 0.000000,
+                          0.605000 1.805000 0.090000,
+                          0.605000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.990000 1.580951 0.164365,
+                          0.990000 1.416743 0.120365,
+                          0.990000 1.438743 0.038262,
+                          0.990000 1.602950 0.082261,
+                          0.990000 1.392233 0.147444,
+                          0.990000 1.431056 0.002556,
+                          0.990000 1.807767 0.103495,
+                          0.990000 1.768944 0.248384,
+                          0.800000 1.768944 0.248384,
+                          0.800000 1.392233 0.147444,
+                          0.800000 1.431056 0.002556,
+                          0.800000 1.807767 0.103495,
+                          0.800000 1.602950 0.082261,
+                          0.800000 1.438743 0.038262,
+                          0.800000 1.416743 0.120365,
+                          0.800000 1.580951 0.164365,
+                          0.990000 1.761257 0.212678,
+                          0.800000 1.761257 0.212678,
+                          0.990000 1.597050 0.168678,
+                          0.800000 1.597050 0.168678,
+                          0.800000 1.619049 0.086575,
+                          0.800000 1.783257 0.130574,
+                          0.990000 1.783257 0.130574,
+                          0.990000 1.619049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 1.580951 0.164365,
+                          0.800000 1.416743 0.120365,
+                          0.800000 1.438743 0.038262,
+                          0.800000 1.602950 0.082261,
+                          0.800000 1.392233 0.147444,
+                          0.800000 1.431056 0.002556,
+                          0.800000 1.807767 0.103495,
+                          0.800000 1.768944 0.248384,
+                          0.610000 1.768944 0.248384,
+                          0.610000 1.392233 0.147444,
+                          0.610000 1.431056 0.002556,
+                          0.610000 1.807767 0.103495,
+                          0.610000 1.602950 0.082261,
+                          0.610000 1.438743 0.038262,
+                          0.610000 1.416743 0.120365,
+                          0.610000 1.580951 0.164365,
+                          0.800000 1.761257 0.212678,
+                          0.610000 1.761257 0.212678,
+                          0.800000 1.597050 0.168678,
+                          0.610000 1.597050 0.168678,
+                          0.610000 1.619049 0.086575,
+                          0.610000 1.783257 0.130574,
+                          0.800000 1.783257 0.130574,
+                          0.800000 1.619049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 1.705000 0.000000,
+                          0.995000 1.705000 0.090000,
+                          0.605000 1.705000 0.000000,
+                          0.605000 1.705000 0.090000,
+                          0.995000 1.795000 0.000000,
+                          0.605000 1.795000 0.000000,
+                          0.605000 1.795000 0.090000,
+                          0.995000 1.795000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.780951 1.010000 0.314365,
+                          0.616743 1.010000 0.270365,
+                          0.638743 1.010000 0.188262,
+                          0.802950 1.010000 0.232261,
+                          0.592233 1.010000 0.297444,
+                          0.631056 1.010000 0.152556,
+                          1.007767 1.010000 0.253495,
+                          0.968944 1.010000 0.398384,
+                          0.968944 1.200000 0.398384,
+                          0.592233 1.200000 0.297444,
+                          0.631056 1.200000 0.152556,
+                          1.007767 1.200000 0.253495,
+                          0.802950 1.200000 0.232261,
+                          0.638743 1.200000 0.188262,
+                          0.616743 1.200000 0.270365,
+                          0.780951 1.200000 0.314365,
+                          0.961257 1.010000 0.362678,
+                          0.961257 1.200000 0.362678,
+                          0.797050 1.010000 0.318678,
+                          0.797050 1.200000 0.318678,
+                          0.819049 1.200000 0.236575,
+                          0.983257 1.200000 0.280574,
+                          0.983257 1.010000 0.280574,
+                          0.819049 1.010000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.780951 1.200000 0.314365,
+                          0.616743 1.200000 0.270365,
+                          0.638743 1.200000 0.188262,
+                          0.802950 1.200000 0.232261,
+                          0.592233 1.200000 0.297444,
+                          0.631056 1.200000 0.152556,
+                          1.007767 1.200000 0.253495,
+                          0.968944 1.200000 0.398384,
+                          0.968944 1.390000 0.398384,
+                          0.592233 1.390000 0.297444,
+                          0.631056 1.390000 0.152556,
+                          1.007767 1.390000 0.253495,
+                          0.802950 1.390000 0.232261,
+                          0.638743 1.390000 0.188262,
+                          0.616743 1.390000 0.270365,
+                          0.780951 1.390000 0.314365,
+                          0.961257 1.200000 0.362678,
+                          0.961257 1.390000 0.362678,
+                          0.797050 1.200000 0.318678,
+                          0.797050 1.390000 0.318678,
+                          0.819049 1.390000 0.236575,
+                          0.983257 1.390000 0.280574,
+                          0.983257 1.200000 0.280574,
+                          0.819049 1.200000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.905000 1.005000 0.150000,
+                          0.905000 1.005000 0.240000,
+                          0.905000 1.395000 0.150000,
+                          0.905000 1.395000 0.240000,
+                          0.995000 1.005000 0.150000,
+                          0.995000 1.395000 0.150000,
+                          0.995000 1.395000 0.240000,
+                          0.995000 1.005000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.610000 0.819049 0.314365,
+                          0.610000 0.983257 0.270365,
+                          0.610000 0.961257 0.188262,
+                          0.610000 0.797050 0.232261,
+                          0.610000 1.007767 0.297444,
+                          0.610000 0.968944 0.152556,
+                          0.610000 0.592233 0.253495,
+                          0.610000 0.631056 0.398384,
+                          0.800000 0.631056 0.398384,
+                          0.800000 1.007767 0.297444,
+                          0.800000 0.968944 0.152556,
+                          0.800000 0.592233 0.253495,
+                          0.800000 0.797050 0.232261,
+                          0.800000 0.961257 0.188262,
+                          0.800000 0.983257 0.270365,
+                          0.800000 0.819049 0.314365,
+                          0.610000 0.638743 0.362678,
+                          0.800000 0.638743 0.362678,
+                          0.610000 0.802950 0.318678,
+                          0.800000 0.802950 0.318678,
+                          0.800000 0.780951 0.236575,
+                          0.800000 0.616743 0.280574,
+                          0.610000 0.616743 0.280574,
+                          0.610000 0.780951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 0.819049 0.314365,
+                          0.800000 0.983257 0.270365,
+                          0.800000 0.961257 0.188262,
+                          0.800000 0.797050 0.232261,
+                          0.800000 1.007767 0.297444,
+                          0.800000 0.968944 0.152556,
+                          0.800000 0.592233 0.253495,
+                          0.800000 0.631056 0.398384,
+                          0.990000 0.631056 0.398384,
+                          0.990000 1.007767 0.297444,
+                          0.990000 0.968944 0.152556,
+                          0.990000 0.592233 0.253495,
+                          0.990000 0.797050 0.232261,
+                          0.990000 0.961257 0.188262,
+                          0.990000 0.983257 0.270365,
+                          0.990000 0.819049 0.314365,
+                          0.800000 0.638743 0.362678,
+                          0.990000 0.638743 0.362678,
+                          0.800000 0.802950 0.318678,
+                          0.990000 0.802950 0.318678,
+                          0.990000 0.780951 0.236575,
+                          0.990000 0.616743 0.280574,
+                          0.800000 0.616743 0.280574,
+                          0.800000 0.780951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.605000 0.695000 0.150000,
+                          0.605000 0.695000 0.240000,
+                          0.995000 0.695000 0.150000,
+                          0.995000 0.695000 0.240000,
+                          0.605000 0.605000 0.150000,
+                          0.995000 0.605000 0.150000,
+                          0.995000 0.605000 0.240000,
+                          0.605000 0.605000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 0.590000 0.164365,
+                          0.983257 0.590000 0.120365,
+                          0.961257 0.590000 0.038262,
+                          0.797050 0.590000 0.082261,
+                          1.007767 0.590000 0.147444,
+                          0.968944 0.590000 0.002556,
+                          0.592233 0.590000 0.103495,
+                          0.631056 0.590000 0.248384,
+                          0.631056 0.400000 0.248384,
+                          1.007767 0.400000 0.147444,
+                          0.968944 0.400000 0.002556,
+                          0.592233 0.400000 0.103495,
+                          0.797050 0.400000 0.082261,
+                          0.961257 0.400000 0.038262,
+                          0.983257 0.400000 0.120365,
+                          0.819049 0.400000 0.164365,
+                          0.638743 0.590000 0.212678,
+                          0.638743 0.400000 0.212678,
+                          0.802950 0.590000 0.168678,
+                          0.802950 0.400000 0.168678,
+                          0.780951 0.400000 0.086575,
+                          0.616743 0.400000 0.130574,
+                          0.616743 0.590000 0.130574,
+                          0.780951 0.590000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 0.400000 0.164365,
+                          0.983257 0.400000 0.120365,
+                          0.961257 0.400000 0.038262,
+                          0.797050 0.400000 0.082261,
+                          1.007767 0.400000 0.147444,
+                          0.968944 0.400000 0.002556,
+                          0.592233 0.400000 0.103495,
+                          0.631056 0.400000 0.248384,
+                          0.631056 0.210000 0.248384,
+                          1.007767 0.210000 0.147444,
+                          0.968944 0.210000 0.002556,
+                          0.592233 0.210000 0.103495,
+                          0.797050 0.210000 0.082261,
+                          0.961257 0.210000 0.038262,
+                          0.983257 0.210000 0.120365,
+                          0.819049 0.210000 0.164365,
+                          0.638743 0.400000 0.212678,
+                          0.638743 0.210000 0.212678,
+                          0.802950 0.400000 0.168678,
+                          0.802950 0.210000 0.168678,
+                          0.780951 0.210000 0.086575,
+                          0.616743 0.210000 0.130574,
+                          0.616743 0.400000 0.130574,
+                          0.780951 0.400000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.695000 0.595000 0.000000,
+                          0.695000 0.595000 0.090000,
+                          0.695000 0.205000 0.000000,
+                          0.695000 0.205000 0.090000,
+                          0.605000 0.595000 0.000000,
+                          0.605000 0.205000 0.000000,
+                          0.605000 0.205000 0.090000,
+                          0.605000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.990000 -0.019049 0.164365,
+                          0.990000 -0.183257 0.120365,
+                          0.990000 -0.161257 0.038262,
+                          0.990000 0.002950 0.082261,
+                          0.990000 -0.207767 0.147444,
+                          0.990000 -0.168944 0.002556,
+                          0.990000 0.207767 0.103495,
+                          0.990000 0.168944 0.248384,
+                          0.800000 0.168944 0.248384,
+                          0.800000 -0.207767 0.147444,
+                          0.800000 -0.168944 0.002556,
+                          0.800000 0.207767 0.103495,
+                          0.800000 0.002950 0.082261,
+                          0.800000 -0.161257 0.038262,
+                          0.800000 -0.183257 0.120365,
+                          0.800000 -0.019049 0.164365,
+                          0.990000 0.161257 0.212678,
+                          0.800000 0.161257 0.212678,
+                          0.990000 -0.002950 0.168678,
+                          0.800000 -0.002950 0.168678,
+                          0.800000 0.019049 0.086575,
+                          0.800000 0.183257 0.130574,
+                          0.990000 0.183257 0.130574,
+                          0.990000 0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 -0.019049 0.164365,
+                          0.800000 -0.183257 0.120365,
+                          0.800000 -0.161257 0.038262,
+                          0.800000 0.002950 0.082261,
+                          0.800000 -0.207767 0.147444,
+                          0.800000 -0.168944 0.002556,
+                          0.800000 0.207767 0.103495,
+                          0.800000 0.168944 0.248384,
+                          0.610000 0.168944 0.248384,
+                          0.610000 -0.207767 0.147444,
+                          0.610000 -0.168944 0.002556,
+                          0.610000 0.207767 0.103495,
+                          0.610000 0.002950 0.082261,
+                          0.610000 -0.161257 0.038262,
+                          0.610000 -0.183257 0.120365,
+                          0.610000 -0.019049 0.164365,
+                          0.800000 0.161257 0.212678,
+                          0.610000 0.161257 0.212678,
+                          0.800000 -0.002950 0.168678,
+                          0.610000 -0.002950 0.168678,
+                          0.610000 0.019049 0.086575,
+                          0.610000 0.183257 0.130574,
+                          0.800000 0.183257 0.130574,
+                          0.800000 0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 0.105000 0.000000,
+                          0.995000 0.105000 0.090000,
+                          0.605000 0.105000 0.000000,
+                          0.605000 0.105000 0.090000,
+                          0.995000 0.195000 0.000000,
+                          0.605000 0.195000 0.000000,
+                          0.605000 0.195000 0.090000,
+                          0.995000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.590000 1.980951 0.164365,
+                          0.590000 1.816743 0.120365,
+                          0.590000 1.838743 0.038262,
+                          0.590000 2.002950 0.082261,
+                          0.590000 1.792233 0.147444,
+                          0.590000 1.831056 0.002556,
+                          0.590000 2.207767 0.103495,
+                          0.590000 2.168944 0.248384,
+                          0.400000 2.168944 0.248384,
+                          0.400000 1.792233 0.147444,
+                          0.400000 1.831056 0.002556,
+                          0.400000 2.207767 0.103495,
+                          0.400000 2.002950 0.082261,
+                          0.400000 1.838743 0.038262,
+                          0.400000 1.816743 0.120365,
+                          0.400000 1.980951 0.164365,
+                          0.590000 2.161257 0.212678,
+                          0.400000 2.161257 0.212678,
+                          0.590000 1.997050 0.168678,
+                          0.400000 1.997050 0.168678,
+                          0.400000 2.019049 0.086575,
+                          0.400000 2.183257 0.130574,
+                          0.590000 2.183257 0.130574,
+                          0.590000 2.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 1.980951 0.164365,
+                          0.400000 1.816743 0.120365,
+                          0.400000 1.838743 0.038262,
+                          0.400000 2.002950 0.082261,
+                          0.400000 1.792233 0.147444,
+                          0.400000 1.831056 0.002556,
+                          0.400000 2.207767 0.103495,
+                          0.400000 2.168944 0.248384,
+                          0.210000 2.168944 0.248384,
+                          0.210000 1.792233 0.147444,
+                          0.210000 1.831056 0.002556,
+                          0.210000 2.207767 0.103495,
+                          0.210000 2.002950 0.082261,
+                          0.210000 1.838743 0.038262,
+                          0.210000 1.816743 0.120365,
+                          0.210000 1.980951 0.164365,
+                          0.400000 2.161257 0.212678,
+                          0.210000 2.161257 0.212678,
+                          0.400000 1.997050 0.168678,
+                          0.210000 1.997050 0.168678,
+                          0.210000 2.019049 0.086575,
+                          0.210000 2.183257 0.130574,
+                          0.400000 2.183257 0.130574,
+                          0.400000 2.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 2.105000 0.000000,
+                          0.595000 2.105000 0.090000,
+                          0.205000 2.105000 0.000000,
+                          0.205000 2.105000 0.090000,
+                          0.595000 2.195000 0.000000,
+                          0.205000 2.195000 0.000000,
+                          0.205000 2.195000 0.090000,
+                          0.595000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 1.410000 0.164365,
+                          0.216743 1.410000 0.120365,
+                          0.238743 1.410000 0.038262,
+                          0.402950 1.410000 0.082261,
+                          0.192233 1.410000 0.147444,
+                          0.231056 1.410000 0.002556,
+                          0.607767 1.410000 0.103495,
+                          0.568944 1.410000 0.248384,
+                          0.568944 1.600000 0.248384,
+                          0.192233 1.600000 0.147444,
+                          0.231056 1.600000 0.002556,
+                          0.607767 1.600000 0.103495,
+                          0.402950 1.600000 0.082261,
+                          0.238743 1.600000 0.038262,
+                          0.216743 1.600000 0.120365,
+                          0.380951 1.600000 0.164365,
+                          0.561257 1.410000 0.212678,
+                          0.561257 1.600000 0.212678,
+                          0.397050 1.410000 0.168678,
+                          0.397050 1.600000 0.168678,
+                          0.419049 1.600000 0.086575,
+                          0.583257 1.600000 0.130574,
+                          0.583257 1.410000 0.130574,
+                          0.419049 1.410000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 1.600000 0.164365,
+                          0.216743 1.600000 0.120365,
+                          0.238743 1.600000 0.038262,
+                          0.402950 1.600000 0.082261,
+                          0.192233 1.600000 0.147444,
+                          0.231056 1.600000 0.002556,
+                          0.607767 1.600000 0.103495,
+                          0.568944 1.600000 0.248384,
+                          0.568944 1.790000 0.248384,
+                          0.192233 1.790000 0.147444,
+                          0.231056 1.790000 0.002556,
+                          0.607767 1.790000 0.103495,
+                          0.402950 1.790000 0.082261,
+                          0.238743 1.790000 0.038262,
+                          0.216743 1.790000 0.120365,
+                          0.380951 1.790000 0.164365,
+                          0.561257 1.600000 0.212678,
+                          0.561257 1.790000 0.212678,
+                          0.397050 1.600000 0.168678,
+                          0.397050 1.790000 0.168678,
+                          0.419049 1.790000 0.086575,
+                          0.583257 1.790000 0.130574,
+                          0.583257 1.600000 0.130574,
+                          0.419049 1.600000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.505000 1.405000 0.000000,
+                          0.505000 1.405000 0.090000,
+                          0.505000 1.795000 0.000000,
+                          0.505000 1.795000 0.090000,
+                          0.595000 1.405000 0.000000,
+                          0.595000 1.795000 0.000000,
+                          0.595000 1.795000 0.090000,
+                          0.595000 1.405000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.210000 1.219049 0.314365,
+                          0.210000 1.383257 0.270365,
+                          0.210000 1.361257 0.188262,
+                          0.210000 1.197050 0.232261,
+                          0.210000 1.407767 0.297444,
+                          0.210000 1.368944 0.152556,
+                          0.210000 0.992233 0.253495,
+                          0.210000 1.031056 0.398384,
+                          0.400000 1.031056 0.398384,
+                          0.400000 1.407767 0.297444,
+                          0.400000 1.368944 0.152556,
+                          0.400000 0.992233 0.253495,
+                          0.400000 1.197050 0.232261,
+                          0.400000 1.361257 0.188262,
+                          0.400000 1.383257 0.270365,
+                          0.400000 1.219049 0.314365,
+                          0.210000 1.038743 0.362678,
+                          0.400000 1.038743 0.362678,
+                          0.210000 1.202950 0.318678,
+                          0.400000 1.202950 0.318678,
+                          0.400000 1.180951 0.236575,
+                          0.400000 1.016743 0.280574,
+                          0.210000 1.016743 0.280574,
+                          0.210000 1.180951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 1.219049 0.314365,
+                          0.400000 1.383257 0.270365,
+                          0.400000 1.361257 0.188262,
+                          0.400000 1.197050 0.232261,
+                          0.400000 1.407767 0.297444,
+                          0.400000 1.368944 0.152556,
+                          0.400000 0.992233 0.253495,
+                          0.400000 1.031056 0.398384,
+                          0.590000 1.031056 0.398384,
+                          0.590000 1.407767 0.297444,
+                          0.590000 1.368944 0.152556,
+                          0.590000 0.992233 0.253495,
+                          0.590000 1.197050 0.232261,
+                          0.590000 1.361257 0.188262,
+                          0.590000 1.383257 0.270365,
+                          0.590000 1.219049 0.314365,
+                          0.400000 1.038743 0.362678,
+                          0.590000 1.038743 0.362678,
+                          0.400000 1.202950 0.318678,
+                          0.590000 1.202950 0.318678,
+                          0.590000 1.180951 0.236575,
+                          0.590000 1.016743 0.280574,
+                          0.400000 1.016743 0.280574,
+                          0.400000 1.180951 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.205000 1.095000 0.150000,
+                          0.205000 1.095000 0.240000,
+                          0.595000 1.095000 0.150000,
+                          0.595000 1.095000 0.240000,
+                          0.205000 1.005000 0.150000,
+                          0.595000 1.005000 0.150000,
+                          0.595000 1.005000 0.240000,
+                          0.205000 1.005000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.419049 0.990000 0.314365,
+                          0.583257 0.990000 0.270365,
+                          0.561257 0.990000 0.188262,
+                          0.397050 0.990000 0.232261,
+                          0.607767 0.990000 0.297444,
+                          0.568944 0.990000 0.152556,
+                          0.192233 0.990000 0.253495,
+                          0.231056 0.990000 0.398384,
+                          0.231056 0.800000 0.398384,
+                          0.607767 0.800000 0.297444,
+                          0.568944 0.800000 0.152556,
+                          0.192233 0.800000 0.253495,
+                          0.397050 0.800000 0.232261,
+                          0.561257 0.800000 0.188262,
+                          0.583257 0.800000 0.270365,
+                          0.419049 0.800000 0.314365,
+                          0.238743 0.990000 0.362678,
+                          0.238743 0.800000 0.362678,
+                          0.402950 0.990000 0.318678,
+                          0.402950 0.800000 0.318678,
+                          0.380951 0.800000 0.236575,
+                          0.216743 0.800000 0.280574,
+                          0.216743 0.990000 0.280574,
+                          0.380951 0.990000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.419049 0.800000 0.314365,
+                          0.583257 0.800000 0.270365,
+                          0.561257 0.800000 0.188262,
+                          0.397050 0.800000 0.232261,
+                          0.607767 0.800000 0.297444,
+                          0.568944 0.800000 0.152556,
+                          0.192233 0.800000 0.253495,
+                          0.231056 0.800000 0.398384,
+                          0.231056 0.610000 0.398384,
+                          0.607767 0.610000 0.297444,
+                          0.568944 0.610000 0.152556,
+                          0.192233 0.610000 0.253495,
+                          0.397050 0.610000 0.232261,
+                          0.561257 0.610000 0.188262,
+                          0.583257 0.610000 0.270365,
+                          0.419049 0.610000 0.314365,
+                          0.238743 0.800000 0.362678,
+                          0.238743 0.610000 0.362678,
+                          0.402950 0.800000 0.318678,
+                          0.402950 0.610000 0.318678,
+                          0.380951 0.610000 0.236575,
+                          0.216743 0.610000 0.280574,
+                          0.216743 0.800000 0.280574,
+                          0.380951 0.800000 0.236575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.295000 0.995000 0.150000,
+                          0.295000 0.995000 0.240000,
+                          0.295000 0.605000 0.150000,
+                          0.295000 0.605000 0.240000,
+                          0.205000 0.995000 0.150000,
+                          0.205000 0.605000 0.150000,
+                          0.205000 0.605000 0.240000,
+                          0.205000 0.995000 0.240000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.590000 0.380951 0.164365,
+                          0.590000 0.216743 0.120365,
+                          0.590000 0.238743 0.038262,
+                          0.590000 0.402950 0.082261,
+                          0.590000 0.192233 0.147444,
+                          0.590000 0.231056 0.002556,
+                          0.590000 0.607767 0.103495,
+                          0.590000 0.568944 0.248384,
+                          0.400000 0.568944 0.248384,
+                          0.400000 0.192233 0.147444,
+                          0.400000 0.231056 0.002556,
+                          0.400000 0.607767 0.103495,
+                          0.400000 0.402950 0.082261,
+                          0.400000 0.238743 0.038262,
+                          0.400000 0.216743 0.120365,
+                          0.400000 0.380951 0.164365,
+                          0.590000 0.561257 0.212678,
+                          0.400000 0.561257 0.212678,
+                          0.590000 0.397050 0.168678,
+                          0.400000 0.397050 0.168678,
+                          0.400000 0.419049 0.086575,
+                          0.400000 0.583257 0.130574,
+                          0.590000 0.583257 0.130574,
+                          0.590000 0.419049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 0.380951 0.164365,
+                          0.400000 0.216743 0.120365,
+                          0.400000 0.238743 0.038262,
+                          0.400000 0.402950 0.082261,
+                          0.400000 0.192233 0.147444,
+                          0.400000 0.231056 0.002556,
+                          0.400000 0.607767 0.103495,
+                          0.400000 0.568944 0.248384,
+                          0.210000 0.568944 0.248384,
+                          0.210000 0.192233 0.147444,
+                          0.210000 0.231056 0.002556,
+                          0.210000 0.607767 0.103495,
+                          0.210000 0.402950 0.082261,
+                          0.210000 0.238743 0.038262,
+                          0.210000 0.216743 0.120365,
+                          0.210000 0.380951 0.164365,
+                          0.400000 0.561257 0.212678,
+                          0.210000 0.561257 0.212678,
+                          0.400000 0.397050 0.168678,
+                          0.210000 0.397050 0.168678,
+                          0.210000 0.419049 0.086575,
+                          0.210000 0.583257 0.130574,
+                          0.400000 0.583257 0.130574,
+                          0.400000 0.419049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 0.505000 0.000000,
+                          0.595000 0.505000 0.090000,
+                          0.205000 0.505000 0.000000,
+                          0.205000 0.505000 0.090000,
+                          0.595000 0.595000 0.000000,
+                          0.205000 0.595000 0.000000,
+                          0.205000 0.595000 0.090000,
+                          0.595000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 -0.190000 0.164365,
+                          0.216743 -0.190000 0.120365,
+                          0.238743 -0.190000 0.038262,
+                          0.402950 -0.190000 0.082261,
+                          0.192233 -0.190000 0.147444,
+                          0.231056 -0.190000 0.002556,
+                          0.607767 -0.190000 0.103495,
+                          0.568944 -0.190000 0.248384,
+                          0.568944 -0.000000 0.248384,
+                          0.192233 0.000000 0.147444,
+                          0.231056 0.000000 0.002556,
+                          0.607767 -0.000000 0.103495,
+                          0.402950 0.000000 0.082261,
+                          0.238743 -0.000000 0.038262,
+                          0.216743 -0.000000 0.120365,
+                          0.380951 0.000000 0.164365,
+                          0.561257 -0.190000 0.212678,
+                          0.561257 -0.000000 0.212678,
+                          0.397050 -0.190000 0.168678,
+                          0.397050 -0.000000 0.168678,
+                          0.419049 -0.000000 0.086575,
+                          0.583257 -0.000000 0.130574,
+                          0.583257 -0.190000 0.130574,
+                          0.419049 -0.190000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 0.000000 0.164365,
+                          0.216743 0.000000 0.120365,
+                          0.238743 0.000000 0.038262,
+                          0.402950 0.000000 0.082261,
+                          0.192233 0.000000 0.147444,
+                          0.231056 0.000000 0.002556,
+                          0.607767 -0.000000 0.103495,
+                          0.568944 -0.000000 0.248384,
+                          0.568944 0.190000 0.248384,
+                          0.192233 0.190000 0.147444,
+                          0.231056 0.190000 0.002556,
+                          0.607767 0.190000 0.103495,
+                          0.402950 0.190000 0.082261,
+                          0.238743 0.190000 0.038262,
+                          0.216743 0.190000 0.120365,
+                          0.380951 0.190000 0.164365,
+                          0.561257 0.000000 0.212678,
+                          0.561257 0.190000 0.212678,
+                          0.397050 -0.000000 0.168678,
+                          0.397050 0.190000 0.168678,
+                          0.419049 0.190000 0.086575,
+                          0.583257 0.190000 0.130574,
+                          0.583257 0.000000 0.130574,
+                          0.419049 -0.000000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.505000 -0.195000 0.000000,
+                          0.505000 -0.195000 0.090000,
+                          0.505000 0.195000 0.000000,
+                          0.505000 0.195000 0.090000,
+                          0.595000 -0.195000 0.000000,
+                          0.595000 0.195000 0.000000,
+                          0.595000 0.195000 0.090000,
+                          0.595000 -0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 1.810000 0.164365,
+                          -0.183257 1.810000 0.120365,
+                          -0.161257 1.810000 0.038262,
+                          0.002950 1.810000 0.082261,
+                          -0.207767 1.810000 0.147444,
+                          -0.168944 1.810000 0.002556,
+                          0.207767 1.810000 0.103495,
+                          0.168944 1.810000 0.248384,
+                          0.168944 2.000000 0.248384,
+                          -0.207767 2.000000 0.147444,
+                          -0.168944 2.000000 0.002556,
+                          0.207767 2.000000 0.103495,
+                          0.002950 2.000000 0.082261,
+                          -0.161257 2.000000 0.038262,
+                          -0.183257 2.000000 0.120365,
+                          -0.019049 2.000000 0.164365,
+                          0.161257 1.810000 0.212678,
+                          0.161257 2.000000 0.212678,
+                          -0.002950 1.810000 0.168678,
+                          -0.002950 2.000000 0.168678,
+                          0.019049 2.000000 0.086575,
+                          0.183257 2.000000 0.130574,
+                          0.183257 1.810000 0.130574,
+                          0.019049 1.810000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 2.000000 0.164365,
+                          -0.183257 2.000000 0.120365,
+                          -0.161257 2.000000 0.038262,
+                          0.002950 2.000000 0.082261,
+                          -0.207767 2.000000 0.147444,
+                          -0.168944 2.000000 0.002556,
+                          0.207767 2.000000 0.103495,
+                          0.168944 2.000000 0.248384,
+                          0.168944 2.190000 0.248384,
+                          -0.207767 2.190000 0.147444,
+                          -0.168944 2.190000 0.002556,
+                          0.207767 2.190000 0.103495,
+                          0.002950 2.190000 0.082261,
+                          -0.161257 2.190000 0.038262,
+                          -0.183257 2.190000 0.120365,
+                          -0.019049 2.190000 0.164365,
+                          0.161257 2.000000 0.212678,
+                          0.161257 2.190000 0.212678,
+                          -0.002950 2.000000 0.168678,
+                          -0.002950 2.190000 0.168678,
+                          0.019049 2.190000 0.086575,
+                          0.183257 2.190000 0.130574,
+                          0.183257 2.000000 0.130574,
+                          0.019049 2.000000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.105000 1.805000 0.000000,
+                          0.105000 1.805000 0.090000,
+                          0.105000 2.195000 0.000000,
+                          0.105000 2.195000 0.090000,
+                          0.195000 1.805000 0.000000,
+                          0.195000 2.195000 0.000000,
+                          0.195000 2.195000 0.090000,
+                          0.195000 1.805000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.190000 1.619049 0.164365,
+                          -0.190000 1.783257 0.120365,
+                          -0.190000 1.761257 0.038262,
+                          -0.190000 1.597050 0.082261,
+                          -0.190000 1.807767 0.147444,
+                          -0.190000 1.768944 0.002556,
+                          -0.190000 1.392233 0.103495,
+                          -0.190000 1.431056 0.248384,
+                          0.000000 1.431056 0.248384,
+                          0.000000 1.807767 0.147444,
+                          0.000000 1.768944 0.002556,
+                          0.000000 1.392233 0.103495,
+                          0.000000 1.597050 0.082261,
+                          0.000000 1.761257 0.038262,
+                          0.000000 1.783257 0.120365,
+                          0.000000 1.619049 0.164365,
+                          -0.190000 1.438743 0.212678,
+                          0.000000 1.438743 0.212678,
+                          -0.190000 1.602950 0.168678,
+                          0.000000 1.602950 0.168678,
+                          0.000000 1.580951 0.086575,
+                          0.000000 1.416743 0.130574,
+                          -0.190000 1.416743 0.130574,
+                          -0.190000 1.580951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 1.619049 0.164365,
+                          0.000000 1.783257 0.120365,
+                          0.000000 1.761257 0.038262,
+                          0.000000 1.597050 0.082261,
+                          0.000000 1.807767 0.147444,
+                          0.000000 1.768944 0.002556,
+                          0.000000 1.392233 0.103495,
+                          0.000000 1.431056 0.248384,
+                          0.190000 1.431056 0.248384,
+                          0.190000 1.807767 0.147444,
+                          0.190000 1.768944 0.002556,
+                          0.190000 1.392233 0.103495,
+                          0.190000 1.597050 0.082261,
+                          0.190000 1.761257 0.038262,
+                          0.190000 1.783257 0.120365,
+                          0.190000 1.619049 0.164365,
+                          0.000000 1.438743 0.212678,
+                          0.190000 1.438743 0.212678,
+                          0.000000 1.602950 0.168678,
+                          0.190000 1.602950 0.168678,
+                          0.190000 1.580951 0.086575,
+                          0.190000 1.416743 0.130574,
+                          0.000000 1.416743 0.130574,
+                          0.000000 1.580951 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 1.495000 0.000000,
+                          -0.195000 1.495000 0.090000,
+                          0.195000 1.495000 0.000000,
+                          0.195000 1.495000 0.090000,
+                          -0.195000 1.405000 0.000000,
+                          0.195000 1.405000 0.000000,
+                          0.195000 1.405000 0.090000,
+                          -0.195000 1.405000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.019049 1.390000 0.164365,
+                          0.183257 1.390000 0.120365,
+                          0.161257 1.390000 0.038262,
+                          -0.002950 1.390000 0.082261,
+                          0.207767 1.390000 0.147444,
+                          0.168944 1.390000 0.002556,
+                          -0.207767 1.390000 0.103495,
+                          -0.168944 1.390000 0.248384,
+                          -0.168944 1.200000 0.248384,
+                          0.207767 1.200000 0.147444,
+                          0.168944 1.200000 0.002556,
+                          -0.207767 1.200000 0.103495,
+                          -0.002950 1.200000 0.082261,
+                          0.161257 1.200000 0.038262,
+                          0.183257 1.200000 0.120365,
+                          0.019049 1.200000 0.164365,
+                          -0.161257 1.390000 0.212678,
+                          -0.161257 1.200000 0.212678,
+                          0.002950 1.390000 0.168678,
+                          0.002950 1.200000 0.168678,
+                          -0.019049 1.200000 0.086575,
+                          -0.183257 1.200000 0.130574,
+                          -0.183257 1.390000 0.130574,
+                          -0.019049 1.390000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.019049 1.200000 0.164365,
+                          0.183257 1.200000 0.120365,
+                          0.161257 1.200000 0.038262,
+                          -0.002950 1.200000 0.082261,
+                          0.207767 1.200000 0.147444,
+                          0.168944 1.200000 0.002556,
+                          -0.207767 1.200000 0.103495,
+                          -0.168944 1.200000 0.248384,
+                          -0.168944 1.010000 0.248384,
+                          0.207767 1.010000 0.147444,
+                          0.168944 1.010000 0.002556,
+                          -0.207767 1.010000 0.103495,
+                          -0.002950 1.010000 0.082261,
+                          0.161257 1.010000 0.038262,
+                          0.183257 1.010000 0.120365,
+                          0.019049 1.010000 0.164365,
+                          -0.161257 1.200000 0.212678,
+                          -0.161257 1.010000 0.212678,
+                          0.002950 1.200000 0.168678,
+                          0.002950 1.010000 0.168678,
+                          -0.019049 1.010000 0.086575,
+                          -0.183257 1.010000 0.130574,
+                          -0.183257 1.200000 0.130574,
+                          -0.019049 1.200000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.105000 1.395000 0.000000,
+                          -0.105000 1.395000 0.090000,
+                          -0.105000 1.005000 0.000000,
+                          -0.105000 1.005000 0.090000,
+                          -0.195000 1.395000 0.000000,
+                          -0.195000 1.005000 0.000000,
+                          -0.195000 1.005000 0.090000,
+                          -0.195000 1.395000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.190000 0.780951 0.164365,
+                          0.190000 0.616743 0.120365,
+                          0.190000 0.638743 0.038262,
+                          0.190000 0.802950 0.082261,
+                          0.190000 0.592233 0.147444,
+                          0.190000 0.631056 0.002556,
+                          0.190000 1.007767 0.103495,
+                          0.190000 0.968944 0.248384,
+                          0.000000 0.968944 0.248384,
+                          -0.000000 0.592233 0.147444,
+                          -0.000000 0.631056 0.002556,
+                          0.000000 1.007767 0.103495,
+                          0.000000 0.802950 0.082261,
+                          -0.000000 0.638743 0.038262,
+                          -0.000000 0.616743 0.120365,
+                          -0.000000 0.780951 0.164365,
+                          0.190000 0.961257 0.212678,
+                          0.000000 0.961257 0.212678,
+                          0.190000 0.797050 0.168678,
+                          0.000000 0.797050 0.168678,
+                          0.000000 0.819049 0.086575,
+                          0.000000 0.983257 0.130574,
+                          0.190000 0.983257 0.130574,
+                          0.190000 0.819049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.780951 0.164365,
+                          0.000000 0.616743 0.120365,
+                          0.000000 0.638743 0.038262,
+                          0.000000 0.802950 0.082261,
+                          -0.000000 0.592233 0.147444,
+                          0.000000 0.631056 0.002556,
+                          0.000000 1.007767 0.103495,
+                          0.000000 0.968944 0.248384,
+                          -0.190000 0.968944 0.248384,
+                          -0.190000 0.592233 0.147444,
+                          -0.190000 0.631056 0.002556,
+                          -0.190000 1.007767 0.103495,
+                          -0.190000 0.802950 0.082261,
+                          -0.190000 0.638743 0.038262,
+                          -0.190000 0.616743 0.120365,
+                          -0.190000 0.780951 0.164365,
+                          0.000000 0.961257 0.212678,
+                          -0.190000 0.961257 0.212678,
+                          0.000000 0.797050 0.168678,
+                          -0.190000 0.797050 0.168678,
+                          -0.190000 0.819049 0.086575,
+                          -0.190000 0.983257 0.130574,
+                          0.000000 0.983257 0.130574,
+                          0.000000 0.819049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.195000 0.905000 0.000000,
+                          0.195000 0.905000 0.090000,
+                          -0.195000 0.905000 0.000000,
+                          -0.195000 0.905000 0.090000,
+                          0.195000 0.995000 0.000000,
+                          -0.195000 0.995000 0.000000,
+                          -0.195000 0.995000 0.090000,
+                          0.195000 0.995000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 0.210000 0.164365,
+                          -0.183257 0.210000 0.120365,
+                          -0.161257 0.210000 0.038262,
+                          0.002950 0.210000 0.082261,
+                          -0.207767 0.210000 0.147444,
+                          -0.168944 0.210000 0.002556,
+                          0.207767 0.210000 0.103495,
+                          0.168944 0.210000 0.248384,
+                          0.168944 0.400000 0.248384,
+                          -0.207767 0.400000 0.147444,
+                          -0.168944 0.400000 0.002556,
+                          0.207767 0.400000 0.103495,
+                          0.002950 0.400000 0.082261,
+                          -0.161257 0.400000 0.038262,
+                          -0.183257 0.400000 0.120365,
+                          -0.019049 0.400000 0.164365,
+                          0.161257 0.210000 0.212678,
+                          0.161257 0.400000 0.212678,
+                          -0.002950 0.210000 0.168678,
+                          -0.002950 0.400000 0.168678,
+                          0.019049 0.400000 0.086575,
+                          0.183257 0.400000 0.130574,
+                          0.183257 0.210000 0.130574,
+                          0.019049 0.210000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 0.400000 0.164365,
+                          -0.183257 0.400000 0.120365,
+                          -0.161257 0.400000 0.038262,
+                          0.002950 0.400000 0.082261,
+                          -0.207767 0.400000 0.147444,
+                          -0.168944 0.400000 0.002556,
+                          0.207767 0.400000 0.103495,
+                          0.168944 0.400000 0.248384,
+                          0.168944 0.590000 0.248384,
+                          -0.207767 0.590000 0.147444,
+                          -0.168944 0.590000 0.002556,
+                          0.207767 0.590000 0.103495,
+                          0.002950 0.590000 0.082261,
+                          -0.161257 0.590000 0.038262,
+                          -0.183257 0.590000 0.120365,
+                          -0.019049 0.590000 0.164365,
+                          0.161257 0.400000 0.212678,
+                          0.161257 0.590000 0.212678,
+                          -0.002950 0.400000 0.168678,
+                          -0.002950 0.590000 0.168678,
+                          0.019049 0.590000 0.086575,
+                          0.183257 0.590000 0.130574,
+                          0.183257 0.400000 0.130574,
+                          0.019049 0.400000 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.105000 0.205000 0.000000,
+                          0.105000 0.205000 0.090000,
+                          0.105000 0.595000 0.000000,
+                          0.105000 0.595000 0.090000,
+                          0.195000 0.205000 0.000000,
+                          0.195000 0.595000 0.000000,
+                          0.195000 0.595000 0.090000,
+                          0.195000 0.205000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.190000 0.019049 0.164365,
+                          -0.190000 0.183257 0.120365,
+                          -0.190000 0.161257 0.038262,
+                          -0.190000 -0.002950 0.082261,
+                          -0.190000 0.207767 0.147444,
+                          -0.190000 0.168944 0.002556,
+                          -0.190000 -0.207767 0.103495,
+                          -0.190000 -0.168944 0.248384,
+                          0.000000 -0.168944 0.248384,
+                          0.000000 0.207767 0.147444,
+                          0.000000 0.168944 0.002556,
+                          0.000000 -0.207767 0.103495,
+                          0.000000 -0.002950 0.082261,
+                          0.000000 0.161257 0.038262,
+                          0.000000 0.183257 0.120365,
+                          0.000000 0.019049 0.164365,
+                          -0.190000 -0.161257 0.212678,
+                          0.000000 -0.161257 0.212678,
+                          -0.190000 0.002950 0.168678,
+                          0.000000 0.002950 0.168678,
+                          0.000000 -0.019049 0.086575,
+                          0.000000 -0.183257 0.130574,
+                          -0.190000 -0.183257 0.130574,
+                          -0.190000 -0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.019049 0.164365,
+                          0.000000 0.183257 0.120365,
+                          0.000000 0.161257 0.038262,
+                          0.000000 -0.002950 0.082261,
+                          0.000000 0.207767 0.147444,
+                          0.000000 0.168944 0.002556,
+                          0.000000 -0.207767 0.103495,
+                          0.000000 -0.168944 0.248384,
+                          0.190000 -0.168944 0.248384,
+                          0.190000 0.207767 0.147444,
+                          0.190000 0.168944 0.002556,
+                          0.190000 -0.207767 0.103495,
+                          0.190000 -0.002950 0.082261,
+                          0.190000 0.161257 0.038262,
+                          0.190000 0.183257 0.120365,
+                          0.190000 0.019049 0.164365,
+                          0.000000 -0.161257 0.212678,
+                          0.190000 -0.161257 0.212678,
+                          0.000000 0.002950 0.168678,
+                          0.190000 0.002950 0.168678,
+                          0.190000 -0.019049 0.086575,
+                          0.190000 -0.183257 0.130574,
+                          0.000000 -0.183257 0.130574,
+                          0.000000 -0.019049 0.086575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 -0.105000 0.000000,
+                          -0.195000 -0.105000 0.090000,
+                          0.195000 -0.105000 0.000000,
+                          0.195000 -0.105000 0.090000,
+                          -0.195000 -0.195000 0.000000,
+                          0.195000 -0.195000 0.000000,
+                          0.195000 -0.195000 0.090000,
+                          -0.195000 -0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+             ]
+          } #Segment
+       ]
+    } #WAIST
+   ] # END of HumanoidBody
+
+   joints [
+    USE WAIST
+   ]
+
+   segments [
+    USE ROOT-LINK_S
+   ]
+
+}

--- a/sample/environments/DRCTestbedTerrainUSBlock.wrl
+++ b/sample/environments/DRCTestbedTerrainUSBlock.wrl
@@ -1,0 +1,8694 @@
+#VRML V2.0 utf8
+
+# Produced by EusLisp 9.11(f542489 1.0.3 66193) for Linux64 created on W540-nozawa(Thu Mar 19 17:30:45 JST 2015)
+# Date: Thu Mar 19 18:34:09 2015
+
+
+PROTO Joint [
+ exposedField     SFVec3f      center              0 0 0
+ exposedField     MFNode       children            []
+ exposedField     MFFloat      llimit              []
+ exposedField     SFRotation   limitOrientation    0 0 1 0
+ exposedField     SFString     name                ""
+ exposedField     SFRotation   rotation            0 0 1 0
+ exposedField     SFVec3f      scale               1 1 1
+ exposedField     SFRotation   scaleOrientation    0 0 1 0
+ exposedField     MFFloat      stiffness           [ 0 0 0 ]
+ exposedField     SFVec3f      translation         0 0 0
+ exposedField     MFFloat      ulimit              []
+ exposedField     MFFloat      dh                  [0 0 0 0]
+ exposedField     SFString     jointType           ""
+ exposedField     SFInt32      jointId             -1
+ exposedField     SFVec3f     jointAxis           0 0 1
+]
+{
+   Transform {
+      center           IS center
+      children         IS children
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+   }
+}
+
+PROTO Segment [
+ field           SFVec3f     bboxCenter        0 0 0
+ field           SFVec3f     bboxSize          -1 -1 -1
+ exposedField    SFVec3f     centerOfMass      0 0 0
+ exposedField    MFNode      children          [ ]
+ exposedField    SFNode      coord             NULL
+ exposedField    MFNode      displacers        [ ]
+ exposedField    SFFloat     mass              0
+ exposedField    MFFloat     momentsOfInertia  [ 0 0 0 0 0 0 0 0 0 ]
+ exposedField    SFString    name              ""
+ eventIn         MFNode      addChildren
+ eventIn         MFNode      removeChildren
+]
+{
+   Group {
+      addChildren    IS addChildren
+      bboxCenter     IS bboxCenter
+      bboxSize       IS bboxSize
+      children       IS children
+      removeChildren IS removeChildren
+   }
+}
+
+
+PROTO Humanoid [
+ field           SFVec3f    bboxCenter            0 0 0
+ field           SFVec3f    bboxSize              -1 -1 -1
+ exposedField    SFVec3f    center                0 0 0
+ exposedField    MFNode     humanoidBody          [ ]
+ exposedField    MFString   info                  [ ]
+ exposedField    MFNode     joints                [ ]
+ exposedField    SFString   name                  ""
+ exposedField    SFRotation rotation              0 0 1 0
+ exposedField    SFVec3f    scale                 1 1 1
+ exposedField    SFRotation scaleOrientation      0 0 1 0
+ exposedField    MFNode     segments              [ ]
+ exposedField    MFNode     sites                 [ ]
+ exposedField    SFVec3f    translation           0 0 0
+ exposedField    SFString   version               "1.1"
+ exposedField    MFNode     viewpoints            [ ]
+]
+{
+   Transform {
+      bboxCenter       IS bboxCenter
+      bboxSize         IS bboxSize
+      center           IS center
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+      children [
+         Group {
+            children IS viewpoints
+         }
+         Group {
+            children IS humanoidBody
+         }
+      ]
+   }
+}
+
+
+PROTO VisionSensor [
+  exposedField SFVec3f    translation       0 0 0
+  exposedField SFRotation rotation              0 0 1 0
+  #exposedField SFRotation orientation       0 0 1 0
+  exposedField SFFloat    fieldOfView       0.785398
+  exposedField SFString   name              ""
+  exposedField SFFloat    frontClipDistance 0.01
+  exposedField SFFloat    backClipDistance  10.0
+  exposedField SFString   type              "NONE"
+  exposedField SFInt32    sensorId          -1
+  exposedField SFInt32    width             320  # 
+  exposedField SFInt32    height            240  # 
+  #exposedField MFNode       children            [] # for me
+]
+{
+  Transform {
+    rotation         IS rotation
+    translation      IS translation
+    #children IS children # for me
+  }
+}
+
+
+PROTO ForceSensor [
+  exposedField SFVec3f maxForce -1 -1 -1
+  exposedField SFVec3f maxTorque -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO Gyro [
+  exposedField SFVec3f maxAngularVelocity -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO AccelerationSensor [
+  exposedField SFVec3f maxAcceleration -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO PressureSensor [
+  exposedField SFFloat maxPressure -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+
+NavigationInfo {
+   avatarSize    0.5
+   headlight     TRUE
+   type  ["EXAMINE", "ANY"]
+}
+Viewpoint {
+   position    3 0 0.835
+   orientation 0.5770 0.5775 0.5775 2.0935
+}
+DEF DRCTestbedTerrainUSBlock Humanoid {
+   humanoidBody [
+    DEF WAIST Joint {
+       jointType "fixed"
+       dh [0 0 0 0]
+       translation 0.000000 0.000000 0.000000
+       rotation 0.0 0.0 1.0 0
+       children [
+          DEF ROOT-LINK_S Segment {
+             centerOfMass 0.0 0.0 0.0
+             mass 0.001
+             momentsOfInertia [ 1.000000e-09 0.0 0.0 0.0 1.000000e-09 0.0 0.0 0.0 1.000000e-09 ]
+             children [
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 2.195000 0.159365,
+                          2.583257 2.195000 0.115365,
+                          2.561257 2.195000 0.033262,
+                          2.397050 2.195000 0.077261,
+                          2.606473 2.195000 0.137615,
+                          2.570238 2.195000 0.002385,
+                          2.193527 2.195000 0.103325,
+                          2.229762 2.195000 0.238554,
+                          2.229762 2.000000 0.238554,
+                          2.606473 2.000000 0.137615,
+                          2.570238 2.000000 0.002385,
+                          2.193527 2.000000 0.103325,
+                          2.397050 2.000000 0.077261,
+                          2.561257 2.000000 0.033262,
+                          2.583257 2.000000 0.115365,
+                          2.419049 2.000000 0.159365,
+                          2.238743 2.195000 0.207678,
+                          2.238743 2.000000 0.207678,
+                          2.402950 2.195000 0.163678,
+                          2.402950 2.000000 0.163678,
+                          2.380951 2.000000 0.081575,
+                          2.216743 2.000000 0.125574,
+                          2.216743 2.195000 0.125574,
+                          2.380951 2.195000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 2.000000 0.159365,
+                          2.583257 2.000000 0.115365,
+                          2.561257 2.000000 0.033262,
+                          2.397050 2.000000 0.077261,
+                          2.606473 2.000000 0.137615,
+                          2.570238 2.000000 0.002385,
+                          2.193527 2.000000 0.103325,
+                          2.229762 2.000000 0.238554,
+                          2.229762 1.805000 0.238554,
+                          2.606473 1.805000 0.137615,
+                          2.570238 1.805000 0.002385,
+                          2.193527 1.805000 0.103325,
+                          2.397050 1.805000 0.077261,
+                          2.561257 1.805000 0.033262,
+                          2.583257 1.805000 0.115365,
+                          2.419049 1.805000 0.159365,
+                          2.238743 2.000000 0.207678,
+                          2.238743 1.805000 0.207678,
+                          2.402950 2.000000 0.163678,
+                          2.402950 1.805000 0.163678,
+                          2.380951 1.805000 0.081575,
+                          2.216743 1.805000 0.125574,
+                          2.216743 2.000000 0.125574,
+                          2.380951 2.000000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.295000 2.195000 0.000000,
+                          2.295000 2.195000 0.090000,
+                          2.295000 1.805000 0.000000,
+                          2.295000 1.805000 0.090000,
+                          2.205000 2.195000 0.000000,
+                          2.205000 1.805000 0.000000,
+                          2.205000 1.805000 0.090000,
+                          2.205000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 1.580951 0.159365,
+                          2.595000 1.416743 0.115365,
+                          2.595000 1.438743 0.033262,
+                          2.595000 1.602950 0.077261,
+                          2.595000 1.393527 0.137615,
+                          2.595000 1.429762 0.002385,
+                          2.595000 1.806473 0.103325,
+                          2.595000 1.770238 0.238554,
+                          2.400000 1.770238 0.238554,
+                          2.400000 1.393527 0.137615,
+                          2.400000 1.429762 0.002385,
+                          2.400000 1.806473 0.103325,
+                          2.400000 1.602950 0.077261,
+                          2.400000 1.438743 0.033262,
+                          2.400000 1.416743 0.115365,
+                          2.400000 1.580951 0.159365,
+                          2.595000 1.761257 0.207678,
+                          2.400000 1.761257 0.207678,
+                          2.595000 1.597050 0.163678,
+                          2.400000 1.597050 0.163678,
+                          2.400000 1.619049 0.081575,
+                          2.400000 1.783257 0.125574,
+                          2.595000 1.783257 0.125574,
+                          2.595000 1.619049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 1.580951 0.159365,
+                          2.400000 1.416743 0.115365,
+                          2.400000 1.438743 0.033262,
+                          2.400000 1.602950 0.077261,
+                          2.400000 1.393527 0.137615,
+                          2.400000 1.429762 0.002385,
+                          2.400000 1.806473 0.103325,
+                          2.400000 1.770238 0.238554,
+                          2.205000 1.770238 0.238554,
+                          2.205000 1.393527 0.137615,
+                          2.205000 1.429762 0.002385,
+                          2.205000 1.806473 0.103325,
+                          2.205000 1.602950 0.077261,
+                          2.205000 1.438743 0.033262,
+                          2.205000 1.416743 0.115365,
+                          2.205000 1.580951 0.159365,
+                          2.400000 1.761257 0.207678,
+                          2.205000 1.761257 0.207678,
+                          2.400000 1.597050 0.163678,
+                          2.205000 1.597050 0.163678,
+                          2.205000 1.619049 0.081575,
+                          2.205000 1.783257 0.125574,
+                          2.400000 1.783257 0.125574,
+                          2.400000 1.619049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 1.705000 0.000000,
+                          2.595000 1.705000 0.090000,
+                          2.205000 1.705000 0.000000,
+                          2.205000 1.705000 0.090000,
+                          2.595000 1.795000 0.000000,
+                          2.205000 1.795000 0.000000,
+                          2.205000 1.795000 0.090000,
+                          2.595000 1.795000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.380951 1.005000 0.159365,
+                          2.216743 1.005000 0.115365,
+                          2.238743 1.005000 0.033262,
+                          2.402950 1.005000 0.077261,
+                          2.193527 1.005000 0.137615,
+                          2.229762 1.005000 0.002385,
+                          2.606473 1.005000 0.103325,
+                          2.570238 1.005000 0.238554,
+                          2.570238 1.200000 0.238554,
+                          2.193527 1.200000 0.137615,
+                          2.229762 1.200000 0.002385,
+                          2.606473 1.200000 0.103325,
+                          2.402950 1.200000 0.077261,
+                          2.238743 1.200000 0.033262,
+                          2.216743 1.200000 0.115365,
+                          2.380951 1.200000 0.159365,
+                          2.561257 1.005000 0.207678,
+                          2.561257 1.200000 0.207678,
+                          2.397050 1.005000 0.163678,
+                          2.397050 1.200000 0.163678,
+                          2.419049 1.200000 0.081575,
+                          2.583257 1.200000 0.125574,
+                          2.583257 1.005000 0.125574,
+                          2.419049 1.005000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.380951 1.200000 0.159365,
+                          2.216743 1.200000 0.115365,
+                          2.238743 1.200000 0.033262,
+                          2.402950 1.200000 0.077261,
+                          2.193527 1.200000 0.137615,
+                          2.229762 1.200000 0.002385,
+                          2.606473 1.200000 0.103325,
+                          2.570238 1.200000 0.238554,
+                          2.570238 1.395000 0.238554,
+                          2.193527 1.395000 0.137615,
+                          2.229762 1.395000 0.002385,
+                          2.606473 1.395000 0.103325,
+                          2.402950 1.395000 0.077261,
+                          2.238743 1.395000 0.033262,
+                          2.216743 1.395000 0.115365,
+                          2.380951 1.395000 0.159365,
+                          2.561257 1.200000 0.207678,
+                          2.561257 1.395000 0.207678,
+                          2.397050 1.200000 0.163678,
+                          2.397050 1.395000 0.163678,
+                          2.419049 1.395000 0.081575,
+                          2.583257 1.395000 0.125574,
+                          2.583257 1.200000 0.125574,
+                          2.419049 1.200000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.505000 1.005000 0.000000,
+                          2.505000 1.005000 0.090000,
+                          2.505000 1.395000 0.000000,
+                          2.505000 1.395000 0.090000,
+                          2.595000 1.005000 0.000000,
+                          2.595000 1.395000 0.000000,
+                          2.595000 1.395000 0.090000,
+                          2.595000 1.005000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.205000 0.819049 0.159365,
+                          2.205000 0.983257 0.115365,
+                          2.205000 0.961257 0.033262,
+                          2.205000 0.797050 0.077261,
+                          2.205000 1.006473 0.137615,
+                          2.205000 0.970238 0.002385,
+                          2.205000 0.593527 0.103325,
+                          2.205000 0.629762 0.238554,
+                          2.400000 0.629762 0.238554,
+                          2.400000 1.006473 0.137615,
+                          2.400000 0.970238 0.002385,
+                          2.400000 0.593527 0.103325,
+                          2.400000 0.797050 0.077261,
+                          2.400000 0.961257 0.033262,
+                          2.400000 0.983257 0.115365,
+                          2.400000 0.819049 0.159365,
+                          2.205000 0.638743 0.207678,
+                          2.400000 0.638743 0.207678,
+                          2.205000 0.802950 0.163678,
+                          2.400000 0.802950 0.163678,
+                          2.400000 0.780951 0.081575,
+                          2.400000 0.616743 0.125574,
+                          2.205000 0.616743 0.125574,
+                          2.205000 0.780951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 0.819049 0.159365,
+                          2.400000 0.983257 0.115365,
+                          2.400000 0.961257 0.033262,
+                          2.400000 0.797050 0.077261,
+                          2.400000 1.006473 0.137615,
+                          2.400000 0.970238 0.002385,
+                          2.400000 0.593527 0.103325,
+                          2.400000 0.629762 0.238554,
+                          2.595000 0.629762 0.238554,
+                          2.595000 1.006473 0.137615,
+                          2.595000 0.970238 0.002385,
+                          2.595000 0.593527 0.103325,
+                          2.595000 0.797050 0.077261,
+                          2.595000 0.961257 0.033262,
+                          2.595000 0.983257 0.115365,
+                          2.595000 0.819049 0.159365,
+                          2.400000 0.638743 0.207678,
+                          2.595000 0.638743 0.207678,
+                          2.400000 0.802950 0.163678,
+                          2.595000 0.802950 0.163678,
+                          2.595000 0.780951 0.081575,
+                          2.595000 0.616743 0.125574,
+                          2.400000 0.616743 0.125574,
+                          2.400000 0.780951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.205000 0.695000 0.000000,
+                          2.205000 0.695000 0.090000,
+                          2.595000 0.695000 0.000000,
+                          2.595000 0.695000 0.090000,
+                          2.205000 0.605000 0.000000,
+                          2.595000 0.605000 0.000000,
+                          2.595000 0.605000 0.090000,
+                          2.205000 0.605000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 0.595000 0.159365,
+                          2.583257 0.595000 0.115365,
+                          2.561257 0.595000 0.033262,
+                          2.397050 0.595000 0.077261,
+                          2.606473 0.595000 0.137615,
+                          2.570238 0.595000 0.002385,
+                          2.193527 0.595000 0.103325,
+                          2.229762 0.595000 0.238554,
+                          2.229762 0.400000 0.238554,
+                          2.606473 0.400000 0.137615,
+                          2.570238 0.400000 0.002385,
+                          2.193527 0.400000 0.103325,
+                          2.397050 0.400000 0.077261,
+                          2.561257 0.400000 0.033262,
+                          2.583257 0.400000 0.115365,
+                          2.419049 0.400000 0.159365,
+                          2.238743 0.595000 0.207678,
+                          2.238743 0.400000 0.207678,
+                          2.402950 0.595000 0.163678,
+                          2.402950 0.400000 0.163678,
+                          2.380951 0.400000 0.081575,
+                          2.216743 0.400000 0.125574,
+                          2.216743 0.595000 0.125574,
+                          2.380951 0.595000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.419049 0.400000 0.159365,
+                          2.583257 0.400000 0.115365,
+                          2.561257 0.400000 0.033262,
+                          2.397050 0.400000 0.077261,
+                          2.606473 0.400000 0.137615,
+                          2.570238 0.400000 0.002385,
+                          2.193527 0.400000 0.103325,
+                          2.229762 0.400000 0.238554,
+                          2.229762 0.205000 0.238554,
+                          2.606473 0.205000 0.137615,
+                          2.570238 0.205000 0.002385,
+                          2.193527 0.205000 0.103325,
+                          2.397050 0.205000 0.077261,
+                          2.561257 0.205000 0.033262,
+                          2.583257 0.205000 0.115365,
+                          2.419049 0.205000 0.159365,
+                          2.238743 0.400000 0.207678,
+                          2.238743 0.205000 0.207678,
+                          2.402950 0.400000 0.163678,
+                          2.402950 0.205000 0.163678,
+                          2.380951 0.205000 0.081575,
+                          2.216743 0.205000 0.125574,
+                          2.216743 0.400000 0.125574,
+                          2.380951 0.400000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.295000 0.595000 0.000000,
+                          2.295000 0.595000 0.090000,
+                          2.295000 0.205000 0.000000,
+                          2.295000 0.205000 0.090000,
+                          2.205000 0.595000 0.000000,
+                          2.205000 0.205000 0.000000,
+                          2.205000 0.205000 0.090000,
+                          2.205000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 -0.019049 0.159365,
+                          2.595000 -0.183257 0.115365,
+                          2.595000 -0.161257 0.033262,
+                          2.595000 0.002950 0.077261,
+                          2.595000 -0.206473 0.137615,
+                          2.595000 -0.170238 0.002385,
+                          2.595000 0.206473 0.103325,
+                          2.595000 0.170238 0.238554,
+                          2.400000 0.170238 0.238554,
+                          2.400000 -0.206473 0.137615,
+                          2.400000 -0.170238 0.002385,
+                          2.400000 0.206473 0.103325,
+                          2.400000 0.002950 0.077261,
+                          2.400000 -0.161257 0.033262,
+                          2.400000 -0.183257 0.115365,
+                          2.400000 -0.019049 0.159365,
+                          2.595000 0.161257 0.207678,
+                          2.400000 0.161257 0.207678,
+                          2.595000 -0.002950 0.163678,
+                          2.400000 -0.002950 0.163678,
+                          2.400000 0.019049 0.081575,
+                          2.400000 0.183257 0.125574,
+                          2.595000 0.183257 0.125574,
+                          2.595000 0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.400000 -0.019049 0.159365,
+                          2.400000 -0.183257 0.115365,
+                          2.400000 -0.161257 0.033262,
+                          2.400000 0.002950 0.077261,
+                          2.400000 -0.206473 0.137615,
+                          2.400000 -0.170238 0.002385,
+                          2.400000 0.206473 0.103325,
+                          2.400000 0.170238 0.238554,
+                          2.205000 0.170238 0.238554,
+                          2.205000 -0.206473 0.137615,
+                          2.205000 -0.170238 0.002385,
+                          2.205000 0.206473 0.103325,
+                          2.205000 0.002950 0.077261,
+                          2.205000 -0.161257 0.033262,
+                          2.205000 -0.183257 0.115365,
+                          2.205000 -0.019049 0.159365,
+                          2.400000 0.161257 0.207678,
+                          2.205000 0.161257 0.207678,
+                          2.400000 -0.002950 0.163678,
+                          2.205000 -0.002950 0.163678,
+                          2.205000 0.019049 0.081575,
+                          2.205000 0.183257 0.125574,
+                          2.400000 0.183257 0.125574,
+                          2.400000 0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.595000 0.105000 0.000000,
+                          2.595000 0.105000 0.090000,
+                          2.205000 0.105000 0.000000,
+                          2.205000 0.105000 0.090000,
+                          2.595000 0.195000 0.000000,
+                          2.205000 0.195000 0.000000,
+                          2.205000 0.195000 0.090000,
+                          2.595000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 1.980951 0.299365,
+                          2.195000 1.816743 0.255365,
+                          2.195000 1.838743 0.173262,
+                          2.195000 2.002950 0.217261,
+                          2.195000 1.793527 0.277615,
+                          2.195000 1.829762 0.142385,
+                          2.195000 2.206473 0.243325,
+                          2.195000 2.170238 0.378554,
+                          2.000000 2.170238 0.378554,
+                          2.000000 1.793527 0.277615,
+                          2.000000 1.829762 0.142385,
+                          2.000000 2.206473 0.243325,
+                          2.000000 2.002950 0.217261,
+                          2.000000 1.838743 0.173262,
+                          2.000000 1.816743 0.255365,
+                          2.000000 1.980951 0.299365,
+                          2.195000 2.161257 0.347678,
+                          2.000000 2.161257 0.347678,
+                          2.195000 1.997050 0.303678,
+                          2.000000 1.997050 0.303678,
+                          2.000000 2.019049 0.221575,
+                          2.000000 2.183257 0.265574,
+                          2.195000 2.183257 0.265574,
+                          2.195000 2.019049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 1.980951 0.299365,
+                          2.000000 1.816743 0.255365,
+                          2.000000 1.838743 0.173262,
+                          2.000000 2.002950 0.217261,
+                          2.000000 1.793527 0.277615,
+                          2.000000 1.829762 0.142385,
+                          2.000000 2.206473 0.243325,
+                          2.000000 2.170238 0.378554,
+                          1.805000 2.170238 0.378554,
+                          1.805000 1.793527 0.277615,
+                          1.805000 1.829762 0.142385,
+                          1.805000 2.206473 0.243325,
+                          1.805000 2.002950 0.217261,
+                          1.805000 1.838743 0.173262,
+                          1.805000 1.816743 0.255365,
+                          1.805000 1.980951 0.299365,
+                          2.000000 2.161257 0.347678,
+                          1.805000 2.161257 0.347678,
+                          2.000000 1.997050 0.303678,
+                          1.805000 1.997050 0.303678,
+                          1.805000 2.019049 0.221575,
+                          1.805000 2.183257 0.265574,
+                          2.000000 2.183257 0.265574,
+                          2.000000 2.019049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 2.105000 0.140000,
+                          2.195000 2.105000 0.230000,
+                          1.805000 2.105000 0.140000,
+                          1.805000 2.105000 0.230000,
+                          2.195000 2.195000 0.140000,
+                          1.805000 2.195000 0.140000,
+                          1.805000 2.195000 0.230000,
+                          2.195000 2.195000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 1.405000 0.299365,
+                          1.816743 1.405000 0.255365,
+                          1.838743 1.405000 0.173262,
+                          2.002950 1.405000 0.217261,
+                          1.793527 1.405000 0.277615,
+                          1.829762 1.405000 0.142385,
+                          2.206473 1.405000 0.243325,
+                          2.170238 1.405000 0.378554,
+                          2.170238 1.600000 0.378554,
+                          1.793527 1.600000 0.277615,
+                          1.829762 1.600000 0.142385,
+                          2.206473 1.600000 0.243325,
+                          2.002950 1.600000 0.217261,
+                          1.838743 1.600000 0.173262,
+                          1.816743 1.600000 0.255365,
+                          1.980951 1.600000 0.299365,
+                          2.161257 1.405000 0.347678,
+                          2.161257 1.600000 0.347678,
+                          1.997050 1.405000 0.303678,
+                          1.997050 1.600000 0.303678,
+                          2.019049 1.600000 0.221575,
+                          2.183257 1.600000 0.265574,
+                          2.183257 1.405000 0.265574,
+                          2.019049 1.405000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 1.600000 0.299365,
+                          1.816743 1.600000 0.255365,
+                          1.838743 1.600000 0.173262,
+                          2.002950 1.600000 0.217261,
+                          1.793527 1.600000 0.277615,
+                          1.829762 1.600000 0.142385,
+                          2.206473 1.600000 0.243325,
+                          2.170238 1.600000 0.378554,
+                          2.170238 1.795000 0.378554,
+                          1.793527 1.795000 0.277615,
+                          1.829762 1.795000 0.142385,
+                          2.206473 1.795000 0.243325,
+                          2.002950 1.795000 0.217261,
+                          1.838743 1.795000 0.173262,
+                          1.816743 1.795000 0.255365,
+                          1.980951 1.795000 0.299365,
+                          2.161257 1.600000 0.347678,
+                          2.161257 1.795000 0.347678,
+                          1.997050 1.600000 0.303678,
+                          1.997050 1.795000 0.303678,
+                          2.019049 1.795000 0.221575,
+                          2.183257 1.795000 0.265574,
+                          2.183257 1.600000 0.265574,
+                          2.019049 1.600000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 1.405000 0.140000,
+                          2.105000 1.405000 0.230000,
+                          2.105000 1.795000 0.140000,
+                          2.105000 1.795000 0.230000,
+                          2.195000 1.405000 0.140000,
+                          2.195000 1.795000 0.140000,
+                          2.195000 1.795000 0.230000,
+                          2.195000 1.405000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.805000 1.219049 0.299365,
+                          1.805000 1.383257 0.255365,
+                          1.805000 1.361257 0.173262,
+                          1.805000 1.197050 0.217261,
+                          1.805000 1.406473 0.277615,
+                          1.805000 1.370238 0.142385,
+                          1.805000 0.993527 0.243325,
+                          1.805000 1.029762 0.378554,
+                          2.000000 1.029762 0.378554,
+                          2.000000 1.406473 0.277615,
+                          2.000000 1.370238 0.142385,
+                          2.000000 0.993527 0.243325,
+                          2.000000 1.197050 0.217261,
+                          2.000000 1.361257 0.173262,
+                          2.000000 1.383257 0.255365,
+                          2.000000 1.219049 0.299365,
+                          1.805000 1.038743 0.347678,
+                          2.000000 1.038743 0.347678,
+                          1.805000 1.202950 0.303678,
+                          2.000000 1.202950 0.303678,
+                          2.000000 1.180951 0.221575,
+                          2.000000 1.016743 0.265574,
+                          1.805000 1.016743 0.265574,
+                          1.805000 1.180951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 1.219049 0.299365,
+                          2.000000 1.383257 0.255365,
+                          2.000000 1.361257 0.173262,
+                          2.000000 1.197050 0.217261,
+                          2.000000 1.406473 0.277615,
+                          2.000000 1.370238 0.142385,
+                          2.000000 0.993527 0.243325,
+                          2.000000 1.029762 0.378554,
+                          2.195000 1.029762 0.378554,
+                          2.195000 1.406473 0.277615,
+                          2.195000 1.370238 0.142385,
+                          2.195000 0.993527 0.243325,
+                          2.195000 1.197050 0.217261,
+                          2.195000 1.361257 0.173262,
+                          2.195000 1.383257 0.255365,
+                          2.195000 1.219049 0.299365,
+                          2.000000 1.038743 0.347678,
+                          2.195000 1.038743 0.347678,
+                          2.000000 1.202950 0.303678,
+                          2.195000 1.202950 0.303678,
+                          2.195000 1.180951 0.221575,
+                          2.195000 1.016743 0.265574,
+                          2.000000 1.016743 0.265574,
+                          2.000000 1.180951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.805000 1.095000 0.140000,
+                          1.805000 1.095000 0.230000,
+                          2.195000 1.095000 0.140000,
+                          2.195000 1.095000 0.230000,
+                          1.805000 1.005000 0.140000,
+                          2.195000 1.005000 0.140000,
+                          2.195000 1.005000 0.230000,
+                          1.805000 1.005000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.019049 0.995000 0.299365,
+                          2.183257 0.995000 0.255365,
+                          2.161257 0.995000 0.173262,
+                          1.997050 0.995000 0.217261,
+                          2.206473 0.995000 0.277615,
+                          2.170238 0.995000 0.142385,
+                          1.793527 0.995000 0.243325,
+                          1.829762 0.995000 0.378554,
+                          1.829762 0.800000 0.378554,
+                          2.206473 0.800000 0.277615,
+                          2.170238 0.800000 0.142385,
+                          1.793527 0.800000 0.243325,
+                          1.997050 0.800000 0.217261,
+                          2.161257 0.800000 0.173262,
+                          2.183257 0.800000 0.255365,
+                          2.019049 0.800000 0.299365,
+                          1.838743 0.995000 0.347678,
+                          1.838743 0.800000 0.347678,
+                          2.002950 0.995000 0.303678,
+                          2.002950 0.800000 0.303678,
+                          1.980951 0.800000 0.221575,
+                          1.816743 0.800000 0.265574,
+                          1.816743 0.995000 0.265574,
+                          1.980951 0.995000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.019049 0.800000 0.299365,
+                          2.183257 0.800000 0.255365,
+                          2.161257 0.800000 0.173262,
+                          1.997050 0.800000 0.217261,
+                          2.206473 0.800000 0.277615,
+                          2.170238 0.800000 0.142385,
+                          1.793527 0.800000 0.243325,
+                          1.829762 0.800000 0.378554,
+                          1.829762 0.605000 0.378554,
+                          2.206473 0.605000 0.277615,
+                          2.170238 0.605000 0.142385,
+                          1.793527 0.605000 0.243325,
+                          1.997050 0.605000 0.217261,
+                          2.161257 0.605000 0.173262,
+                          2.183257 0.605000 0.255365,
+                          2.019049 0.605000 0.299365,
+                          1.838743 0.800000 0.347678,
+                          1.838743 0.605000 0.347678,
+                          2.002950 0.800000 0.303678,
+                          2.002950 0.605000 0.303678,
+                          1.980951 0.605000 0.221575,
+                          1.816743 0.605000 0.265574,
+                          1.816743 0.800000 0.265574,
+                          1.980951 0.800000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.895000 0.995000 0.140000,
+                          1.895000 0.995000 0.230000,
+                          1.895000 0.605000 0.140000,
+                          1.895000 0.605000 0.230000,
+                          1.805000 0.995000 0.140000,
+                          1.805000 0.605000 0.140000,
+                          1.805000 0.605000 0.230000,
+                          1.805000 0.995000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 0.380951 0.299365,
+                          2.195000 0.216743 0.255365,
+                          2.195000 0.238743 0.173262,
+                          2.195000 0.402950 0.217261,
+                          2.195000 0.193527 0.277615,
+                          2.195000 0.229762 0.142385,
+                          2.195000 0.606473 0.243325,
+                          2.195000 0.570238 0.378554,
+                          2.000000 0.570238 0.378554,
+                          2.000000 0.193527 0.277615,
+                          2.000000 0.229762 0.142385,
+                          2.000000 0.606473 0.243325,
+                          2.000000 0.402950 0.217261,
+                          2.000000 0.238743 0.173262,
+                          2.000000 0.216743 0.255365,
+                          2.000000 0.380951 0.299365,
+                          2.195000 0.561257 0.347678,
+                          2.000000 0.561257 0.347678,
+                          2.195000 0.397050 0.303678,
+                          2.000000 0.397050 0.303678,
+                          2.000000 0.419049 0.221575,
+                          2.000000 0.583257 0.265574,
+                          2.195000 0.583257 0.265574,
+                          2.195000 0.419049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.000000 0.380951 0.299365,
+                          2.000000 0.216743 0.255365,
+                          2.000000 0.238743 0.173262,
+                          2.000000 0.402950 0.217261,
+                          2.000000 0.193527 0.277615,
+                          2.000000 0.229762 0.142385,
+                          2.000000 0.606473 0.243325,
+                          2.000000 0.570238 0.378554,
+                          1.805000 0.570238 0.378554,
+                          1.805000 0.193527 0.277615,
+                          1.805000 0.229762 0.142385,
+                          1.805000 0.606473 0.243325,
+                          1.805000 0.402950 0.217261,
+                          1.805000 0.238743 0.173262,
+                          1.805000 0.216743 0.255365,
+                          1.805000 0.380951 0.299365,
+                          2.000000 0.561257 0.347678,
+                          1.805000 0.561257 0.347678,
+                          2.000000 0.397050 0.303678,
+                          1.805000 0.397050 0.303678,
+                          1.805000 0.419049 0.221575,
+                          1.805000 0.583257 0.265574,
+                          2.000000 0.583257 0.265574,
+                          2.000000 0.419049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.195000 0.505000 0.140000,
+                          2.195000 0.505000 0.230000,
+                          1.805000 0.505000 0.140000,
+                          1.805000 0.505000 0.230000,
+                          2.195000 0.595000 0.140000,
+                          1.805000 0.595000 0.140000,
+                          1.805000 0.595000 0.230000,
+                          2.195000 0.595000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 -0.195000 0.299365,
+                          1.816743 -0.195000 0.255365,
+                          1.838743 -0.195000 0.173262,
+                          2.002950 -0.195000 0.217261,
+                          1.793527 -0.195000 0.277615,
+                          1.829762 -0.195000 0.142385,
+                          2.206473 -0.195000 0.243325,
+                          2.170238 -0.195000 0.378554,
+                          2.170238 -0.000000 0.378554,
+                          1.793527 0.000000 0.277615,
+                          1.829762 0.000000 0.142385,
+                          2.206473 -0.000000 0.243325,
+                          2.002950 0.000000 0.217261,
+                          1.838743 -0.000000 0.173262,
+                          1.816743 -0.000000 0.255365,
+                          1.980951 0.000000 0.299365,
+                          2.161257 -0.195000 0.347678,
+                          2.161257 -0.000000 0.347678,
+                          1.997050 -0.195000 0.303678,
+                          1.997050 -0.000000 0.303678,
+                          2.019049 -0.000000 0.221575,
+                          2.183257 -0.000000 0.265574,
+                          2.183257 -0.195000 0.265574,
+                          2.019049 -0.195000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.980951 0.000000 0.299365,
+                          1.816743 -0.000000 0.255365,
+                          1.838743 -0.000000 0.173262,
+                          2.002950 0.000000 0.217261,
+                          1.793527 0.000000 0.277615,
+                          1.829762 0.000000 0.142385,
+                          2.206473 -0.000000 0.243325,
+                          2.170238 -0.000000 0.378554,
+                          2.170238 0.195000 0.378554,
+                          1.793527 0.195000 0.277615,
+                          1.829762 0.195000 0.142385,
+                          2.206473 0.195000 0.243325,
+                          2.002950 0.195000 0.217261,
+                          1.838743 0.195000 0.173262,
+                          1.816743 0.195000 0.255365,
+                          1.980951 0.195000 0.299365,
+                          2.161257 -0.000000 0.347678,
+                          2.161257 0.195000 0.347678,
+                          1.997050 -0.000000 0.303678,
+                          1.997050 0.195000 0.303678,
+                          2.019049 0.195000 0.221575,
+                          2.183257 0.195000 0.265574,
+                          2.183257 -0.000000 0.265574,
+                          2.019049 -0.000000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 -0.195000 0.140000,
+                          2.105000 -0.195000 0.230000,
+                          2.105000 0.195000 0.140000,
+                          2.105000 0.195000 0.230000,
+                          2.195000 -0.195000 0.140000,
+                          2.195000 0.195000 0.140000,
+                          2.195000 0.195000 0.230000,
+                          2.195000 -0.195000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 1.805000 0.299365,
+                          1.416743 1.805000 0.255365,
+                          1.438743 1.805000 0.173262,
+                          1.602950 1.805000 0.217261,
+                          1.393527 1.805000 0.277615,
+                          1.429762 1.805000 0.142385,
+                          1.806473 1.805000 0.243325,
+                          1.770238 1.805000 0.378554,
+                          1.770238 2.000000 0.378554,
+                          1.393527 2.000000 0.277615,
+                          1.429762 2.000000 0.142385,
+                          1.806473 2.000000 0.243325,
+                          1.602950 2.000000 0.217261,
+                          1.438743 2.000000 0.173262,
+                          1.416743 2.000000 0.255365,
+                          1.580951 2.000000 0.299365,
+                          1.761257 1.805000 0.347678,
+                          1.761257 2.000000 0.347678,
+                          1.597050 1.805000 0.303678,
+                          1.597050 2.000000 0.303678,
+                          1.619049 2.000000 0.221575,
+                          1.783257 2.000000 0.265574,
+                          1.783257 1.805000 0.265574,
+                          1.619049 1.805000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 2.000000 0.299365,
+                          1.416743 2.000000 0.255365,
+                          1.438743 2.000000 0.173262,
+                          1.602950 2.000000 0.217261,
+                          1.393527 2.000000 0.277615,
+                          1.429762 2.000000 0.142385,
+                          1.806473 2.000000 0.243325,
+                          1.770238 2.000000 0.378554,
+                          1.770238 2.195000 0.378554,
+                          1.393527 2.195000 0.277615,
+                          1.429762 2.195000 0.142385,
+                          1.806473 2.195000 0.243325,
+                          1.602950 2.195000 0.217261,
+                          1.438743 2.195000 0.173262,
+                          1.416743 2.195000 0.255365,
+                          1.580951 2.195000 0.299365,
+                          1.761257 2.000000 0.347678,
+                          1.761257 2.195000 0.347678,
+                          1.597050 2.000000 0.303678,
+                          1.597050 2.195000 0.303678,
+                          1.619049 2.195000 0.221575,
+                          1.783257 2.195000 0.265574,
+                          1.783257 2.000000 0.265574,
+                          1.619049 2.000000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.705000 1.805000 0.140000,
+                          1.705000 1.805000 0.230000,
+                          1.705000 2.195000 0.140000,
+                          1.705000 2.195000 0.230000,
+                          1.795000 1.805000 0.140000,
+                          1.795000 2.195000 0.140000,
+                          1.795000 2.195000 0.230000,
+                          1.795000 1.805000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 1.619049 0.439365,
+                          1.405000 1.783257 0.395365,
+                          1.405000 1.761257 0.313262,
+                          1.405000 1.597050 0.357261,
+                          1.405000 1.806473 0.417615,
+                          1.405000 1.770238 0.282385,
+                          1.405000 1.393527 0.383325,
+                          1.405000 1.429762 0.518554,
+                          1.600000 1.429762 0.518554,
+                          1.600000 1.806473 0.417615,
+                          1.600000 1.770238 0.282385,
+                          1.600000 1.393527 0.383325,
+                          1.600000 1.597050 0.357261,
+                          1.600000 1.761257 0.313262,
+                          1.600000 1.783257 0.395365,
+                          1.600000 1.619049 0.439365,
+                          1.405000 1.438743 0.487678,
+                          1.600000 1.438743 0.487678,
+                          1.405000 1.602950 0.443678,
+                          1.600000 1.602950 0.443678,
+                          1.600000 1.580951 0.361575,
+                          1.600000 1.416743 0.405574,
+                          1.405000 1.416743 0.405574,
+                          1.405000 1.580951 0.361575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 1.619049 0.439365,
+                          1.600000 1.783257 0.395365,
+                          1.600000 1.761257 0.313262,
+                          1.600000 1.597050 0.357261,
+                          1.600000 1.806473 0.417615,
+                          1.600000 1.770238 0.282385,
+                          1.600000 1.393527 0.383325,
+                          1.600000 1.429762 0.518554,
+                          1.795000 1.429762 0.518554,
+                          1.795000 1.806473 0.417615,
+                          1.795000 1.770238 0.282385,
+                          1.795000 1.393527 0.383325,
+                          1.795000 1.597050 0.357261,
+                          1.795000 1.761257 0.313262,
+                          1.795000 1.783257 0.395365,
+                          1.795000 1.619049 0.439365,
+                          1.600000 1.438743 0.487678,
+                          1.795000 1.438743 0.487678,
+                          1.600000 1.602950 0.443678,
+                          1.795000 1.602950 0.443678,
+                          1.795000 1.580951 0.361575,
+                          1.795000 1.416743 0.405574,
+                          1.600000 1.416743 0.405574,
+                          1.600000 1.580951 0.361575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 1.495000 0.280000,
+                          1.405000 1.495000 0.370000,
+                          1.795000 1.495000 0.280000,
+                          1.795000 1.495000 0.370000,
+                          1.405000 1.405000 0.280000,
+                          1.795000 1.405000 0.280000,
+                          1.795000 1.405000 0.370000,
+                          1.405000 1.405000 0.370000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.619049 1.395000 0.299365,
+                          1.783257 1.395000 0.255365,
+                          1.761257 1.395000 0.173262,
+                          1.597050 1.395000 0.217261,
+                          1.806473 1.395000 0.277615,
+                          1.770238 1.395000 0.142385,
+                          1.393527 1.395000 0.243325,
+                          1.429762 1.395000 0.378554,
+                          1.429762 1.200000 0.378554,
+                          1.806473 1.200000 0.277615,
+                          1.770238 1.200000 0.142385,
+                          1.393527 1.200000 0.243325,
+                          1.597050 1.200000 0.217261,
+                          1.761257 1.200000 0.173262,
+                          1.783257 1.200000 0.255365,
+                          1.619049 1.200000 0.299365,
+                          1.438743 1.395000 0.347678,
+                          1.438743 1.200000 0.347678,
+                          1.602950 1.395000 0.303678,
+                          1.602950 1.200000 0.303678,
+                          1.580951 1.200000 0.221575,
+                          1.416743 1.200000 0.265574,
+                          1.416743 1.395000 0.265574,
+                          1.580951 1.395000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.619049 1.200000 0.299365,
+                          1.783257 1.200000 0.255365,
+                          1.761257 1.200000 0.173262,
+                          1.597050 1.200000 0.217261,
+                          1.806473 1.200000 0.277615,
+                          1.770238 1.200000 0.142385,
+                          1.393527 1.200000 0.243325,
+                          1.429762 1.200000 0.378554,
+                          1.429762 1.005000 0.378554,
+                          1.806473 1.005000 0.277615,
+                          1.770238 1.005000 0.142385,
+                          1.393527 1.005000 0.243325,
+                          1.597050 1.005000 0.217261,
+                          1.761257 1.005000 0.173262,
+                          1.783257 1.005000 0.255365,
+                          1.619049 1.005000 0.299365,
+                          1.438743 1.200000 0.347678,
+                          1.438743 1.005000 0.347678,
+                          1.602950 1.200000 0.303678,
+                          1.602950 1.005000 0.303678,
+                          1.580951 1.005000 0.221575,
+                          1.416743 1.005000 0.265574,
+                          1.416743 1.200000 0.265574,
+                          1.580951 1.200000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.495000 1.395000 0.140000,
+                          1.495000 1.395000 0.230000,
+                          1.495000 1.005000 0.140000,
+                          1.495000 1.005000 0.230000,
+                          1.405000 1.395000 0.140000,
+                          1.405000 1.005000 0.140000,
+                          1.405000 1.005000 0.230000,
+                          1.405000 1.395000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.795000 0.780951 0.299365,
+                          1.795000 0.616743 0.255365,
+                          1.795000 0.638743 0.173262,
+                          1.795000 0.802950 0.217261,
+                          1.795000 0.593527 0.277615,
+                          1.795000 0.629762 0.142385,
+                          1.795000 1.006473 0.243325,
+                          1.795000 0.970238 0.378554,
+                          1.600000 0.970238 0.378554,
+                          1.600000 0.593527 0.277615,
+                          1.600000 0.629762 0.142385,
+                          1.600000 1.006473 0.243325,
+                          1.600000 0.802950 0.217261,
+                          1.600000 0.638743 0.173262,
+                          1.600000 0.616743 0.255365,
+                          1.600000 0.780951 0.299365,
+                          1.795000 0.961257 0.347678,
+                          1.600000 0.961257 0.347678,
+                          1.795000 0.797050 0.303678,
+                          1.600000 0.797050 0.303678,
+                          1.600000 0.819049 0.221575,
+                          1.600000 0.983257 0.265574,
+                          1.795000 0.983257 0.265574,
+                          1.795000 0.819049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 0.780951 0.299365,
+                          1.600000 0.616743 0.255365,
+                          1.600000 0.638743 0.173262,
+                          1.600000 0.802950 0.217261,
+                          1.600000 0.593527 0.277615,
+                          1.600000 0.629762 0.142385,
+                          1.600000 1.006473 0.243325,
+                          1.600000 0.970238 0.378554,
+                          1.405000 0.970238 0.378554,
+                          1.405000 0.593527 0.277615,
+                          1.405000 0.629762 0.142385,
+                          1.405000 1.006473 0.243325,
+                          1.405000 0.802950 0.217261,
+                          1.405000 0.638743 0.173262,
+                          1.405000 0.616743 0.255365,
+                          1.405000 0.780951 0.299365,
+                          1.600000 0.961257 0.347678,
+                          1.405000 0.961257 0.347678,
+                          1.600000 0.797050 0.303678,
+                          1.405000 0.797050 0.303678,
+                          1.405000 0.819049 0.221575,
+                          1.405000 0.983257 0.265574,
+                          1.600000 0.983257 0.265574,
+                          1.600000 0.819049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.795000 0.905000 0.140000,
+                          1.795000 0.905000 0.230000,
+                          1.405000 0.905000 0.140000,
+                          1.405000 0.905000 0.230000,
+                          1.795000 0.995000 0.140000,
+                          1.405000 0.995000 0.140000,
+                          1.405000 0.995000 0.230000,
+                          1.795000 0.995000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 0.205000 0.439365,
+                          1.416743 0.205000 0.395365,
+                          1.438743 0.205000 0.313262,
+                          1.602950 0.205000 0.357261,
+                          1.393527 0.205000 0.417615,
+                          1.429762 0.205000 0.282385,
+                          1.806473 0.205000 0.383325,
+                          1.770238 0.205000 0.518554,
+                          1.770238 0.400000 0.518554,
+                          1.393527 0.400000 0.417615,
+                          1.429762 0.400000 0.282385,
+                          1.806473 0.400000 0.383325,
+                          1.602950 0.400000 0.357261,
+                          1.438743 0.400000 0.313262,
+                          1.416743 0.400000 0.395365,
+                          1.580951 0.400000 0.439365,
+                          1.761257 0.205000 0.487678,
+                          1.761257 0.400000 0.487678,
+                          1.597050 0.205000 0.443678,
+                          1.597050 0.400000 0.443678,
+                          1.619049 0.400000 0.361575,
+                          1.783257 0.400000 0.405574,
+                          1.783257 0.205000 0.405574,
+                          1.619049 0.205000 0.361575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.580951 0.400000 0.439365,
+                          1.416743 0.400000 0.395365,
+                          1.438743 0.400000 0.313262,
+                          1.602950 0.400000 0.357261,
+                          1.393527 0.400000 0.417615,
+                          1.429762 0.400000 0.282385,
+                          1.806473 0.400000 0.383325,
+                          1.770238 0.400000 0.518554,
+                          1.770238 0.595000 0.518554,
+                          1.393527 0.595000 0.417615,
+                          1.429762 0.595000 0.282385,
+                          1.806473 0.595000 0.383325,
+                          1.602950 0.595000 0.357261,
+                          1.438743 0.595000 0.313262,
+                          1.416743 0.595000 0.395365,
+                          1.580951 0.595000 0.439365,
+                          1.761257 0.400000 0.487678,
+                          1.761257 0.595000 0.487678,
+                          1.597050 0.400000 0.443678,
+                          1.597050 0.595000 0.443678,
+                          1.619049 0.595000 0.361575,
+                          1.783257 0.595000 0.405574,
+                          1.783257 0.400000 0.405574,
+                          1.619049 0.400000 0.361575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.705000 0.205000 0.280000,
+                          1.705000 0.205000 0.370000,
+                          1.705000 0.595000 0.280000,
+                          1.705000 0.595000 0.370000,
+                          1.795000 0.205000 0.280000,
+                          1.795000 0.595000 0.280000,
+                          1.795000 0.595000 0.370000,
+                          1.795000 0.205000 0.370000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 0.019049 0.299365,
+                          1.405000 0.183257 0.255365,
+                          1.405000 0.161257 0.173262,
+                          1.405000 -0.002950 0.217261,
+                          1.405000 0.206473 0.277615,
+                          1.405000 0.170238 0.142385,
+                          1.405000 -0.206473 0.243325,
+                          1.405000 -0.170238 0.378554,
+                          1.600000 -0.170238 0.378554,
+                          1.600000 0.206473 0.277615,
+                          1.600000 0.170238 0.142385,
+                          1.600000 -0.206473 0.243325,
+                          1.600000 -0.002950 0.217261,
+                          1.600000 0.161257 0.173262,
+                          1.600000 0.183257 0.255365,
+                          1.600000 0.019049 0.299365,
+                          1.405000 -0.161257 0.347678,
+                          1.600000 -0.161257 0.347678,
+                          1.405000 0.002950 0.303678,
+                          1.600000 0.002950 0.303678,
+                          1.600000 -0.019049 0.221575,
+                          1.600000 -0.183257 0.265574,
+                          1.405000 -0.183257 0.265574,
+                          1.405000 -0.019049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.600000 0.019049 0.299365,
+                          1.600000 0.183257 0.255365,
+                          1.600000 0.161257 0.173262,
+                          1.600000 -0.002950 0.217261,
+                          1.600000 0.206473 0.277615,
+                          1.600000 0.170238 0.142385,
+                          1.600000 -0.206473 0.243325,
+                          1.600000 -0.170238 0.378554,
+                          1.795000 -0.170238 0.378554,
+                          1.795000 0.206473 0.277615,
+                          1.795000 0.170238 0.142385,
+                          1.795000 -0.206473 0.243325,
+                          1.795000 -0.002950 0.217261,
+                          1.795000 0.161257 0.173262,
+                          1.795000 0.183257 0.255365,
+                          1.795000 0.019049 0.299365,
+                          1.600000 -0.161257 0.347678,
+                          1.795000 -0.161257 0.347678,
+                          1.600000 0.002950 0.303678,
+                          1.795000 0.002950 0.303678,
+                          1.795000 -0.019049 0.221575,
+                          1.795000 -0.183257 0.265574,
+                          1.600000 -0.183257 0.265574,
+                          1.600000 -0.019049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.405000 -0.105000 0.140000,
+                          1.405000 -0.105000 0.230000,
+                          1.795000 -0.105000 0.140000,
+                          1.795000 -0.105000 0.230000,
+                          1.405000 -0.195000 0.140000,
+                          1.795000 -0.195000 0.140000,
+                          1.795000 -0.195000 0.230000,
+                          1.405000 -0.195000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 2.019049 0.159365,
+                          1.005000 2.183257 0.115365,
+                          1.005000 2.161257 0.033262,
+                          1.005000 1.997050 0.077261,
+                          1.005000 2.206473 0.137615,
+                          1.005000 2.170238 0.002385,
+                          1.005000 1.793527 0.103325,
+                          1.005000 1.829762 0.238554,
+                          1.200000 1.829762 0.238554,
+                          1.200000 2.206473 0.137615,
+                          1.200000 2.170238 0.002385,
+                          1.200000 1.793527 0.103325,
+                          1.200000 1.997050 0.077261,
+                          1.200000 2.161257 0.033262,
+                          1.200000 2.183257 0.115365,
+                          1.200000 2.019049 0.159365,
+                          1.005000 1.838743 0.207678,
+                          1.200000 1.838743 0.207678,
+                          1.005000 2.002950 0.163678,
+                          1.200000 2.002950 0.163678,
+                          1.200000 1.980951 0.081575,
+                          1.200000 1.816743 0.125574,
+                          1.005000 1.816743 0.125574,
+                          1.005000 1.980951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 2.019049 0.159365,
+                          1.200000 2.183257 0.115365,
+                          1.200000 2.161257 0.033262,
+                          1.200000 1.997050 0.077261,
+                          1.200000 2.206473 0.137615,
+                          1.200000 2.170238 0.002385,
+                          1.200000 1.793527 0.103325,
+                          1.200000 1.829762 0.238554,
+                          1.395000 1.829762 0.238554,
+                          1.395000 2.206473 0.137615,
+                          1.395000 2.170238 0.002385,
+                          1.395000 1.793527 0.103325,
+                          1.395000 1.997050 0.077261,
+                          1.395000 2.161257 0.033262,
+                          1.395000 2.183257 0.115365,
+                          1.395000 2.019049 0.159365,
+                          1.200000 1.838743 0.207678,
+                          1.395000 1.838743 0.207678,
+                          1.200000 2.002950 0.163678,
+                          1.395000 2.002950 0.163678,
+                          1.395000 1.980951 0.081575,
+                          1.395000 1.816743 0.125574,
+                          1.200000 1.816743 0.125574,
+                          1.200000 1.980951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 1.895000 0.000000,
+                          1.005000 1.895000 0.090000,
+                          1.395000 1.895000 0.000000,
+                          1.395000 1.895000 0.090000,
+                          1.005000 1.805000 0.000000,
+                          1.395000 1.805000 0.000000,
+                          1.395000 1.805000 0.090000,
+                          1.005000 1.805000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 1.795000 0.299365,
+                          1.383257 1.795000 0.255365,
+                          1.361257 1.795000 0.173262,
+                          1.197050 1.795000 0.217261,
+                          1.406473 1.795000 0.277615,
+                          1.370238 1.795000 0.142385,
+                          0.993527 1.795000 0.243325,
+                          1.029762 1.795000 0.378554,
+                          1.029762 1.600000 0.378554,
+                          1.406473 1.600000 0.277615,
+                          1.370238 1.600000 0.142385,
+                          0.993527 1.600000 0.243325,
+                          1.197050 1.600000 0.217261,
+                          1.361257 1.600000 0.173262,
+                          1.383257 1.600000 0.255365,
+                          1.219049 1.600000 0.299365,
+                          1.038743 1.795000 0.347678,
+                          1.038743 1.600000 0.347678,
+                          1.202950 1.795000 0.303678,
+                          1.202950 1.600000 0.303678,
+                          1.180951 1.600000 0.221575,
+                          1.016743 1.600000 0.265574,
+                          1.016743 1.795000 0.265574,
+                          1.180951 1.795000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 1.600000 0.299365,
+                          1.383257 1.600000 0.255365,
+                          1.361257 1.600000 0.173262,
+                          1.197050 1.600000 0.217261,
+                          1.406473 1.600000 0.277615,
+                          1.370238 1.600000 0.142385,
+                          0.993527 1.600000 0.243325,
+                          1.029762 1.600000 0.378554,
+                          1.029762 1.405000 0.378554,
+                          1.406473 1.405000 0.277615,
+                          1.370238 1.405000 0.142385,
+                          0.993527 1.405000 0.243325,
+                          1.197050 1.405000 0.217261,
+                          1.361257 1.405000 0.173262,
+                          1.383257 1.405000 0.255365,
+                          1.219049 1.405000 0.299365,
+                          1.038743 1.600000 0.347678,
+                          1.038743 1.405000 0.347678,
+                          1.202950 1.600000 0.303678,
+                          1.202950 1.405000 0.303678,
+                          1.180951 1.405000 0.221575,
+                          1.016743 1.405000 0.265574,
+                          1.016743 1.600000 0.265574,
+                          1.180951 1.600000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.095000 1.795000 0.140000,
+                          1.095000 1.795000 0.230000,
+                          1.095000 1.405000 0.140000,
+                          1.095000 1.405000 0.230000,
+                          1.005000 1.795000 0.140000,
+                          1.005000 1.405000 0.140000,
+                          1.005000 1.405000 0.230000,
+                          1.005000 1.795000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.395000 1.180951 0.299365,
+                          1.395000 1.016743 0.255365,
+                          1.395000 1.038743 0.173262,
+                          1.395000 1.202950 0.217261,
+                          1.395000 0.993527 0.277615,
+                          1.395000 1.029762 0.142385,
+                          1.395000 1.406473 0.243325,
+                          1.395000 1.370238 0.378554,
+                          1.200000 1.370238 0.378554,
+                          1.200000 0.993527 0.277615,
+                          1.200000 1.029762 0.142385,
+                          1.200000 1.406473 0.243325,
+                          1.200000 1.202950 0.217261,
+                          1.200000 1.038743 0.173262,
+                          1.200000 1.016743 0.255365,
+                          1.200000 1.180951 0.299365,
+                          1.395000 1.361257 0.347678,
+                          1.200000 1.361257 0.347678,
+                          1.395000 1.197050 0.303678,
+                          1.200000 1.197050 0.303678,
+                          1.200000 1.219049 0.221575,
+                          1.200000 1.383257 0.265574,
+                          1.395000 1.383257 0.265574,
+                          1.395000 1.219049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 1.180951 0.299365,
+                          1.200000 1.016743 0.255365,
+                          1.200000 1.038743 0.173262,
+                          1.200000 1.202950 0.217261,
+                          1.200000 0.993527 0.277615,
+                          1.200000 1.029762 0.142385,
+                          1.200000 1.406473 0.243325,
+                          1.200000 1.370238 0.378554,
+                          1.005000 1.370238 0.378554,
+                          1.005000 0.993527 0.277615,
+                          1.005000 1.029762 0.142385,
+                          1.005000 1.406473 0.243325,
+                          1.005000 1.202950 0.217261,
+                          1.005000 1.038743 0.173262,
+                          1.005000 1.016743 0.255365,
+                          1.005000 1.180951 0.299365,
+                          1.200000 1.361257 0.347678,
+                          1.005000 1.361257 0.347678,
+                          1.200000 1.197050 0.303678,
+                          1.005000 1.197050 0.303678,
+                          1.005000 1.219049 0.221575,
+                          1.005000 1.383257 0.265574,
+                          1.200000 1.383257 0.265574,
+                          1.200000 1.219049 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.395000 1.305000 0.140000,
+                          1.395000 1.305000 0.230000,
+                          1.005000 1.305000 0.140000,
+                          1.005000 1.305000 0.230000,
+                          1.395000 1.395000 0.140000,
+                          1.005000 1.395000 0.140000,
+                          1.005000 1.395000 0.230000,
+                          1.395000 1.395000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.180951 0.605000 0.299365,
+                          1.016743 0.605000 0.255365,
+                          1.038743 0.605000 0.173262,
+                          1.202950 0.605000 0.217261,
+                          0.993527 0.605000 0.277615,
+                          1.029762 0.605000 0.142385,
+                          1.406473 0.605000 0.243325,
+                          1.370238 0.605000 0.378554,
+                          1.370238 0.800000 0.378554,
+                          0.993527 0.800000 0.277615,
+                          1.029762 0.800000 0.142385,
+                          1.406473 0.800000 0.243325,
+                          1.202950 0.800000 0.217261,
+                          1.038743 0.800000 0.173262,
+                          1.016743 0.800000 0.255365,
+                          1.180951 0.800000 0.299365,
+                          1.361257 0.605000 0.347678,
+                          1.361257 0.800000 0.347678,
+                          1.197050 0.605000 0.303678,
+                          1.197050 0.800000 0.303678,
+                          1.219049 0.800000 0.221575,
+                          1.383257 0.800000 0.265574,
+                          1.383257 0.605000 0.265574,
+                          1.219049 0.605000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.180951 0.800000 0.299365,
+                          1.016743 0.800000 0.255365,
+                          1.038743 0.800000 0.173262,
+                          1.202950 0.800000 0.217261,
+                          0.993527 0.800000 0.277615,
+                          1.029762 0.800000 0.142385,
+                          1.406473 0.800000 0.243325,
+                          1.370238 0.800000 0.378554,
+                          1.370238 0.995000 0.378554,
+                          0.993527 0.995000 0.277615,
+                          1.029762 0.995000 0.142385,
+                          1.406473 0.995000 0.243325,
+                          1.202950 0.995000 0.217261,
+                          1.038743 0.995000 0.173262,
+                          1.016743 0.995000 0.255365,
+                          1.180951 0.995000 0.299365,
+                          1.361257 0.800000 0.347678,
+                          1.361257 0.995000 0.347678,
+                          1.197050 0.800000 0.303678,
+                          1.197050 0.995000 0.303678,
+                          1.219049 0.995000 0.221575,
+                          1.383257 0.995000 0.265574,
+                          1.383257 0.800000 0.265574,
+                          1.219049 0.800000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.305000 0.605000 0.140000,
+                          1.305000 0.605000 0.230000,
+                          1.305000 0.995000 0.140000,
+                          1.305000 0.995000 0.230000,
+                          1.395000 0.605000 0.140000,
+                          1.395000 0.995000 0.140000,
+                          1.395000 0.995000 0.230000,
+                          1.395000 0.605000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 0.419049 0.299365,
+                          1.005000 0.583257 0.255365,
+                          1.005000 0.561257 0.173262,
+                          1.005000 0.397050 0.217261,
+                          1.005000 0.606473 0.277615,
+                          1.005000 0.570238 0.142385,
+                          1.005000 0.193527 0.243325,
+                          1.005000 0.229762 0.378554,
+                          1.200000 0.229762 0.378554,
+                          1.200000 0.606473 0.277615,
+                          1.200000 0.570238 0.142385,
+                          1.200000 0.193527 0.243325,
+                          1.200000 0.397050 0.217261,
+                          1.200000 0.561257 0.173262,
+                          1.200000 0.583257 0.255365,
+                          1.200000 0.419049 0.299365,
+                          1.005000 0.238743 0.347678,
+                          1.200000 0.238743 0.347678,
+                          1.005000 0.402950 0.303678,
+                          1.200000 0.402950 0.303678,
+                          1.200000 0.380951 0.221575,
+                          1.200000 0.216743 0.265574,
+                          1.005000 0.216743 0.265574,
+                          1.005000 0.380951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.200000 0.419049 0.299365,
+                          1.200000 0.583257 0.255365,
+                          1.200000 0.561257 0.173262,
+                          1.200000 0.397050 0.217261,
+                          1.200000 0.606473 0.277615,
+                          1.200000 0.570238 0.142385,
+                          1.200000 0.193527 0.243325,
+                          1.200000 0.229762 0.378554,
+                          1.395000 0.229762 0.378554,
+                          1.395000 0.606473 0.277615,
+                          1.395000 0.570238 0.142385,
+                          1.395000 0.193527 0.243325,
+                          1.395000 0.397050 0.217261,
+                          1.395000 0.561257 0.173262,
+                          1.395000 0.583257 0.255365,
+                          1.395000 0.419049 0.299365,
+                          1.200000 0.238743 0.347678,
+                          1.395000 0.238743 0.347678,
+                          1.200000 0.402950 0.303678,
+                          1.395000 0.402950 0.303678,
+                          1.395000 0.380951 0.221575,
+                          1.395000 0.216743 0.265574,
+                          1.200000 0.216743 0.265574,
+                          1.200000 0.380951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.005000 0.295000 0.140000,
+                          1.005000 0.295000 0.230000,
+                          1.395000 0.295000 0.140000,
+                          1.395000 0.295000 0.230000,
+                          1.005000 0.205000 0.140000,
+                          1.395000 0.205000 0.140000,
+                          1.395000 0.205000 0.230000,
+                          1.005000 0.205000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 0.195000 0.159365,
+                          1.383257 0.195000 0.115365,
+                          1.361257 0.195000 0.033262,
+                          1.197050 0.195000 0.077261,
+                          1.406473 0.195000 0.137615,
+                          1.370238 0.195000 0.002385,
+                          0.993527 0.195000 0.103325,
+                          1.029762 0.195000 0.238554,
+                          1.029762 0.000000 0.238554,
+                          1.406473 0.000000 0.137615,
+                          1.370238 0.000000 0.002385,
+                          0.993527 0.000000 0.103325,
+                          1.197050 0.000000 0.077261,
+                          1.361257 0.000000 0.033262,
+                          1.383257 0.000000 0.115365,
+                          1.219049 0.000000 0.159365,
+                          1.038743 0.195000 0.207678,
+                          1.038743 0.000000 0.207678,
+                          1.202950 0.195000 0.163678,
+                          1.202950 0.000000 0.163678,
+                          1.180951 0.000000 0.081575,
+                          1.016743 0.000000 0.125574,
+                          1.016743 0.195000 0.125574,
+                          1.180951 0.195000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.219049 -0.000000 0.159365,
+                          1.383257 0.000000 0.115365,
+                          1.361257 0.000000 0.033262,
+                          1.197050 -0.000000 0.077261,
+                          1.406473 0.000000 0.137615,
+                          1.370238 0.000000 0.002385,
+                          0.993527 0.000000 0.103325,
+                          1.029762 0.000000 0.238554,
+                          1.029762 -0.195000 0.238554,
+                          1.406473 -0.195000 0.137615,
+                          1.370238 -0.195000 0.002385,
+                          0.993527 -0.195000 0.103325,
+                          1.197050 -0.195000 0.077261,
+                          1.361257 -0.195000 0.033262,
+                          1.383257 -0.195000 0.115365,
+                          1.219049 -0.195000 0.159365,
+                          1.038743 -0.000000 0.207678,
+                          1.038743 -0.195000 0.207678,
+                          1.202950 0.000000 0.163678,
+                          1.202950 -0.195000 0.163678,
+                          1.180951 -0.195000 0.081575,
+                          1.016743 -0.195000 0.125574,
+                          1.016743 -0.000000 0.125574,
+                          1.180951 0.000000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          1.095000 0.195000 0.000000,
+                          1.095000 0.195000 0.090000,
+                          1.095000 -0.195000 0.000000,
+                          1.095000 -0.195000 0.090000,
+                          1.005000 0.195000 0.000000,
+                          1.005000 -0.195000 0.000000,
+                          1.005000 -0.195000 0.090000,
+                          1.005000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 2.195000 0.159365,
+                          0.983257 2.195000 0.115365,
+                          0.961257 2.195000 0.033262,
+                          0.797050 2.195000 0.077261,
+                          1.006473 2.195000 0.137615,
+                          0.970238 2.195000 0.002385,
+                          0.593527 2.195000 0.103325,
+                          0.629762 2.195000 0.238554,
+                          0.629762 2.000000 0.238554,
+                          1.006473 2.000000 0.137615,
+                          0.970238 2.000000 0.002385,
+                          0.593527 2.000000 0.103325,
+                          0.797050 2.000000 0.077261,
+                          0.961257 2.000000 0.033262,
+                          0.983257 2.000000 0.115365,
+                          0.819049 2.000000 0.159365,
+                          0.638743 2.195000 0.207678,
+                          0.638743 2.000000 0.207678,
+                          0.802950 2.195000 0.163678,
+                          0.802950 2.000000 0.163678,
+                          0.780951 2.000000 0.081575,
+                          0.616743 2.000000 0.125574,
+                          0.616743 2.195000 0.125574,
+                          0.780951 2.195000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 2.000000 0.159365,
+                          0.983257 2.000000 0.115365,
+                          0.961257 2.000000 0.033262,
+                          0.797050 2.000000 0.077261,
+                          1.006473 2.000000 0.137615,
+                          0.970238 2.000000 0.002385,
+                          0.593527 2.000000 0.103325,
+                          0.629762 2.000000 0.238554,
+                          0.629762 1.805000 0.238554,
+                          1.006473 1.805000 0.137615,
+                          0.970238 1.805000 0.002385,
+                          0.593527 1.805000 0.103325,
+                          0.797050 1.805000 0.077261,
+                          0.961257 1.805000 0.033262,
+                          0.983257 1.805000 0.115365,
+                          0.819049 1.805000 0.159365,
+                          0.638743 2.000000 0.207678,
+                          0.638743 1.805000 0.207678,
+                          0.802950 2.000000 0.163678,
+                          0.802950 1.805000 0.163678,
+                          0.780951 1.805000 0.081575,
+                          0.616743 1.805000 0.125574,
+                          0.616743 2.000000 0.125574,
+                          0.780951 2.000000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.695000 2.195000 0.000000,
+                          0.695000 2.195000 0.090000,
+                          0.695000 1.805000 0.000000,
+                          0.695000 1.805000 0.090000,
+                          0.605000 2.195000 0.000000,
+                          0.605000 1.805000 0.000000,
+                          0.605000 1.805000 0.090000,
+                          0.605000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 1.580951 0.159365,
+                          0.995000 1.416743 0.115365,
+                          0.995000 1.438743 0.033262,
+                          0.995000 1.602950 0.077261,
+                          0.995000 1.393527 0.137615,
+                          0.995000 1.429762 0.002385,
+                          0.995000 1.806473 0.103325,
+                          0.995000 1.770238 0.238554,
+                          0.800000 1.770238 0.238554,
+                          0.800000 1.393527 0.137615,
+                          0.800000 1.429762 0.002385,
+                          0.800000 1.806473 0.103325,
+                          0.800000 1.602950 0.077261,
+                          0.800000 1.438743 0.033262,
+                          0.800000 1.416743 0.115365,
+                          0.800000 1.580951 0.159365,
+                          0.995000 1.761257 0.207678,
+                          0.800000 1.761257 0.207678,
+                          0.995000 1.597050 0.163678,
+                          0.800000 1.597050 0.163678,
+                          0.800000 1.619049 0.081575,
+                          0.800000 1.783257 0.125574,
+                          0.995000 1.783257 0.125574,
+                          0.995000 1.619049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 1.580951 0.159365,
+                          0.800000 1.416743 0.115365,
+                          0.800000 1.438743 0.033262,
+                          0.800000 1.602950 0.077261,
+                          0.800000 1.393527 0.137615,
+                          0.800000 1.429762 0.002385,
+                          0.800000 1.806473 0.103325,
+                          0.800000 1.770238 0.238554,
+                          0.605000 1.770238 0.238554,
+                          0.605000 1.393527 0.137615,
+                          0.605000 1.429762 0.002385,
+                          0.605000 1.806473 0.103325,
+                          0.605000 1.602950 0.077261,
+                          0.605000 1.438743 0.033262,
+                          0.605000 1.416743 0.115365,
+                          0.605000 1.580951 0.159365,
+                          0.800000 1.761257 0.207678,
+                          0.605000 1.761257 0.207678,
+                          0.800000 1.597050 0.163678,
+                          0.605000 1.597050 0.163678,
+                          0.605000 1.619049 0.081575,
+                          0.605000 1.783257 0.125574,
+                          0.800000 1.783257 0.125574,
+                          0.800000 1.619049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 1.705000 0.000000,
+                          0.995000 1.705000 0.090000,
+                          0.605000 1.705000 0.000000,
+                          0.605000 1.705000 0.090000,
+                          0.995000 1.795000 0.000000,
+                          0.605000 1.795000 0.000000,
+                          0.605000 1.795000 0.090000,
+                          0.995000 1.795000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.780951 1.005000 0.299365,
+                          0.616743 1.005000 0.255365,
+                          0.638743 1.005000 0.173262,
+                          0.802950 1.005000 0.217261,
+                          0.593527 1.005000 0.277615,
+                          0.629762 1.005000 0.142385,
+                          1.006473 1.005000 0.243325,
+                          0.970238 1.005000 0.378554,
+                          0.970238 1.200000 0.378554,
+                          0.593527 1.200000 0.277615,
+                          0.629762 1.200000 0.142385,
+                          1.006473 1.200000 0.243325,
+                          0.802950 1.200000 0.217261,
+                          0.638743 1.200000 0.173262,
+                          0.616743 1.200000 0.255365,
+                          0.780951 1.200000 0.299365,
+                          0.961257 1.005000 0.347678,
+                          0.961257 1.200000 0.347678,
+                          0.797050 1.005000 0.303678,
+                          0.797050 1.200000 0.303678,
+                          0.819049 1.200000 0.221575,
+                          0.983257 1.200000 0.265574,
+                          0.983257 1.005000 0.265574,
+                          0.819049 1.005000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.780951 1.200000 0.299365,
+                          0.616743 1.200000 0.255365,
+                          0.638743 1.200000 0.173262,
+                          0.802950 1.200000 0.217261,
+                          0.593527 1.200000 0.277615,
+                          0.629762 1.200000 0.142385,
+                          1.006473 1.200000 0.243325,
+                          0.970238 1.200000 0.378554,
+                          0.970238 1.395000 0.378554,
+                          0.593527 1.395000 0.277615,
+                          0.629762 1.395000 0.142385,
+                          1.006473 1.395000 0.243325,
+                          0.802950 1.395000 0.217261,
+                          0.638743 1.395000 0.173262,
+                          0.616743 1.395000 0.255365,
+                          0.780951 1.395000 0.299365,
+                          0.961257 1.200000 0.347678,
+                          0.961257 1.395000 0.347678,
+                          0.797050 1.200000 0.303678,
+                          0.797050 1.395000 0.303678,
+                          0.819049 1.395000 0.221575,
+                          0.983257 1.395000 0.265574,
+                          0.983257 1.200000 0.265574,
+                          0.819049 1.200000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.905000 1.005000 0.140000,
+                          0.905000 1.005000 0.230000,
+                          0.905000 1.395000 0.140000,
+                          0.905000 1.395000 0.230000,
+                          0.995000 1.005000 0.140000,
+                          0.995000 1.395000 0.140000,
+                          0.995000 1.395000 0.230000,
+                          0.995000 1.005000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.605000 0.819049 0.299365,
+                          0.605000 0.983257 0.255365,
+                          0.605000 0.961257 0.173262,
+                          0.605000 0.797050 0.217261,
+                          0.605000 1.006473 0.277615,
+                          0.605000 0.970238 0.142385,
+                          0.605000 0.593527 0.243325,
+                          0.605000 0.629762 0.378554,
+                          0.800000 0.629762 0.378554,
+                          0.800000 1.006473 0.277615,
+                          0.800000 0.970238 0.142385,
+                          0.800000 0.593527 0.243325,
+                          0.800000 0.797050 0.217261,
+                          0.800000 0.961257 0.173262,
+                          0.800000 0.983257 0.255365,
+                          0.800000 0.819049 0.299365,
+                          0.605000 0.638743 0.347678,
+                          0.800000 0.638743 0.347678,
+                          0.605000 0.802950 0.303678,
+                          0.800000 0.802950 0.303678,
+                          0.800000 0.780951 0.221575,
+                          0.800000 0.616743 0.265574,
+                          0.605000 0.616743 0.265574,
+                          0.605000 0.780951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 0.819049 0.299365,
+                          0.800000 0.983257 0.255365,
+                          0.800000 0.961257 0.173262,
+                          0.800000 0.797050 0.217261,
+                          0.800000 1.006473 0.277615,
+                          0.800000 0.970238 0.142385,
+                          0.800000 0.593527 0.243325,
+                          0.800000 0.629762 0.378554,
+                          0.995000 0.629762 0.378554,
+                          0.995000 1.006473 0.277615,
+                          0.995000 0.970238 0.142385,
+                          0.995000 0.593527 0.243325,
+                          0.995000 0.797050 0.217261,
+                          0.995000 0.961257 0.173262,
+                          0.995000 0.983257 0.255365,
+                          0.995000 0.819049 0.299365,
+                          0.800000 0.638743 0.347678,
+                          0.995000 0.638743 0.347678,
+                          0.800000 0.802950 0.303678,
+                          0.995000 0.802950 0.303678,
+                          0.995000 0.780951 0.221575,
+                          0.995000 0.616743 0.265574,
+                          0.800000 0.616743 0.265574,
+                          0.800000 0.780951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.605000 0.695000 0.140000,
+                          0.605000 0.695000 0.230000,
+                          0.995000 0.695000 0.140000,
+                          0.995000 0.695000 0.230000,
+                          0.605000 0.605000 0.140000,
+                          0.995000 0.605000 0.140000,
+                          0.995000 0.605000 0.230000,
+                          0.605000 0.605000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 0.595000 0.159365,
+                          0.983257 0.595000 0.115365,
+                          0.961257 0.595000 0.033262,
+                          0.797050 0.595000 0.077261,
+                          1.006473 0.595000 0.137615,
+                          0.970238 0.595000 0.002385,
+                          0.593527 0.595000 0.103325,
+                          0.629762 0.595000 0.238554,
+                          0.629762 0.400000 0.238554,
+                          1.006473 0.400000 0.137615,
+                          0.970238 0.400000 0.002385,
+                          0.593527 0.400000 0.103325,
+                          0.797050 0.400000 0.077261,
+                          0.961257 0.400000 0.033262,
+                          0.983257 0.400000 0.115365,
+                          0.819049 0.400000 0.159365,
+                          0.638743 0.595000 0.207678,
+                          0.638743 0.400000 0.207678,
+                          0.802950 0.595000 0.163678,
+                          0.802950 0.400000 0.163678,
+                          0.780951 0.400000 0.081575,
+                          0.616743 0.400000 0.125574,
+                          0.616743 0.595000 0.125574,
+                          0.780951 0.595000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.819049 0.400000 0.159365,
+                          0.983257 0.400000 0.115365,
+                          0.961257 0.400000 0.033262,
+                          0.797050 0.400000 0.077261,
+                          1.006473 0.400000 0.137615,
+                          0.970238 0.400000 0.002385,
+                          0.593527 0.400000 0.103325,
+                          0.629762 0.400000 0.238554,
+                          0.629762 0.205000 0.238554,
+                          1.006473 0.205000 0.137615,
+                          0.970238 0.205000 0.002385,
+                          0.593527 0.205000 0.103325,
+                          0.797050 0.205000 0.077261,
+                          0.961257 0.205000 0.033262,
+                          0.983257 0.205000 0.115365,
+                          0.819049 0.205000 0.159365,
+                          0.638743 0.400000 0.207678,
+                          0.638743 0.205000 0.207678,
+                          0.802950 0.400000 0.163678,
+                          0.802950 0.205000 0.163678,
+                          0.780951 0.205000 0.081575,
+                          0.616743 0.205000 0.125574,
+                          0.616743 0.400000 0.125574,
+                          0.780951 0.400000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.695000 0.595000 0.000000,
+                          0.695000 0.595000 0.090000,
+                          0.695000 0.205000 0.000000,
+                          0.695000 0.205000 0.090000,
+                          0.605000 0.595000 0.000000,
+                          0.605000 0.205000 0.000000,
+                          0.605000 0.205000 0.090000,
+                          0.605000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 -0.019049 0.159365,
+                          0.995000 -0.183257 0.115365,
+                          0.995000 -0.161257 0.033262,
+                          0.995000 0.002950 0.077261,
+                          0.995000 -0.206473 0.137615,
+                          0.995000 -0.170238 0.002385,
+                          0.995000 0.206473 0.103325,
+                          0.995000 0.170238 0.238554,
+                          0.800000 0.170238 0.238554,
+                          0.800000 -0.206473 0.137615,
+                          0.800000 -0.170238 0.002385,
+                          0.800000 0.206473 0.103325,
+                          0.800000 0.002950 0.077261,
+                          0.800000 -0.161257 0.033262,
+                          0.800000 -0.183257 0.115365,
+                          0.800000 -0.019049 0.159365,
+                          0.995000 0.161257 0.207678,
+                          0.800000 0.161257 0.207678,
+                          0.995000 -0.002950 0.163678,
+                          0.800000 -0.002950 0.163678,
+                          0.800000 0.019049 0.081575,
+                          0.800000 0.183257 0.125574,
+                          0.995000 0.183257 0.125574,
+                          0.995000 0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.800000 -0.019049 0.159365,
+                          0.800000 -0.183257 0.115365,
+                          0.800000 -0.161257 0.033262,
+                          0.800000 0.002950 0.077261,
+                          0.800000 -0.206473 0.137615,
+                          0.800000 -0.170238 0.002385,
+                          0.800000 0.206473 0.103325,
+                          0.800000 0.170238 0.238554,
+                          0.605000 0.170238 0.238554,
+                          0.605000 -0.206473 0.137615,
+                          0.605000 -0.170238 0.002385,
+                          0.605000 0.206473 0.103325,
+                          0.605000 0.002950 0.077261,
+                          0.605000 -0.161257 0.033262,
+                          0.605000 -0.183257 0.115365,
+                          0.605000 -0.019049 0.159365,
+                          0.800000 0.161257 0.207678,
+                          0.605000 0.161257 0.207678,
+                          0.800000 -0.002950 0.163678,
+                          0.605000 -0.002950 0.163678,
+                          0.605000 0.019049 0.081575,
+                          0.605000 0.183257 0.125574,
+                          0.800000 0.183257 0.125574,
+                          0.800000 0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.995000 0.105000 0.000000,
+                          0.995000 0.105000 0.090000,
+                          0.605000 0.105000 0.000000,
+                          0.605000 0.105000 0.090000,
+                          0.995000 0.195000 0.000000,
+                          0.605000 0.195000 0.000000,
+                          0.605000 0.195000 0.090000,
+                          0.995000 0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 1.980951 0.159365,
+                          0.595000 1.816743 0.115365,
+                          0.595000 1.838743 0.033262,
+                          0.595000 2.002950 0.077261,
+                          0.595000 1.793527 0.137615,
+                          0.595000 1.829762 0.002385,
+                          0.595000 2.206473 0.103325,
+                          0.595000 2.170238 0.238554,
+                          0.400000 2.170238 0.238554,
+                          0.400000 1.793527 0.137615,
+                          0.400000 1.829762 0.002385,
+                          0.400000 2.206473 0.103325,
+                          0.400000 2.002950 0.077261,
+                          0.400000 1.838743 0.033262,
+                          0.400000 1.816743 0.115365,
+                          0.400000 1.980951 0.159365,
+                          0.595000 2.161257 0.207678,
+                          0.400000 2.161257 0.207678,
+                          0.595000 1.997050 0.163678,
+                          0.400000 1.997050 0.163678,
+                          0.400000 2.019049 0.081575,
+                          0.400000 2.183257 0.125574,
+                          0.595000 2.183257 0.125574,
+                          0.595000 2.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 1.980951 0.159365,
+                          0.400000 1.816743 0.115365,
+                          0.400000 1.838743 0.033262,
+                          0.400000 2.002950 0.077261,
+                          0.400000 1.793527 0.137615,
+                          0.400000 1.829762 0.002385,
+                          0.400000 2.206473 0.103325,
+                          0.400000 2.170238 0.238554,
+                          0.205000 2.170238 0.238554,
+                          0.205000 1.793527 0.137615,
+                          0.205000 1.829762 0.002385,
+                          0.205000 2.206473 0.103325,
+                          0.205000 2.002950 0.077261,
+                          0.205000 1.838743 0.033262,
+                          0.205000 1.816743 0.115365,
+                          0.205000 1.980951 0.159365,
+                          0.400000 2.161257 0.207678,
+                          0.205000 2.161257 0.207678,
+                          0.400000 1.997050 0.163678,
+                          0.205000 1.997050 0.163678,
+                          0.205000 2.019049 0.081575,
+                          0.205000 2.183257 0.125574,
+                          0.400000 2.183257 0.125574,
+                          0.400000 2.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 2.105000 0.000000,
+                          0.595000 2.105000 0.090000,
+                          0.205000 2.105000 0.000000,
+                          0.205000 2.105000 0.090000,
+                          0.595000 2.195000 0.000000,
+                          0.205000 2.195000 0.000000,
+                          0.205000 2.195000 0.090000,
+                          0.595000 2.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 1.405000 0.159365,
+                          0.216743 1.405000 0.115365,
+                          0.238743 1.405000 0.033262,
+                          0.402950 1.405000 0.077261,
+                          0.193527 1.405000 0.137615,
+                          0.229762 1.405000 0.002385,
+                          0.606473 1.405000 0.103325,
+                          0.570238 1.405000 0.238554,
+                          0.570238 1.600000 0.238554,
+                          0.193527 1.600000 0.137615,
+                          0.229762 1.600000 0.002385,
+                          0.606473 1.600000 0.103325,
+                          0.402950 1.600000 0.077261,
+                          0.238743 1.600000 0.033262,
+                          0.216743 1.600000 0.115365,
+                          0.380951 1.600000 0.159365,
+                          0.561257 1.405000 0.207678,
+                          0.561257 1.600000 0.207678,
+                          0.397050 1.405000 0.163678,
+                          0.397050 1.600000 0.163678,
+                          0.419049 1.600000 0.081575,
+                          0.583257 1.600000 0.125574,
+                          0.583257 1.405000 0.125574,
+                          0.419049 1.405000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 1.600000 0.159365,
+                          0.216743 1.600000 0.115365,
+                          0.238743 1.600000 0.033262,
+                          0.402950 1.600000 0.077261,
+                          0.193527 1.600000 0.137615,
+                          0.229762 1.600000 0.002385,
+                          0.606473 1.600000 0.103325,
+                          0.570238 1.600000 0.238554,
+                          0.570238 1.795000 0.238554,
+                          0.193527 1.795000 0.137615,
+                          0.229762 1.795000 0.002385,
+                          0.606473 1.795000 0.103325,
+                          0.402950 1.795000 0.077261,
+                          0.238743 1.795000 0.033262,
+                          0.216743 1.795000 0.115365,
+                          0.380951 1.795000 0.159365,
+                          0.561257 1.600000 0.207678,
+                          0.561257 1.795000 0.207678,
+                          0.397050 1.600000 0.163678,
+                          0.397050 1.795000 0.163678,
+                          0.419049 1.795000 0.081575,
+                          0.583257 1.795000 0.125574,
+                          0.583257 1.600000 0.125574,
+                          0.419049 1.600000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.505000 1.405000 0.000000,
+                          0.505000 1.405000 0.090000,
+                          0.505000 1.795000 0.000000,
+                          0.505000 1.795000 0.090000,
+                          0.595000 1.405000 0.000000,
+                          0.595000 1.795000 0.000000,
+                          0.595000 1.795000 0.090000,
+                          0.595000 1.405000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.205000 1.219049 0.299365,
+                          0.205000 1.383257 0.255365,
+                          0.205000 1.361257 0.173262,
+                          0.205000 1.197050 0.217261,
+                          0.205000 1.406473 0.277615,
+                          0.205000 1.370238 0.142385,
+                          0.205000 0.993527 0.243325,
+                          0.205000 1.029762 0.378554,
+                          0.400000 1.029762 0.378554,
+                          0.400000 1.406473 0.277615,
+                          0.400000 1.370238 0.142385,
+                          0.400000 0.993527 0.243325,
+                          0.400000 1.197050 0.217261,
+                          0.400000 1.361257 0.173262,
+                          0.400000 1.383257 0.255365,
+                          0.400000 1.219049 0.299365,
+                          0.205000 1.038743 0.347678,
+                          0.400000 1.038743 0.347678,
+                          0.205000 1.202950 0.303678,
+                          0.400000 1.202950 0.303678,
+                          0.400000 1.180951 0.221575,
+                          0.400000 1.016743 0.265574,
+                          0.205000 1.016743 0.265574,
+                          0.205000 1.180951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 1.219049 0.299365,
+                          0.400000 1.383257 0.255365,
+                          0.400000 1.361257 0.173262,
+                          0.400000 1.197050 0.217261,
+                          0.400000 1.406473 0.277615,
+                          0.400000 1.370238 0.142385,
+                          0.400000 0.993527 0.243325,
+                          0.400000 1.029762 0.378554,
+                          0.595000 1.029762 0.378554,
+                          0.595000 1.406473 0.277615,
+                          0.595000 1.370238 0.142385,
+                          0.595000 0.993527 0.243325,
+                          0.595000 1.197050 0.217261,
+                          0.595000 1.361257 0.173262,
+                          0.595000 1.383257 0.255365,
+                          0.595000 1.219049 0.299365,
+                          0.400000 1.038743 0.347678,
+                          0.595000 1.038743 0.347678,
+                          0.400000 1.202950 0.303678,
+                          0.595000 1.202950 0.303678,
+                          0.595000 1.180951 0.221575,
+                          0.595000 1.016743 0.265574,
+                          0.400000 1.016743 0.265574,
+                          0.400000 1.180951 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.205000 1.095000 0.140000,
+                          0.205000 1.095000 0.230000,
+                          0.595000 1.095000 0.140000,
+                          0.595000 1.095000 0.230000,
+                          0.205000 1.005000 0.140000,
+                          0.595000 1.005000 0.140000,
+                          0.595000 1.005000 0.230000,
+                          0.205000 1.005000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.419049 0.995000 0.299365,
+                          0.583257 0.995000 0.255365,
+                          0.561257 0.995000 0.173262,
+                          0.397050 0.995000 0.217261,
+                          0.606473 0.995000 0.277615,
+                          0.570238 0.995000 0.142385,
+                          0.193527 0.995000 0.243325,
+                          0.229762 0.995000 0.378554,
+                          0.229762 0.800000 0.378554,
+                          0.606473 0.800000 0.277615,
+                          0.570238 0.800000 0.142385,
+                          0.193527 0.800000 0.243325,
+                          0.397050 0.800000 0.217261,
+                          0.561257 0.800000 0.173262,
+                          0.583257 0.800000 0.255365,
+                          0.419049 0.800000 0.299365,
+                          0.238743 0.995000 0.347678,
+                          0.238743 0.800000 0.347678,
+                          0.402950 0.995000 0.303678,
+                          0.402950 0.800000 0.303678,
+                          0.380951 0.800000 0.221575,
+                          0.216743 0.800000 0.265574,
+                          0.216743 0.995000 0.265574,
+                          0.380951 0.995000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.419049 0.800000 0.299365,
+                          0.583257 0.800000 0.255365,
+                          0.561257 0.800000 0.173262,
+                          0.397050 0.800000 0.217261,
+                          0.606473 0.800000 0.277615,
+                          0.570238 0.800000 0.142385,
+                          0.193527 0.800000 0.243325,
+                          0.229762 0.800000 0.378554,
+                          0.229762 0.605000 0.378554,
+                          0.606473 0.605000 0.277615,
+                          0.570238 0.605000 0.142385,
+                          0.193527 0.605000 0.243325,
+                          0.397050 0.605000 0.217261,
+                          0.561257 0.605000 0.173262,
+                          0.583257 0.605000 0.255365,
+                          0.419049 0.605000 0.299365,
+                          0.238743 0.800000 0.347678,
+                          0.238743 0.605000 0.347678,
+                          0.402950 0.800000 0.303678,
+                          0.402950 0.605000 0.303678,
+                          0.380951 0.605000 0.221575,
+                          0.216743 0.605000 0.265574,
+                          0.216743 0.800000 0.265574,
+                          0.380951 0.800000 0.221575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.295000 0.995000 0.140000,
+                          0.295000 0.995000 0.230000,
+                          0.295000 0.605000 0.140000,
+                          0.295000 0.605000 0.230000,
+                          0.205000 0.995000 0.140000,
+                          0.205000 0.605000 0.140000,
+                          0.205000 0.605000 0.230000,
+                          0.205000 0.995000 0.230000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 0.380951 0.159365,
+                          0.595000 0.216743 0.115365,
+                          0.595000 0.238743 0.033262,
+                          0.595000 0.402950 0.077261,
+                          0.595000 0.193527 0.137615,
+                          0.595000 0.229762 0.002385,
+                          0.595000 0.606473 0.103325,
+                          0.595000 0.570238 0.238554,
+                          0.400000 0.570238 0.238554,
+                          0.400000 0.193527 0.137615,
+                          0.400000 0.229762 0.002385,
+                          0.400000 0.606473 0.103325,
+                          0.400000 0.402950 0.077261,
+                          0.400000 0.238743 0.033262,
+                          0.400000 0.216743 0.115365,
+                          0.400000 0.380951 0.159365,
+                          0.595000 0.561257 0.207678,
+                          0.400000 0.561257 0.207678,
+                          0.595000 0.397050 0.163678,
+                          0.400000 0.397050 0.163678,
+                          0.400000 0.419049 0.081575,
+                          0.400000 0.583257 0.125574,
+                          0.595000 0.583257 0.125574,
+                          0.595000 0.419049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.400000 0.380951 0.159365,
+                          0.400000 0.216743 0.115365,
+                          0.400000 0.238743 0.033262,
+                          0.400000 0.402950 0.077261,
+                          0.400000 0.193527 0.137615,
+                          0.400000 0.229762 0.002385,
+                          0.400000 0.606473 0.103325,
+                          0.400000 0.570238 0.238554,
+                          0.205000 0.570238 0.238554,
+                          0.205000 0.193527 0.137615,
+                          0.205000 0.229762 0.002385,
+                          0.205000 0.606473 0.103325,
+                          0.205000 0.402950 0.077261,
+                          0.205000 0.238743 0.033262,
+                          0.205000 0.216743 0.115365,
+                          0.205000 0.380951 0.159365,
+                          0.400000 0.561257 0.207678,
+                          0.205000 0.561257 0.207678,
+                          0.400000 0.397050 0.163678,
+                          0.205000 0.397050 0.163678,
+                          0.205000 0.419049 0.081575,
+                          0.205000 0.583257 0.125574,
+                          0.400000 0.583257 0.125574,
+                          0.400000 0.419049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.595000 0.505000 0.000000,
+                          0.595000 0.505000 0.090000,
+                          0.205000 0.505000 0.000000,
+                          0.205000 0.505000 0.090000,
+                          0.595000 0.595000 0.000000,
+                          0.205000 0.595000 0.000000,
+                          0.205000 0.595000 0.090000,
+                          0.595000 0.595000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 -0.195000 0.159365,
+                          0.216743 -0.195000 0.115365,
+                          0.238743 -0.195000 0.033262,
+                          0.402950 -0.195000 0.077261,
+                          0.193527 -0.195000 0.137615,
+                          0.229762 -0.195000 0.002385,
+                          0.606473 -0.195000 0.103325,
+                          0.570238 -0.195000 0.238554,
+                          0.570238 -0.000000 0.238554,
+                          0.193527 0.000000 0.137615,
+                          0.229762 0.000000 0.002385,
+                          0.606473 -0.000000 0.103325,
+                          0.402950 0.000000 0.077261,
+                          0.238743 -0.000000 0.033262,
+                          0.216743 -0.000000 0.115365,
+                          0.380951 0.000000 0.159365,
+                          0.561257 -0.195000 0.207678,
+                          0.561257 -0.000000 0.207678,
+                          0.397050 -0.195000 0.163678,
+                          0.397050 -0.000000 0.163678,
+                          0.419049 -0.000000 0.081575,
+                          0.583257 -0.000000 0.125574,
+                          0.583257 -0.195000 0.125574,
+                          0.419049 -0.195000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.380951 0.000000 0.159365,
+                          0.216743 -0.000000 0.115365,
+                          0.238743 -0.000000 0.033262,
+                          0.402950 0.000000 0.077261,
+                          0.193527 0.000000 0.137615,
+                          0.229762 0.000000 0.002385,
+                          0.606473 -0.000000 0.103325,
+                          0.570238 -0.000000 0.238554,
+                          0.570238 0.195000 0.238554,
+                          0.193527 0.195000 0.137615,
+                          0.229762 0.195000 0.002385,
+                          0.606473 0.195000 0.103325,
+                          0.402950 0.195000 0.077261,
+                          0.238743 0.195000 0.033262,
+                          0.216743 0.195000 0.115365,
+                          0.380951 0.195000 0.159365,
+                          0.561257 -0.000000 0.207678,
+                          0.561257 0.195000 0.207678,
+                          0.397050 -0.000000 0.163678,
+                          0.397050 0.195000 0.163678,
+                          0.419049 0.195000 0.081575,
+                          0.583257 0.195000 0.125574,
+                          0.583257 -0.000000 0.125574,
+                          0.419049 -0.000000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.505000 -0.195000 0.000000,
+                          0.505000 -0.195000 0.090000,
+                          0.505000 0.195000 0.000000,
+                          0.505000 0.195000 0.090000,
+                          0.595000 -0.195000 0.000000,
+                          0.595000 0.195000 0.000000,
+                          0.595000 0.195000 0.090000,
+                          0.595000 -0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 1.805000 0.159365,
+                          -0.183257 1.805000 0.115365,
+                          -0.161257 1.805000 0.033262,
+                          0.002950 1.805000 0.077261,
+                          -0.206473 1.805000 0.137615,
+                          -0.170238 1.805000 0.002385,
+                          0.206473 1.805000 0.103325,
+                          0.170238 1.805000 0.238554,
+                          0.170238 2.000000 0.238554,
+                          -0.206473 2.000000 0.137615,
+                          -0.170238 2.000000 0.002385,
+                          0.206473 2.000000 0.103325,
+                          0.002950 2.000000 0.077261,
+                          -0.161257 2.000000 0.033262,
+                          -0.183257 2.000000 0.115365,
+                          -0.019049 2.000000 0.159365,
+                          0.161257 1.805000 0.207678,
+                          0.161257 2.000000 0.207678,
+                          -0.002950 1.805000 0.163678,
+                          -0.002950 2.000000 0.163678,
+                          0.019049 2.000000 0.081575,
+                          0.183257 2.000000 0.125574,
+                          0.183257 1.805000 0.125574,
+                          0.019049 1.805000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 2.000000 0.159365,
+                          -0.183257 2.000000 0.115365,
+                          -0.161257 2.000000 0.033262,
+                          0.002950 2.000000 0.077261,
+                          -0.206473 2.000000 0.137615,
+                          -0.170238 2.000000 0.002385,
+                          0.206473 2.000000 0.103325,
+                          0.170238 2.000000 0.238554,
+                          0.170238 2.195000 0.238554,
+                          -0.206473 2.195000 0.137615,
+                          -0.170238 2.195000 0.002385,
+                          0.206473 2.195000 0.103325,
+                          0.002950 2.195000 0.077261,
+                          -0.161257 2.195000 0.033262,
+                          -0.183257 2.195000 0.115365,
+                          -0.019049 2.195000 0.159365,
+                          0.161257 2.000000 0.207678,
+                          0.161257 2.195000 0.207678,
+                          -0.002950 2.000000 0.163678,
+                          -0.002950 2.195000 0.163678,
+                          0.019049 2.195000 0.081575,
+                          0.183257 2.195000 0.125574,
+                          0.183257 2.000000 0.125574,
+                          0.019049 2.000000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.105000 1.805000 0.000000,
+                          0.105000 1.805000 0.090000,
+                          0.105000 2.195000 0.000000,
+                          0.105000 2.195000 0.090000,
+                          0.195000 1.805000 0.000000,
+                          0.195000 2.195000 0.000000,
+                          0.195000 2.195000 0.090000,
+                          0.195000 1.805000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 1.619049 0.159365,
+                          -0.195000 1.783257 0.115365,
+                          -0.195000 1.761257 0.033262,
+                          -0.195000 1.597050 0.077261,
+                          -0.195000 1.806473 0.137615,
+                          -0.195000 1.770238 0.002385,
+                          -0.195000 1.393527 0.103325,
+                          -0.195000 1.429762 0.238554,
+                          0.000000 1.429762 0.238554,
+                          0.000000 1.806473 0.137615,
+                          0.000000 1.770238 0.002385,
+                          0.000000 1.393527 0.103325,
+                          0.000000 1.597050 0.077261,
+                          0.000000 1.761257 0.033262,
+                          0.000000 1.783257 0.115365,
+                          0.000000 1.619049 0.159365,
+                          -0.195000 1.438743 0.207678,
+                          0.000000 1.438743 0.207678,
+                          -0.195000 1.602950 0.163678,
+                          0.000000 1.602950 0.163678,
+                          0.000000 1.580951 0.081575,
+                          0.000000 1.416743 0.125574,
+                          -0.195000 1.416743 0.125574,
+                          -0.195000 1.580951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 1.619049 0.159365,
+                          0.000000 1.783257 0.115365,
+                          0.000000 1.761257 0.033262,
+                          0.000000 1.597050 0.077261,
+                          0.000000 1.806473 0.137615,
+                          0.000000 1.770238 0.002385,
+                          0.000000 1.393527 0.103325,
+                          0.000000 1.429762 0.238554,
+                          0.195000 1.429762 0.238554,
+                          0.195000 1.806473 0.137615,
+                          0.195000 1.770238 0.002385,
+                          0.195000 1.393527 0.103325,
+                          0.195000 1.597050 0.077261,
+                          0.195000 1.761257 0.033262,
+                          0.195000 1.783257 0.115365,
+                          0.195000 1.619049 0.159365,
+                          0.000000 1.438743 0.207678,
+                          0.195000 1.438743 0.207678,
+                          0.000000 1.602950 0.163678,
+                          0.195000 1.602950 0.163678,
+                          0.195000 1.580951 0.081575,
+                          0.195000 1.416743 0.125574,
+                          0.000000 1.416743 0.125574,
+                          0.000000 1.580951 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 1.495000 0.000000,
+                          -0.195000 1.495000 0.090000,
+                          0.195000 1.495000 0.000000,
+                          0.195000 1.495000 0.090000,
+                          -0.195000 1.405000 0.000000,
+                          0.195000 1.405000 0.000000,
+                          0.195000 1.405000 0.090000,
+                          -0.195000 1.405000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.019049 1.395000 0.159365,
+                          0.183257 1.395000 0.115365,
+                          0.161257 1.395000 0.033262,
+                          -0.002950 1.395000 0.077261,
+                          0.206473 1.395000 0.137615,
+                          0.170238 1.395000 0.002385,
+                          -0.206473 1.395000 0.103325,
+                          -0.170238 1.395000 0.238554,
+                          -0.170238 1.200000 0.238554,
+                          0.206473 1.200000 0.137615,
+                          0.170238 1.200000 0.002385,
+                          -0.206473 1.200000 0.103325,
+                          -0.002950 1.200000 0.077261,
+                          0.161257 1.200000 0.033262,
+                          0.183257 1.200000 0.115365,
+                          0.019049 1.200000 0.159365,
+                          -0.161257 1.395000 0.207678,
+                          -0.161257 1.200000 0.207678,
+                          0.002950 1.395000 0.163678,
+                          0.002950 1.200000 0.163678,
+                          -0.019049 1.200000 0.081575,
+                          -0.183257 1.200000 0.125574,
+                          -0.183257 1.395000 0.125574,
+                          -0.019049 1.395000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.019049 1.200000 0.159365,
+                          0.183257 1.200000 0.115365,
+                          0.161257 1.200000 0.033262,
+                          -0.002950 1.200000 0.077261,
+                          0.206473 1.200000 0.137615,
+                          0.170238 1.200000 0.002385,
+                          -0.206473 1.200000 0.103325,
+                          -0.170238 1.200000 0.238554,
+                          -0.170238 1.005000 0.238554,
+                          0.206473 1.005000 0.137615,
+                          0.170238 1.005000 0.002385,
+                          -0.206473 1.005000 0.103325,
+                          -0.002950 1.005000 0.077261,
+                          0.161257 1.005000 0.033262,
+                          0.183257 1.005000 0.115365,
+                          0.019049 1.005000 0.159365,
+                          -0.161257 1.200000 0.207678,
+                          -0.161257 1.005000 0.207678,
+                          0.002950 1.200000 0.163678,
+                          0.002950 1.005000 0.163678,
+                          -0.019049 1.005000 0.081575,
+                          -0.183257 1.005000 0.125574,
+                          -0.183257 1.200000 0.125574,
+                          -0.019049 1.200000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.105000 1.395000 0.000000,
+                          -0.105000 1.395000 0.090000,
+                          -0.105000 1.005000 0.000000,
+                          -0.105000 1.005000 0.090000,
+                          -0.195000 1.395000 0.000000,
+                          -0.195000 1.005000 0.000000,
+                          -0.195000 1.005000 0.090000,
+                          -0.195000 1.395000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.195000 0.780951 0.159365,
+                          0.195000 0.616743 0.115365,
+                          0.195000 0.638743 0.033262,
+                          0.195000 0.802950 0.077261,
+                          0.195000 0.593527 0.137615,
+                          0.195000 0.629762 0.002385,
+                          0.195000 1.006473 0.103325,
+                          0.195000 0.970238 0.238554,
+                          0.000000 0.970238 0.238554,
+                          -0.000000 0.593527 0.137615,
+                          -0.000000 0.629762 0.002385,
+                          0.000000 1.006473 0.103325,
+                          -0.000000 0.802950 0.077261,
+                          -0.000000 0.638743 0.033262,
+                          -0.000000 0.616743 0.115365,
+                          -0.000000 0.780951 0.159365,
+                          0.195000 0.961257 0.207678,
+                          0.000000 0.961257 0.207678,
+                          0.195000 0.797050 0.163678,
+                          -0.000000 0.797050 0.163678,
+                          0.000000 0.819049 0.081575,
+                          0.000000 0.983257 0.125574,
+                          0.195000 0.983257 0.125574,
+                          0.195000 0.819049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.780951 0.159365,
+                          0.000000 0.616743 0.115365,
+                          0.000000 0.638743 0.033262,
+                          0.000000 0.802950 0.077261,
+                          0.000000 0.593527 0.137615,
+                          0.000000 0.629762 0.002385,
+                          0.000000 1.006473 0.103325,
+                          0.000000 0.970238 0.238554,
+                          -0.195000 0.970238 0.238554,
+                          -0.195000 0.593527 0.137615,
+                          -0.195000 0.629762 0.002385,
+                          -0.195000 1.006473 0.103325,
+                          -0.195000 0.802950 0.077261,
+                          -0.195000 0.638743 0.033262,
+                          -0.195000 0.616743 0.115365,
+                          -0.195000 0.780951 0.159365,
+                          0.000000 0.961257 0.207678,
+                          -0.195000 0.961257 0.207678,
+                          0.000000 0.797050 0.163678,
+                          -0.195000 0.797050 0.163678,
+                          -0.195000 0.819049 0.081575,
+                          -0.195000 0.983257 0.125574,
+                          0.000000 0.983257 0.125574,
+                          0.000000 0.819049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.195000 0.905000 0.000000,
+                          0.195000 0.905000 0.090000,
+                          -0.195000 0.905000 0.000000,
+                          -0.195000 0.905000 0.090000,
+                          0.195000 0.995000 0.000000,
+                          -0.195000 0.995000 0.000000,
+                          -0.195000 0.995000 0.090000,
+                          0.195000 0.995000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 0.205000 0.159365,
+                          -0.183257 0.205000 0.115365,
+                          -0.161257 0.205000 0.033262,
+                          0.002950 0.205000 0.077261,
+                          -0.206473 0.205000 0.137615,
+                          -0.170238 0.205000 0.002385,
+                          0.206473 0.205000 0.103325,
+                          0.170238 0.205000 0.238554,
+                          0.170238 0.400000 0.238554,
+                          -0.206473 0.400000 0.137615,
+                          -0.170238 0.400000 0.002385,
+                          0.206473 0.400000 0.103325,
+                          0.002950 0.400000 0.077261,
+                          -0.161257 0.400000 0.033262,
+                          -0.183257 0.400000 0.115365,
+                          -0.019049 0.400000 0.159365,
+                          0.161257 0.205000 0.207678,
+                          0.161257 0.400000 0.207678,
+                          -0.002950 0.205000 0.163678,
+                          -0.002950 0.400000 0.163678,
+                          0.019049 0.400000 0.081575,
+                          0.183257 0.400000 0.125574,
+                          0.183257 0.205000 0.125574,
+                          0.019049 0.205000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.019049 0.400000 0.159365,
+                          -0.183257 0.400000 0.115365,
+                          -0.161257 0.400000 0.033262,
+                          0.002950 0.400000 0.077261,
+                          -0.206473 0.400000 0.137615,
+                          -0.170238 0.400000 0.002385,
+                          0.206473 0.400000 0.103325,
+                          0.170238 0.400000 0.238554,
+                          0.170238 0.595000 0.238554,
+                          -0.206473 0.595000 0.137615,
+                          -0.170238 0.595000 0.002385,
+                          0.206473 0.595000 0.103325,
+                          0.002950 0.595000 0.077261,
+                          -0.161257 0.595000 0.033262,
+                          -0.183257 0.595000 0.115365,
+                          -0.019049 0.595000 0.159365,
+                          0.161257 0.400000 0.207678,
+                          0.161257 0.595000 0.207678,
+                          -0.002950 0.400000 0.163678,
+                          -0.002950 0.595000 0.163678,
+                          0.019049 0.595000 0.081575,
+                          0.183257 0.595000 0.125574,
+                          0.183257 0.400000 0.125574,
+                          0.019049 0.400000 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.105000 0.205000 0.000000,
+                          0.105000 0.205000 0.090000,
+                          0.105000 0.595000 0.000000,
+                          0.105000 0.595000 0.090000,
+                          0.195000 0.205000 0.000000,
+                          0.195000 0.595000 0.000000,
+                          0.195000 0.595000 0.090000,
+                          0.195000 0.205000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 0.019049 0.159365,
+                          -0.195000 0.183257 0.115365,
+                          -0.195000 0.161257 0.033262,
+                          -0.195000 -0.002950 0.077261,
+                          -0.195000 0.206473 0.137615,
+                          -0.195000 0.170238 0.002385,
+                          -0.195000 -0.206473 0.103325,
+                          -0.195000 -0.170238 0.238554,
+                          0.000000 -0.170238 0.238554,
+                          0.000000 0.206473 0.137615,
+                          0.000000 0.170238 0.002385,
+                          0.000000 -0.206473 0.103325,
+                          0.000000 -0.002950 0.077261,
+                          0.000000 0.161257 0.033262,
+                          0.000000 0.183257 0.115365,
+                          0.000000 0.019049 0.159365,
+                          -0.195000 -0.161257 0.207678,
+                          0.000000 -0.161257 0.207678,
+                          -0.195000 0.002950 0.163678,
+                          0.000000 0.002950 0.163678,
+                          0.000000 -0.019049 0.081575,
+                          0.000000 -0.183257 0.125574,
+                          -0.195000 -0.183257 0.125574,
+                          -0.195000 -0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.019049 0.159365,
+                          0.000000 0.183257 0.115365,
+                          0.000000 0.161257 0.033262,
+                          0.000000 -0.002950 0.077261,
+                          0.000000 0.206473 0.137615,
+                          0.000000 0.170238 0.002385,
+                          0.000000 -0.206473 0.103325,
+                          0.000000 -0.170238 0.238554,
+                          0.195000 -0.170238 0.238554,
+                          0.195000 0.206473 0.137615,
+                          0.195000 0.170238 0.002385,
+                          0.195000 -0.206473 0.103325,
+                          0.195000 -0.002950 0.077261,
+                          0.195000 0.161257 0.033262,
+                          0.195000 0.183257 0.115365,
+                          0.195000 0.019049 0.159365,
+                          0.000000 -0.161257 0.207678,
+                          0.195000 -0.161257 0.207678,
+                          0.000000 0.002950 0.163678,
+                          0.195000 0.002950 0.163678,
+                          0.195000 -0.019049 0.081575,
+                          0.195000 -0.183257 0.125574,
+                          0.000000 -0.183257 0.125574,
+                          0.000000 -0.019049 0.081575,
+                         ]
+                      }
+                      coordIndex [
+                       13, 2, 3, -1,
+                       3, 12, 13, -1,
+                       1, 2, 13, -1,
+                       13, 14, 1, -1,
+                       0, 1, 14, -1,
+                       14, 15, 0, -1,
+                       15, 12, 3, -1,
+                       3, 0, 15, -1,
+                       5, 6, 7, -1,
+                       7, 4, 5, -1,
+                       11, 6, 5, -1,
+                       5, 10, 11, -1,
+                       9, 4, 7, -1,
+                       7, 8, 9, -1,
+                       9, 10, 5, -1,
+                       5, 4, 9, -1,
+                       11, 8, 7, -1,
+                       7, 6, 11, -1,
+                       8, 11, 10, -1,
+                       10, 9, 8, -1,
+                       21, 22, 16, -1,
+                       16, 17, 21, -1,
+                       18, 19, 17, -1,
+                       17, 16, 18, -1,
+                       23, 20, 19, -1,
+                       19, 18, 23, -1,
+                       20, 23, 22, -1,
+                       22, 21, 20, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.71875 0.523438 0.042969,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.195000 -0.105000 0.000000,
+                          -0.195000 -0.105000 0.090000,
+                          0.195000 -0.105000 0.000000,
+                          0.195000 -0.105000 0.090000,
+                          -0.195000 -0.195000 0.000000,
+                          0.195000 -0.195000 0.000000,
+                          0.195000 -0.195000 0.090000,
+                          -0.195000 -0.195000 0.090000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+             ]
+          } #Segment
+       ]
+    } #WAIST
+   ] # END of HumanoidBody
+
+   joints [
+    USE WAIST
+   ]
+
+   segments [
+    USE ROOT-LINK_S
+   ]
+
+}


### PR DESCRIPTION
ふせいち確認用VRMLを追加しました。
```
(progn (load "package://drc_task_common/euslisp/drc-testbed-models.l")
       (make-drc-terrain)
       (send *terrain* :name "DRCTestbedTerrainUSBlock")
       (eus2wrl *terrain* "/tmp/DRCTestbedTerrainUSBlock.wrl" :mode :openhrp3 :fixed t))

(progn (load "package://drc_task_common/euslisp/drc-testbed-models.l")
       (make-drc-terrain-japanese-block-ver)
       (send *terrain* :name "DRCTestbedTerrainJPBlock")
       (eus2wrl *terrain* "/tmp/DRCTestbedTerrainJPBlock.wrl" :mode :openhrp3 :fixed t))
```
よろしくお願いします。