### PR TITLE
Set all servo off if robot has no joints, which means single rigid body

### DIFF
--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -525,6 +525,7 @@ bool BodyRTC::preOneStep() {
                           << j->jointType << std::endl;
         }
     }
+    if (numJoints() == 0) { all_servo_off = false; }
     if ( all_servo_off ) { // when all servo is off, do not move root joint
         rootLink()->p = m_lastServoOn_p;
         rootLink()->setAttitude(m_lastServoOn_R);


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/560
の修正です。
hrpsys-simulatorのBodyRTCは、ロボットモデルだけでなく環境/物体モデルにも適用されます。

@k-okadaさん
新たに追加したservo off の部分で、ルートリンクの値がかわってしまうようです。
ちょっとどう直すのがよいか自身ないですが、関節がなければルートリンクをかえない？側のif文にいくようにしてみました。
もしかしたらdefaultRootPositionなどをかえたほうがよいかもしれません。