### PR TITLE
add setJointAnglesSequence, very simlar to playPattern but overwrite current motion

### DIFF
--- a/idl/SequencePlayerService.idl
+++ b/idl/SequencePlayerService.idl
@@ -198,5 +198,31 @@ module OpenHRP
      * @return true if set successfully, false otherwise
      */
     boolean setWrenches(in dSequence wrenches, in double tm);
+
+    /**
+     * @brief Interpolate all joint angles on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal.
+     * @param jvs sequence of sequence of joint angles [rad]
+     * @param tm sequence of duration [s]
+     * @return true joint angles are set successfully, false otherwise
+     */
+    boolean setJointAnglesSequence(in dSequenceSequence jvss, in dSequence tms);
+
+    /**
+     * @brief Interpolate all joint angles on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal.
+     * @param jvs sequence of sequence of joint angles  [rad]
+     * @param mask binary vector which selects joints to be interpolated
+     * @param tm sequence of duration [s]
+     * @return true joint angles are set successfully, false otherwise
+     */
+    boolean setJointAnglesSequenceWithMask(in dSequenceSequence jvss, in bSequence mask, in dSequence tms);
+
+    /**
+     * @brief Interpolate all joint angles in groups, using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal.
+     * @param gname name of the joint group
+     * @param jvs sequence of sequence of joint angles [rad]
+     * @param tm sequence of duration [s]
+     * @return true joint angles are set successfully, false otherwise
+     */
+    boolean setJointAnglesSequenceOfGroup(in string gname, in dSequenceSequence jvss, in dSequence tms);
   };
 };

--- a/idl/SequencePlayerService.idl
+++ b/idl/SequencePlayerService.idl
@@ -224,5 +224,21 @@ module OpenHRP
      * @return true joint angles are set successfully, false otherwise
      */
     boolean setJointAnglesSequenceOfGroup(in string gname, in dSequenceSequence jvss, in dSequence tms);
+
+    /**
+     * @brief Interpolate all joint angles, using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal.
+     * @param jvss sequence of sequence of joint angles [rad]
+     * @param vels sequence of sequence of velocities [rad/s]
+     * @param accs sequence of sequence of torques [N]
+     * @param poss sequence of weist pos [mm]
+     * @param rpys sequence of weist rpy [rad]
+     * @param accs sequence of weist acc [m/ss]
+     * @param zmps sequence of weist zmp [mm]
+     * @param wrenches sequence of wrenches [N, Nm]
+     * @param optionss sequence of options []
+     * @param tms sequence of duration [s]
+     * @return true joint angles are set successfully, false otherwise
+     */
+    boolean setJointAnglesSequenceFull(in dSequenceSequence jvss, in dSequenceSequence vels,  in dSequenceSequence torques, in dSequenceSequence poss, in dSequenceSequence rpys, in dSequenceSequence accs, in dSequenceSequence zmps, in dSequenceSequence wrenchs, in dSequenceSequence optionals, in dSequence tms);
   };
 };

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -987,6 +987,26 @@ class HrpsysConfigurator:
                 angles[i] = angles[i] / 180.0 * math.pi
         return self.seq_svc.setJointAnglesSequence(angless, tms)
 
+    def setJointAnglesSequenceOfGroup(self, gname, angless, tms):
+        '''!@brief
+        Set all joint angles.
+        \verbatim
+        NOTE-1: that while this method does not check angle value range,
+                any joints could emit position limit over error, which has not yet
+                been thrown by hrpsys so that there's no way to catch on this client
+                side. Worthwhile opening an enhancement ticket for that at
+                hironx' designated issue tracker.
+
+        \endverbatim
+        @param gname str: Name of the joint group.
+        @param sequence angles list of float: In degree.
+        @param tm sequence of float: Time to complete, In Second
+        '''
+        for angles in angless:
+            for i in range(len(angles)):
+                angles[i] = angles[i] / 180.0 * math.pi
+        return self.seq_svc.setJointAnglesSequenceOfGroup(gname, angless, tms)
+
     def loadPattern(self, fname, tm):
         '''!@brief
         Load a pattern file that is created offline.

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -968,6 +968,25 @@ class HrpsysConfigurator:
             self.waitInterpolationOfGroup(gname)
         return ret
 
+    def setJointAnglesSequence(self, angless, tms):
+        '''!@brief
+        Set all joint angles.
+        \verbatim
+        NOTE-1: that while this method does not check angle value range,
+                any joints could emit position limit over error, which has not yet
+                been thrown by hrpsys so that there's no way to catch on this client
+                side. Worthwhile opening an enhancement ticket for that at
+                hironx' designated issue tracker.
+
+        \endverbatim
+        @param sequence angles list of float: In degree.
+        @param tm sequence of float: Time to complete, In Second
+        '''
+        for angles in angless:
+            for i in range(len(angles)):
+                angles[i] = angles[i] / 180.0 * math.pi
+        return self.seq_svc.setJointAnglesSequence(angless, tms)
+
     def loadPattern(self, fname, tm):
         '''!@brief
         Load a pattern file that is created offline.

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -456,6 +456,31 @@ bool SequencePlayer::setJointAnglesSequenceOfGroup(const char *gname, const Open
     return m_seq->setJointAnglesSequenceOfGroup(gname, v_poss, v_tms);
 }
 
+bool SequencePlayer::setJointAnglesSequenceFull(const OpenHRP::dSequenceSequence i_jvss, const OpenHRP::dSequenceSequence i_vels, const OpenHRP::dSequenceSequence i_torques, const OpenHRP::dSequenceSequence i_poss, const OpenHRP::dSequenceSequence i_rpys, const OpenHRP::dSequenceSequence i_accs, const OpenHRP::dSequenceSequence i_zmps, const OpenHRP::dSequenceSequence i_wrenches, const OpenHRP::dSequenceSequence i_optionals, const dSequence i_tms)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+
+    if (!setInitialState()) return false;
+
+    int len = i_jvss.length();
+    std::vector<const double*> v_jvss, v_vels, v_torques, v_poss, v_rpys, v_accs, v_zmps, v_wrenches, v_optionals;
+    std::vector<double> v_tms;
+    for ( int i = 0; i < i_jvss.length(); i++ ) v_poss.push_back(i_jvss[i].get_buffer());
+    for ( int i = 0; i < i_vels.length(); i++ ) v_poss.push_back(i_vels[i].get_buffer());
+    for ( int i = 0; i < i_torques.length(); i++ ) v_poss.push_back(i_torques[i].get_buffer());
+    for ( int i = 0; i < i_poss.length(); i++ ) v_poss.push_back(i_poss[i].get_buffer());
+    for ( int i = 0; i < i_rpys.length(); i++ ) v_poss.push_back(i_rpys[i].get_buffer());
+    for ( int i = 0; i < i_accs.length(); i++ ) v_poss.push_back(i_accs[i].get_buffer());
+    for ( int i = 0; i < i_zmps.length(); i++ ) v_poss.push_back(i_zmps[i].get_buffer());
+    for ( int i = 0; i < i_wrenches.length(); i++ ) v_poss.push_back(i_wrenches[i].get_buffer());
+    for ( int i = 0; i < i_optionals.length(); i++ ) v_poss.push_back(i_optionals[i].get_buffer());
+    for ( int i = 0; i < i_tms.length();  i++ )  v_tms.push_back(i_tms[i]);
+    return m_seq->setJointAnglesSequenceFull(v_jvss, v_vels, v_torques, v_poss, v_rpys, v_accs, v_zmps, v_wrenches, v_optionals, v_tms);
+}
+
 bool SequencePlayer::setBasePos(const double *pos, double tm)
 {
     if ( m_debugLevel > 0 ) {

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -389,7 +389,11 @@ bool SequencePlayer::setJointAngles(const double *angles, double tm)
     absZmp[2] = 0;
     hrp::Link *root = m_robot->rootLink();
     hrp::Vector3 relZmp = root->R.transpose()*(absZmp - root->p);
-    m_seq->setJointAngles(angles, tm);
+    std::vector<const double*> v_poss;
+    std::vector<double> v_tms;
+    v_poss.push_back(angles);
+    v_tms.push_back(tm);
+    m_seq->setJointAnglesSequence(v_poss, v_tms);
     m_seq->setZmp(relZmp.data(), tm);
     return true;
 }

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -439,6 +439,23 @@ bool SequencePlayer::setJointAnglesSequence(const OpenHRP::dSequenceSequence ang
     return m_seq->setJointAnglesSequence(v_poss, v_tms);
 }
 
+bool SequencePlayer::setJointAnglesSequenceOfGroup(const char *gname, const OpenHRP::dSequenceSequence angless, const OpenHRP::dSequence& times)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+    if (!setInitialState()) return false;
+
+    if (!m_seq->resetJointGroup(gname, m_qInit.data.get_buffer())) return false;
+
+    std::vector<const double*> v_poss;
+    std::vector<double> v_tms;
+    for ( int i = 0; i < angless.length(); i++ ) v_poss.push_back(angless[i].get_buffer());
+    for ( int i = 0; i <  times.length();  i++ )  v_tms.push_back(times[i]);
+    return m_seq->setJointAnglesSequenceOfGroup(gname, v_poss, v_tms);
+}
+
 bool SequencePlayer::setBasePos(const double *pos, double tm)
 {
     if ( m_debugLevel > 0 ) {

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -412,6 +412,29 @@ bool SequencePlayer::setJointAngles(const double *angles, const bool *mask,
     return true;
 }
 
+bool SequencePlayer::setJointAnglesSequence(const OpenHRP::dSequenceSequence angless, const OpenHRP::bSequence& mask, const OpenHRP::dSequence& times)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+
+    if (!setInitialState()) return false;
+
+    bool tmp_mask[robot()->numJoints()];
+    if (mask.length() != robot()->numJoints()) {
+        for (int i=0; i < robot()->numJoints(); i++) tmp_mask[i] = true;
+    }else{
+        for (int i=0; i < robot()->numJoints(); i++) tmp_mask[i] = mask.get_buffer()[i];
+    }
+    int len = angless.length();
+    std::vector<const double*> v_poss;
+    std::vector<double> v_tms;
+    for ( int i = 0; i < angless.length(); i++ ) v_poss.push_back(angless[i].get_buffer());
+    for ( int i = 0; i <  times.length();  i++ )  v_tms.push_back(times[i]);
+    return m_seq->setJointAnglesSequence(v_poss, v_tms);
+}
+
 bool SequencePlayer::setBasePos(const double *pos, double tm)
 {
     if ( m_debugLevel > 0 ) {

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -112,6 +112,7 @@ class SequencePlayer
   bool addJointGroup(const char *gname, const OpenHRP::SequencePlayerService::StrSequence& jnames);
   bool removeJointGroup(const char *gname);
   bool setJointAnglesOfGroup(const char *gname, const double *angles, double tm);
+  bool setJointAnglesSequenceOfGroup(const char *gname, const OpenHRP::dSequenceSequence angless, const OpenHRP::dSequence& times);
   bool playPatternOfGroup(const char *gname, const OpenHRP::dSequenceSequence& pos, const OpenHRP::dSequence& tm);
 
   void setMaxIKError(double pos, double rot);

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -100,6 +100,7 @@ class SequencePlayer
   bool setJointAngles(const double *angles, double tm);
   bool setJointAngles(const double *angles, const bool *mask, double tm);
   bool setJointAnglesSequence(const OpenHRP::dSequenceSequence angless, const OpenHRP::bSequence& mask, const OpenHRP::dSequence& times);
+  bool setJointAnglesSequenceFull(const OpenHRP::dSequenceSequence i_jvss, const OpenHRP::dSequenceSequence i_vels, const OpenHRP::dSequenceSequence i_torques, const OpenHRP::dSequenceSequence i_poss, const OpenHRP::dSequenceSequence i_rpys, const OpenHRP::dSequenceSequence i_accs, const OpenHRP::dSequenceSequence i_zmps, const OpenHRP::dSequenceSequence i_wrenches, const OpenHRP::dSequenceSequence i_optionals, const dSequence i_tms);
   bool setBasePos(const double *pos, double tm);
   bool setBaseRpy(const double *rpy, double tm);
   bool setZmp(const double *zmp, double tm);

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -99,6 +99,7 @@ class SequencePlayer
   bool setJointAngle(short id, double angle, double tm);
   bool setJointAngles(const double *angles, double tm);
   bool setJointAngles(const double *angles, const bool *mask, double tm);
+  bool setJointAnglesSequence(const OpenHRP::dSequenceSequence angless, const OpenHRP::bSequence& mask, const OpenHRP::dSequence& times);
   bool setBasePos(const double *pos, double tm);
   bool setBaseRpy(const double *rpy, double tm);
   bool setZmp(const double *zmp, double tm);

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -70,6 +70,113 @@ CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceWithMask(const 
   return m_player->setJointAnglesSequence(jvss, mask, tms);
 }
 
+CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceFull(const dSequenceSequence& jvss, const dSequenceSequence& vels, const dSequenceSequence& torques, const dSequenceSequence& poss, const dSequenceSequence& rpys, const dSequenceSequence& accs, const dSequenceSequence& zmps, const dSequenceSequence& wrenches, const dSequenceSequence& optionals, const dSequence &tms)
+{
+  if (jvss.length() <= 0) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint angles sequence is invalid:" << jvss.length() << " > 0" << std::endl;
+      return false;
+  }
+  if (jvss.length() != tms.length()) {
+      std::cerr << __PRETTY_FUNCTION__ << " length of joint angles sequence and time sequence differ, joint angle:" << jvss.length() << ", time:" << tms.length() << std::endl;
+      return false;
+  }
+  const dSequence& jvs = jvss[0];
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  if (vels.length() > 0 ) {
+      const dSequence& vel = vels[0];
+      if (vels.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of joint velocitys sequence and time sequence differ, joint velocity:" << vels.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( vel.length() != (unsigned int)(m_player->robot()->numJoints())) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", vel:" << vel.length() << ", robot" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+          return false;
+      }
+  }
+  if (torques.length() > 0 ) {
+      const dSequence& torque = torques[0];
+      if (torques.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of joint torque sequence and time sequence differ, joint torque:" << torques.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( torque.length() != (unsigned int)(m_player->robot()->numJoints())) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", torque:" << torque.length() << ", robot" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+          return false;
+      }
+  }
+
+  if (poss.length() > 0) {
+      const dSequence& pos = poss[0];
+      if (poss.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of base pos sequence and time sequence differ, pos:" << poss.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( pos.length() != 3) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of base pos is differ, pos:" << pos.length() << std::endl;
+          return false;
+      }
+  }
+
+  if (rpys.length() > 0) {
+      const dSequence& rpy = rpys[0];
+      if (rpys.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of base rpy sequence and time sequence differ, rpy:" << rpys.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( rpy.length() != 3) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of base rpy is differ, rpy:" << rpy.length() << std::endl;
+          return false;
+      }
+  }
+
+  if (accs.length() > 0 ) {
+      const dSequence& acc = accs[0];
+      if (accs.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of joint accocitys sequence and time sequence differ, joint accocity:" << accs.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( acc.length() != (unsigned int)(m_player->robot()->numJoints())) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", acc:" << acc.length() << ", robot" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+          return false;
+      }
+  }
+
+  if (zmps.length() > 0) {
+      const dSequence& zmp = zmps[0];
+      if (zmps.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of zmp sequence and time sequence differ, zmp:" << zmps.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      if ( zmp.length() != 3) {
+          std::cerr << __PRETTY_FUNCTION__ << " num of zmp is differ, zmp:" << zmp.length() <<  std::endl;
+          return false;
+      }
+  }
+
+  if (wrenches.length() > 0) {
+      if (wrenches.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of wrench sequence and time sequence differ, wrench:" << wrenches.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      // need to check size of wrench
+      //const dSequence& wrench = wrenches[0];
+  }
+
+  if (optionals.length() > 0) {
+      if (optionals.length() != tms.length()) {
+          std::cerr << __PRETTY_FUNCTION__ << " length of optional sequence and time sequence differ, optional:" << optionals.length() << ", time:" << tms.length() << std::endl;
+          return false;
+      }
+      // need to check size of optional
+      //const dSequence& optional = optionasl[0];
+  }
+
+  return m_player->setJointAnglesSequenceFull(jvss, vels, torques, poss, rpys, accs, zmps, wrenches, optionals, tms);
+}
+
 CORBA::Boolean SequencePlayerService_impl::setJointAngle(const char *jname, CORBA::Double jv, CORBA::Double tm)
 {
     BodyPtr r = m_player->robot();

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -186,7 +186,11 @@ CORBA::Boolean SequencePlayerService_impl::setJointAnglesOfGroup(const char *gna
 
 CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceOfGroup(const char *gname, const dSequenceSequence& jvss, const dSequence& tms)
 {
-    return false;
+    if (jvss.length() != tms.length()) {
+        std::cerr << __PRETTY_FUNCTION__ << " length of joint angles sequence and time sequence differ, joint angle:" << jvss.length() << ", time:" << tms.length() << std::endl;
+        return false;
+    }
+    return m_player->setJointAnglesSequenceOfGroup(gname, jvss, tms);
 }
 
 CORBA::Boolean SequencePlayerService_impl::playPatternOfGroup(const char *gname, const dSequenceSequence& pos, const dSequence& tm)

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -40,6 +40,35 @@ CORBA::Boolean SequencePlayerService_impl::setJointAnglesWithMask(const dSequenc
     return m_player->setJointAngles(jvs.get_buffer(), mask.get_buffer(), tm);
 }
 
+CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequence(const dSequenceSequence& jvss, const dSequence& tms)
+{
+  const OpenHRP::bSequence mask;
+  return setJointAnglesSequenceWithMask(jvss, mask, tms);
+}
+
+CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceWithMask(const dSequenceSequence& jvss, const bSequence& mask, const dSequence& tms)
+{
+  if (jvss.length() <= 0) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint angles sequence is invalid:" << jvss.length() << " > 0" << std::endl;
+      return false;
+  }
+  if (jvss.length() != tms.length()) {
+      std::cerr << __PRETTY_FUNCTION__ << " length of joint angles sequence and time sequence differ, joint angle:" << jvss.length() << ", time:" << tms.length() << std::endl;
+      return false;
+  }
+  const dSequence& jvs = jvss[0];
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+
+  if (mask.length() > 0 && mask.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", mask:" << mask.length() << ", robot" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  
+  return m_player->setJointAnglesSequence(jvss, mask, tms);
+}
 
 CORBA::Boolean SequencePlayerService_impl::setJointAngle(const char *jname, CORBA::Double jv, CORBA::Double tm)
 {
@@ -153,6 +182,11 @@ CORBA::Boolean SequencePlayerService_impl::removeJointGroup(const char* gname)
 CORBA::Boolean SequencePlayerService_impl::setJointAnglesOfGroup(const char *gname, const dSequence& jvs, CORBA::Double tm)
 {
     return m_player->setJointAnglesOfGroup(gname, jvs.get_buffer(), tm);
+}
+
+CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceOfGroup(const char *gname, const dSequenceSequence& jvss, const dSequence& tms)
+{
+    return false;
 }
 
 CORBA::Boolean SequencePlayerService_impl::playPatternOfGroup(const char *gname, const dSequenceSequence& pos, const dSequence& tm)

--- a/rtc/SequencePlayer/SequencePlayerService_impl.h
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.h
@@ -20,6 +20,7 @@ public:
   CORBA::Boolean waitInterpolationOfGroup(const char *gname);
   CORBA::Boolean setJointAnglesSequence(const dSequenceSequence& jvs, const dSequence &tms);
   CORBA::Boolean setJointAnglesSequenceWithMask(const dSequenceSequence& jvs, const bSequence& mask, const dSequence &tms);
+  CORBA::Boolean setJointAnglesSequenceFull(const dSequenceSequence& jvss, const dSequenceSequence& vels, const dSequenceSequence& torques, const dSequenceSequence& poss, const dSequenceSequence& rpys, const dSequenceSequence& accs, const dSequenceSequence& zmps, const dSequenceSequence& wrenches, const dSequenceSequence& optionals, const dSequence &tms);
   CORBA::Boolean setJointAngles(const dSequence& jvs, CORBA::Double tm);
   CORBA::Boolean setJointAnglesWithMask(const dSequence& jvs, const bSequence& mask, CORBA::Double tm);
   CORBA::Boolean setJointAngle(const char *jname, CORBA::Double jv, CORBA::Double tm);

--- a/rtc/SequencePlayer/SequencePlayerService_impl.h
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.h
@@ -18,6 +18,8 @@ public:
   //
   void waitInterpolation();
   CORBA::Boolean waitInterpolationOfGroup(const char *gname);
+  CORBA::Boolean setJointAnglesSequence(const dSequenceSequence& jvs, const dSequence &tms);
+  CORBA::Boolean setJointAnglesSequenceWithMask(const dSequenceSequence& jvs, const bSequence& mask, const dSequence &tms);
   CORBA::Boolean setJointAngles(const dSequence& jvs, CORBA::Double tm);
   CORBA::Boolean setJointAnglesWithMask(const dSequence& jvs, const bSequence& mask, CORBA::Double tm);
   CORBA::Boolean setJointAngle(const char *jname, CORBA::Double jv, CORBA::Double tm);
@@ -36,6 +38,7 @@ public:
   CORBA::Boolean addJointGroup(const char* gname, const OpenHRP::SequencePlayerService::StrSequence& jnames);
   CORBA::Boolean removeJointGroup(const char* gname);
   CORBA::Boolean setJointAnglesOfGroup(const char *gname, const dSequence& jvs, CORBA::Double tm);
+  CORBA::Boolean setJointAnglesSequenceOfGroup(const char *gname, const dSequenceSequence& jvs, const dSequence &tms);
   CORBA::Boolean clearOfGroup(const char *gname, CORBA::Double  i_timelimit);
   CORBA::Boolean playPatternOfGroup(const char *gname, const dSequenceSequence& pos, const dSequence& tm);
   void setMaxIKError(CORBA::Double pos, CORBA::Double rot);

--- a/rtc/SequencePlayer/interpolator.cpp
+++ b/rtc/SequencePlayer/interpolator.cpp
@@ -117,9 +117,10 @@ bool interpolator::setInterpolationMode (interpolation_mode i_mode_)
     return true;
 };
 
-void interpolator::setGoal(const double *newg, double time)
+void interpolator::setGoal(const double *newg, double time,
+                           bool online)
 {
-    setGoal(newg, NULL, time);
+    setGoal(newg, NULL, time, online);
 }
 
 void interpolator::setGoal(const double *newg, const double *newv, double time,

--- a/rtc/SequencePlayer/interpolator.h
+++ b/rtc/SequencePlayer/interpolator.h
@@ -34,7 +34,7 @@ public:
   bool setInterpolationMode (interpolation_mode i_mode_);
   void setGoal(const double *gx, const double *gv, double time,
                bool online=true);
-  void setGoal(const double *gx, double time);
+  void setGoal(const double *gx, double time, bool online=true);
   void interpolate(double& remain_t);
   double deltaT() const { return dt; }
 private:

--- a/rtc/SequencePlayer/interpolator.h
+++ b/rtc/SequencePlayer/interpolator.h
@@ -37,6 +37,7 @@ public:
   void setGoal(const double *gx, double time, bool online=true);
   void interpolate(double& remain_t);
   double deltaT() const { return dt; }
+  double dimension() const { return dim; }
 private:
   interpolation_mode imode;
   deque<double *> q, dq, ddq;

--- a/rtc/SequencePlayer/seqplay.cpp
+++ b/rtc/SequencePlayer/seqplay.cpp
@@ -585,10 +585,11 @@ bool seqplay::playPatternOfGroup(const char *gname, std::vector<const double *> 
 bool seqplay::setJointAnglesSequence(std::vector<const double*> pos, std::vector<double> tm)
 {
 	// setJointAngles to override curren tgoal
-	double x[m_dof], v[m_dof];
-	interpolators[Q]->get(x, v, false);
+	double x[m_dof], v[m_dof], a[m_dof];
+	interpolators[Q]->get(x, v, a, false);
 	interpolators[Q]->set(x, v);
 	interpolators[Q]->clear();
+	interpolators[Q]->push(x, v, a, true);
 
     const double *q=NULL;
     for (unsigned int i=0; i<pos.size(); i++){
@@ -630,35 +631,46 @@ bool seqplay::setJointAnglesSequence(std::vector<const double*> pos, std::vector
 bool seqplay::setJointAnglesSequenceFull(std::vector<const double*> i_pos, std::vector<const double*> i_vel, std::vector<const double*> i_torques, std::vector<const double*> i_bpos, std::vector<const double*> i_brpy, std::vector<const double*> i_bacc,  std::vector<const double*> i_zmps, std::vector<const double*> i_wrenches, std::vector<const double*> i_optionals, std::vector<double> i_tm)
 {
 	// setJointAngles to override curren tgoal
-	double x[m_dof], v[m_dof];
-	interpolators[Q]->get(x, v, false);
+	double x[m_dof], v[m_dof], a[m_dof];
+	interpolators[Q]->get(x, v, a, false);
 	interpolators[Q]->set(x, v);
 	interpolators[Q]->clear();
-	double torque[m_dof];
+	interpolators[Q]->push(x, v, a, true);
+	double torque[m_dof], dummy_dof[m_dof];
+	for (unsigned int j = 0; j < m_dof; j++) { dummy_dof[j] = 0.0; }
 	interpolators[TQ]->get(torque, false);
 	interpolators[TQ]->set(torque);
 	interpolators[TQ]->clear();
-	double bpos[3], brpy[3], bacc[3];
+	interpolators[TQ]->push(torque, dummy_dof, dummy_dof, true);
+	double bpos[3], brpy[3], bacc[3], dummy_3[3]={0,0,0};
 	interpolators[P]->get(bpos, false);
 	interpolators[P]->set(bpos);
 	interpolators[P]->clear();
+	interpolators[P]->push(bpos, dummy_3, dummy_3, true);
 	interpolators[RPY]->get(brpy, false);
 	interpolators[RPY]->set(brpy);
 	interpolators[RPY]->clear();
+	interpolators[RPY]->push(brpy, dummy_3, dummy_3, true);
 	interpolators[ACC]->get(bacc, false);
 	interpolators[ACC]->set(bacc);
 	interpolators[ACC]->clear();
+	interpolators[RPY]->push(bacc, dummy_3, dummy_3, true);
 	int fnum = interpolators[WRENCHES]->dimension()/6, optional_data_dim = interpolators[OPTIONAL_DATA]->dimension();
-	double zmp[3], wrench[6*fnum], optional[optional_data_dim];
+	double zmp[3], wrench[6*fnum], dummy_fnum[6*fnum], optional[optional_data_dim], dummy_optional[optional_data_dim];
+	for (unsigned int j = 0; j < 6*fnum; j++) { dummy_dof[j] = 0.0; }
+	for (unsigned int j = 0; j < optional_data_dim; j++) { dummy_optional[j] = 0.0; }
 	interpolators[ZMP]->get(zmp, false);
 	interpolators[ZMP]->set(zmp);
 	interpolators[ZMP]->clear();
+	interpolators[ZMP]->push(zmp, dummy_3, dummy_3, true);
 	interpolators[WRENCHES]->get(wrench, false);
 	interpolators[WRENCHES]->set(wrench);
 	interpolators[WRENCHES]->clear();
+	interpolators[WRENCHES]->push(wrench, dummy_fnum, dummy_fnum, true);
 	interpolators[OPTIONAL_DATA]->get(optional, false);
 	interpolators[OPTIONAL_DATA]->set(optional);
 	interpolators[OPTIONAL_DATA]->clear();
+	interpolators[OPTIONAL_DATA]->push(optional, dummy_optional, dummy_optional, true);
 
     const double *q=NULL;
     for (unsigned int i=0; i<i_pos.size(); i++){

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -38,6 +38,7 @@ public:
     bool resetJointGroup(const char *gname, const double *full);
     //
     bool setJointAnglesSequence(std::vector<const double*> pos, std::vector<double> tm);
+    bool setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm);
     //
     void setJointAngle(unsigned int i_rank, double jv, double tm);
     void loadPattern(const char *i_basename, double i_tm);

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -37,6 +37,8 @@ public:
 
     bool resetJointGroup(const char *gname, const double *full);
     //
+    bool setJointAnglesSequence(std::vector<const double*> pos, std::vector<double> tm);
+    //
     void setJointAngle(unsigned int i_rank, double jv, double tm);
     void loadPattern(const char *i_basename, double i_tm);
     void clear(double i_timeLimit=0);

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -39,6 +39,7 @@ public:
     //
     bool setJointAnglesSequence(std::vector<const double*> pos, std::vector<double> tm);
     bool setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm);
+    bool setJointAnglesSequenceFull(std::vector<const double*> pos, std::vector<const double*> vel, std::vector<const double*> torques, std::vector<const double*> bpos, std::vector<const double*> brpy, std::vector<const double*> bacc, std::vector<const double*> zmps, std::vector<const double*> wrenches, std::vector<const double*> optionals, std::vector<double> tm);
     //
     void setJointAngle(unsigned int i_rank, double jv, double tm);
     void loadPattern(const char *i_basename, double i_tm);


### PR DESCRIPTION
関節角度列の時系列データを送るときに，現在ロボットが動いていても動いていなくても，即座に指令を反映させて欲しい，という希望が有りました．
（playPatternでは，指令した時系列関節角データが全て送り終わってから出ないと次の指令が反映されない）

- playPatternの挙動を替えるという作戦もありえます．
- どちらにせよ，setJointAngleSequenceとsetJointAnglesを混ぜて使うと変になる気がします．(シミュレータが止まる？）
 - ちゃんと理解したわけではないですが，playPaternではqueueにすべての指令値を入れていて，setJointAngles()ではonExecuteの度に指令値を補間して作っている気がします．前者でないsetJointAngleSequenceは作れない気がして，今の実装ですが，setJointAnglesも同じようにしても大丈夫そうでしょうか？

@YoheiKakiuchi @snozawa 