### PR TITLE
enable to work if co start with collision status

### DIFF
--- a/lib/util/SDLUtil.cpp
+++ b/lib/util/SDLUtil.cpp
@@ -46,7 +46,9 @@ SDLwindow::SDLwindow(GLsceneBase* i_scene, LogManagerBase *i_log,
 
 SDLwindow::~SDLwindow()
 {
-    SDL_Quit();
+    if ( initialized ) {
+        SDL_Quit();
+    }
 }
 
 bool SDLwindow::init(int w, int h, bool resizable)

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -193,6 +193,7 @@ class CollisionDetector
   unsigned int m_debugLevel;
   bool m_enable;
   int collision_beep_freq, collision_beep_count;
+  bool m_have_safe_posture;
   OpenHRP::CollisionDetectorService::CollisionState m_state;
 };
 


### PR DESCRIPTION
```
def demoCollisionStartFromFail ():
    hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
    hcf.seq_svc.waitInterpolation();
    if hcf.co_svc.disableCollisionDetection():
        print "=> Successfully disabled when no collision"
    hcf.seq_svc.setJointAngles(col_fail_pose, 1.0);
    hcf.seq_svc.waitInterpolation();
    hcf.deleteComp("co")
    hcf.co = None
    hcf.createComps()
    hcf.connectComps()
    hcf.activateComps()
    if hcf.co_svc.enableCollisionDetection():
        print "=> Successfully enabled when no collision"
    hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
    hcf.seq_svc.waitInterpolation();

```

we also have to 
```
        ref = self.ref.delete_component(name)
        #ref = findRTC(name).ref.exit() # delte_component did not actually kill component, so use rtc.exit https://github.com/fkanehiro/hrpsys-base/pull/512#issuecomment-80430387           
```
becouse deletion collision detector crashes hrpsys-simulator

- [CollisionDetector] set m_have_safe_posture to false in initial time, so that we can check if the system did not know any safe posture
- [SDLUtil.cpp] SDLwindow::~SDLwindow, call SDL_Quit only when this object is initialized