### PR TITLE
Reset virtual force sensor conf setting

### DIFF
--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -19,6 +19,7 @@ set(CONTROLLER_TIME 0.002)
 set(CONTROLLER_PERIOD 500)
 set(VirtualForceSensorSetting "virtual_force_sensor")
 configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.vfs.conf)
+set(VirtualForceSensorSetting "#virtual_force_sensor") # comment out
 set(JointLimitTableSetting "joint_limit_table")
 configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.el.conf)
 


### PR DESCRIPTION
サンプル用confファイルを生成するときに、virtual force sensorのセッティングが
elチェック用のものにもきいてきてしまっていたので、修正しました。

よろしくお願いいたします。