### PR TITLE
add an output port which is coodinated by the robot base frame relative to a world reference frame

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -298,6 +298,7 @@ class HrpsysConfigurator:
             s_rate = filter(lambda s: s.type == 'RateGyro', self.sensors)
             if (len(s_rate) > 0) and self.rh.port(s_rate[0].name) != None:  # check existence of sensor ;; currently original HRP4C.xml has different naming rule of gsensor and gyrometer
                 connectPorts(self.rh.port(s_rate[0].name), self.kf.port("rate"))
+            connectPorts(self.rh.port("q"), self.kf.port("qCurrent"))
 
         # connection for rh
         if self.rh.port("servoState") != None:

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -340,6 +340,7 @@ class HrpsysConfigurator:
             connectPorts(self.rh.port("lfsensor"), self.st.port("forceL"))
             connectPorts(self.rh.port("rfsensor"), self.st.port("forceR"))
             connectPorts(self.kf.port("rpy"), self.st.port("rpy"))
+            connectPorts(self.kf.port("baserpy"), self.st.port("base_rpy"))
             connectPorts(self.sh.port("zmpOut"), self.abc.port("zmpIn"))
             connectPorts(self.sh.port("basePosOut"), self.abc.port("basePosIn"))
             connectPorts(self.sh.port("baseRpyOut"), self.abc.port("baseRpyIn"))

--- a/rtc/KalmanFilter/CMakeLists.txt
+++ b/rtc/KalmanFilter/CMakeLists.txt
@@ -5,7 +5,7 @@ if(NOT BUILD_KALMAN_FILTER)
 endif()
 
 set(comp_sources KalmanFilter.cpp KalmanFilterService_impl.cpp)
-set(libs hrpModel-3.1 hrpsysBaseStub)
+set(libs hrpModel-3.1 hrpUtil-3.1 hrpsysBaseStub)
 
 include_directories(${PROJECT_SOURCE_DIR}/rtc/KalmanFilter/kalman)
 

--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -44,8 +44,10 @@ KalmanFilter::KalmanFilter(RTC::Manager* manager)
     m_accIn("acc", m_acc),
     m_accRefIn("accRef", m_accRef),
     m_rpyIn("rpyIn", m_rate),
+    m_qCurrentIn("qCurrent", m_qCurrent),
     m_rpyOut("rpy", m_rpy),
     m_rpyRawOut("rpy_raw", m_rpyRaw),
+    m_baseRpyOut("base_rpy", m_baseRpy),
     m_KalmanFilterServicePort("KalmanFilterService"),
     // </rtc-template>
     m_robot(hrp::BodyPtr()),
@@ -78,10 +80,12 @@ RTC::ReturnCode_t KalmanFilter::onInitialize()
   addInPort("acc", m_accIn);
   addInPort("accRef", m_accRefIn);
   addInPort("rpyIn", m_rpyIn);
+  addInPort("qCurrent", m_qCurrentIn);
 
   // Set OutPort buffer
   addOutPort("rpy", m_rpyOut);
   addOutPort("rpy_raw", m_rpyRawOut);
+  addOutPort("base_rpy", m_baseRpyOut);
 
   // Set service provider to Ports
   m_KalmanFilterServicePort.registerProvider("service0", "KalmanFilterService", m_service0);
@@ -128,8 +132,10 @@ RTC::ReturnCode_t KalmanFilter::onInitialize()
   }
   rpy_kf.setParam(m_dt, 0.001, 0.003, 0.03);
   rpy_kf.setSensorR(m_sensorR);
+  rpy_kf.setRobot(m_robot);
   ekf_filter.setdt(m_dt);
   kf_algorithm = OpenHRP::KalmanFilterService::RPYKalmanFilter;
+  m_qCurrent.data.length(m_robot->numJoints());
 
   return RTC::RTC_OK;
 }
@@ -185,6 +191,12 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
   if (m_rateIn.isNew()){
     m_rateIn.read();
   }
+  if (m_qCurrentIn.isNew()) {
+    m_qCurrentIn.read();
+    for ( int i = 0; i < m_robot->numJoints(); i++ ){
+      m_robot->joint(i)->q = m_qCurrent.data[i];
+    }
+  }
   double sx_ref = 0.0, sy_ref = 0.0, sz_ref = 0.0;
   if (m_accRefIn.isNew()){
     m_accRefIn.read();
@@ -199,11 +211,13 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
         std::cerr << "[" << m_profile.instance_name << "] raw data acc : " << std::endl << acc << std::endl;
         std::cerr << "[" << m_profile.instance_name << "] raw data gyro : " << std::endl << gyro << std::endl;
     }
-    hrp::Vector3 rpy, rpyRaw;
+    hrp::Vector3 rpy, rpyRaw, baseRpy;
     if (kf_algorithm == OpenHRP::KalmanFilterService::QuaternionExtendedKalmanFilter) {
         ekf_filter.main_one(rpy, rpyRaw, acc, gyro);
     } else if (kf_algorithm == OpenHRP::KalmanFilterService::RPYKalmanFilter) {
-        rpy_kf.main_one(rpy, rpyRaw, acc, gyro);
+        m_robot->calcForwardKinematics();
+        hrp::Matrix33 sensorLinkR = m_robot->sensor(hrp::Sensor::ACCELERATION, 0)->link->R;
+        rpy_kf.main_one(rpy, rpyRaw, baseRpy, acc, gyro, sensorLinkR);
     }
     m_rpyRaw.data.r = rpyRaw(0);
     m_rpyRaw.data.p = rpyRaw(1);
@@ -211,10 +225,14 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
     m_rpy.data.r = rpy(0);
     m_rpy.data.p = rpy(1);
     m_rpy.data.y = rpy(2);
+    m_baseRpy.data.r = baseRpy(0);
+    m_baseRpy.data.p = baseRpy(1);
+    m_baseRpy.data.y = baseRpy(2);
 
 
     m_rpyOut.write();
     m_rpyRawOut.write();
+    m_baseRpyOut.write();
   }
   return RTC::RTC_OK;
 }

--- a/rtc/KalmanFilter/KalmanFilter.h
+++ b/rtc/KalmanFilter/KalmanFilter.h
@@ -131,6 +131,10 @@ protected:
   OutPort<TimedOrientation3D> m_rpyOut;
   OutPort<TimedOrientation3D> m_rpyRawOut;
   
+  RTC::TimedDoubleSeq m_qCurrent;
+  RTC::InPort<RTC::TimedDoubleSeq> m_qCurrentIn;
+  RTC::TimedOrientation3D m_baseRpy;
+  RTC::OutPort<RTC::TimedOrientation3D> m_baseRpyOut;
   // </rtc-template>
 
   // CORBA Port declaration

--- a/rtc/KalmanFilter/RPYKalmanFilter.h
+++ b/rtc/KalmanFilter/RPYKalmanFilter.h
@@ -2,6 +2,7 @@
 #define RPYKALMANFILTER_H
 
 #include <hrpUtil/EigenTypes.h>
+#include <hrpUtil/Eigen3d.h>
 #include "util/Hrpsys.h"
 namespace hrp{
   typedef Eigen::Vector2d Vector2;
@@ -115,11 +116,7 @@ public:
       p_filter.update(gyro2(1), rpyRaw(1));
       y_filter.update(gyro2(2), rpyRaw(2));
 
-      Eigen::AngleAxis<double> aaZ(y_filter.getx()[0], Eigen::Vector3d::UnitZ());
-      Eigen::AngleAxis<double> aaY(p_filter.getx()[0], Eigen::Vector3d::UnitY());
-      Eigen::AngleAxis<double> aaX(r_filter.getx()[0], Eigen::Vector3d::UnitX());
-      Eigen::Quaternion<double> q = aaZ * aaY * aaX;
-      hrp::Matrix33 imaginaryRotationMatrix = q.toRotationMatrix();
+      hrp::Matrix33 imaginaryRotationMatrix = hrp::rotFromRpy(r_filter.getx()[0], p_filter.getx()[0], y_filter.getx()[0]);
       hrp::Matrix33 realRotationMatrix = imaginaryRotationMatrix * m_sensorR;
       hrp::Vector3 euler = realRotationMatrix.eulerAngles(2,1,0);
       rpy(0) = euler(2);

--- a/rtc/KalmanFilter/RPYKalmanFilter.h
+++ b/rtc/KalmanFilter/RPYKalmanFilter.h
@@ -75,7 +75,7 @@ private:
 class RPYKalmanFilter {
 public:
     RPYKalmanFilter() : m_sensorR(hrp::Matrix33::Identity()) {};
-    void main_one (hrp::Vector3& rpy, hrp::Vector3& rpyRaw, hrp::Vector3& baseRpy, const hrp::Vector3& acc, const hrp::Vector3& gyro, const hrp::Matrix33& sensorLinkR)
+    void main_one (hrp::Vector3& rpy, hrp::Vector3& rpyRaw, hrp::Vector3& baseRpy, const hrp::Vector3& acc, const hrp::Vector3& gyro, const hrp::Matrix33& BtoS, const hrp::Matrix33& slR)
     {
       //
       // G = [ cosb, sinb sina, sinb cosa,
@@ -90,7 +90,7 @@ public:
       double a, b;
       b = atan2( - acc(0) / g, sqrt( acc(1)/g * acc(1)/g + acc(2)/g * acc(2)/g ) );
       a = atan2( ( acc(1)/g ), ( acc(2)/g ) );
-      rpyRaw = hrp::Vector3(a,b,0);
+      rpyRaw = hrp::Vector3(a,b,hrp::rpyFromRot(slR)[2]);
       // #if 0
       //       // complementary filter
       //       m_rpy.data.r = 0.98 *(m_rpy.data.r+m_rate.data.avx*m_dt) + 0.02*m_rpyRaw.data.r;
@@ -122,7 +122,7 @@ public:
       rpy(0) = euler(2);
       rpy(1) = euler(1);
       rpy(2) = euler(0);
-      hrp::Matrix33 realRotationMatrix2 = sensorLinkR.transpose() * imaginaryRotationMatrix;
+      hrp::Matrix33 realRotationMatrix2 = realRotationMatrix * BtoS.transpose();
       hrp::Vector3 euler2 = realRotationMatrix2.eulerAngles(2,1,0);
       baseRpy(0) = euler2(2);
       baseRpy(1) = euler2(1);

--- a/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
+++ b/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
@@ -61,13 +61,13 @@ int main(int argc, char *argv[])
   // Test kalman filter
   RPYKalmanFilter rpy_kf;
   rpy_kf.setParam(dt, Q_angle, Q_rate, R_angle);
-  hrp::Vector3 rate, acc, rpy, rpyRaw, rpyAct;
+  hrp::Vector3 rate, acc, rpy, rpyRaw, baseRpy, rpyAct;
   double time, time2=0.0;
   while(!ratef.eof()){
     posef >> time >> time >> time >> time >> rpyAct[0] >> rpyAct[1] >> rpyAct[2]; // Neglect translation in .pose file
     ratef >> time >> rate[0] >> rate[1] >> rate[2];
     accf >> time >> acc[0] >> acc[1] >> acc[2];
-    rpy_kf.main_one(rpy, rpyRaw, acc, rate);
+    rpy_kf.main_one(rpy, rpyRaw, baseRpy, acc, rate, hrp::Matrix33::Identity());
     // rad->deg
     rpy*=180/3.14159;
     rpyAct*=180/3.14159;

--- a/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
+++ b/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
@@ -67,7 +67,7 @@ int main(int argc, char *argv[])
     posef >> time >> time >> time >> time >> rpyAct[0] >> rpyAct[1] >> rpyAct[2]; // Neglect translation in .pose file
     ratef >> time >> rate[0] >> rate[1] >> rate[2];
     accf >> time >> acc[0] >> acc[1] >> acc[2];
-    rpy_kf.main_one(rpy, rpyRaw, baseRpy, acc, rate, hrp::Matrix33::Identity());
+    rpy_kf.main_one(rpy, rpyRaw, baseRpy, acc, rate, hrp::Matrix33::Identity(), hrp::Matrix33::Identity());
     // rad->deg
     rpy*=180/3.14159;
     rpyAct*=180/3.14159;

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -72,6 +72,7 @@ Stabilizer::Stabilizer(RTC::Manager* manager)
     m_actBaseRpyOut("actBaseRpy", m_actBaseRpy),
     m_currentBasePosOut("currentBasePos", m_currentBasePos),
     m_currentBaseRpyOut("currentBaseRpy", m_currentBaseRpy),
+    m_baseRpyIn_kf("base_rpy", m_baseRpy_kf),
     m_debugDataOut("debugData", m_debugData),
     control_mode(MODE_IDLE),
     st_algorithm(OpenHRP::StabilizerService::TPCC),
@@ -107,6 +108,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   addInPort("baseRpyIn", m_baseRpyIn);
   addInPort("contactStates", m_contactStatesIn);
   addInPort("controlSwingSupportTime", m_controlSwingSupportTimeIn);
+  addInPort("base_rpy", m_baseRpyIn_kf);
 
   // Set OutPort buffer
   addOutPort("q", m_qRefOut);
@@ -373,6 +375,9 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
   if (m_baseRpyIn.isNew()){
     m_baseRpyIn.read();
   }
+  if (m_baseRpyIn_kf.isNew()){
+    m_baseRpyIn_kf.read();
+  }
   if (m_contactStatesIn.isNew()){
     m_contactStatesIn.read();
     for (size_t i = 0; i < m_contactStates.data.length(); i++) {
@@ -531,7 +536,8 @@ void Stabilizer::getActualParameters ()
     hrp::Matrix33 senR = sen->link->R * sen->localR;
     hrp::Matrix33 act_Rs(hrp::rotFromRpy(m_rpy.data.r, m_rpy.data.p, m_rpy.data.y));
     //hrp::Matrix33 act_Rs(hrp::rotFromRpy(m_rpy.data.r*0.5, m_rpy.data.p*0.5, m_rpy.data.y*0.5));
-    m_robot->rootLink()->R = act_Rs * (senR.transpose() * m_robot->rootLink()->R);
+    m_robot->rootLink()->R = hrp::rotFromRpy(m_baseRpy_kf.data.r, m_baseRpy_kf.data.p, m_baseRpy_kf.data.y) * m_robot->rootLink()->R;
+    /* m_robot->rootLink()->R = act_Rs * (senR.transpose() * m_robot->rootLink()->R); */
     m_robot->calcForwardKinematics();
     act_base_rpy = hrp::rpyFromRot(m_robot->rootLink()->R);
     calcFootOriginCoords (foot_origin_pos, foot_origin_rot);

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -207,7 +207,8 @@ class Stabilizer
   RTC::OutPort<RTC::TimedPoint3D> m_currentBasePosOut;
   RTC::OutPort<RTC::TimedOrientation3D> m_currentBaseRpyOut;
   RTC::OutPort<RTC::TimedDoubleSeq> m_debugDataOut;
-  
+  RTC::TimedOrientation3D m_baseRpy_kf;
+  RTC::InPort<RTC::TimedOrientation3D> m_baseRpyIn_kf;
   // </rtc-template>
 
   // CORBA Port declaration


### PR DESCRIPTION
まだマージしないでいただきたいですが，

KFが出力する姿勢角が「直立姿勢時の姿勢センサの座標系で表した現在の姿勢センサの姿勢」になっていますが，「world座標系で表した現在のルートリンクの姿勢」を出力するポートを加えました．

現状のこのPRですと他のRTCやeusなどの上位層との整合性が取れていないのでまずはそのあたりにも対応させつつ，最終的には「world座標系で表した現在のルートリンクの姿勢」の方を使うように変えていきたいと思っています．