### PR TITLE
send emergency signal by hardware servo alarm

### DIFF
--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -44,6 +44,11 @@
 #define SS_POSITION_ERROR	0x200
 #define SS_ENCODER_ERROR	0x400
 #define SS_OTHER		0x800
+
+#define SS_RESERVED1		0x1000
+#define SS_RESERVED2		0x2000
+#define SS_RESERVED3		0x4000
+#define SS_EMERGENCY		0x8000
 //@}
 
 #define JID_ALL -1

--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -222,6 +222,9 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
               m_robot->servo("all", false);
               m_emergencySignal.data = reason;
               m_emergencySignalOut.write();
+          } else if (reason == robot::EMG_SERVO_ALARM) {
+              m_emergencySignal.data = reason;
+              m_emergencySignalOut.write();
           }
       }
   }    

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -211,7 +211,7 @@ public:
     /**
        \brief reasons of emergency
      */
-    typedef enum {EMG_SERVO_ERROR, EMG_FZ} emg_reason;
+    typedef enum {EMG_SERVO_ERROR, EMG_FZ, EMG_SERVO_ALARM} emg_reason;
 
     /**
        \brief check occurrence of emergency state
@@ -289,7 +289,7 @@ private:
     bool m_calibRequested;
     std::string m_calibJointName, m_calibOptions;
     std::string m_pdgainsFilename;
-
+    bool m_reportedEmergency;
     boost::interprocess::interprocess_semaphore wait_sem;
 };
 


### PR DESCRIPTION
servoのalarmフラグの未定義の4bitのうち１ビットを SS_EMERGENCYとさせていただき、
RobotHardwareの checkemergencyでこのビットが立っていたら、emergency signalを出すというようにしました。
https://github.com/fkanehiro/hrpsys-base/issues/490