### PR TITLE
rewrite hrpsyspy

### DIFF
--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,6 +1,4 @@
-configure_file(hrpsyspy.in ${CMAKE_CURRENT_BINARY_DIR}/hrpsyspy)
-
-install(PROGRAMS ${CMAKE_CURRENT_BINARY_DIR}/hrpsyspy DESTINATION bin)
+install(PROGRAMS hrpsyspy DESTINATION bin)
 install(FILES __init__.py rtm.py waitInput.py DESTINATION ${python_dist_pkg_dir}/hrpsys)
 install(PROGRAMS hrpsys_config.py DESTINATION ${python_dist_pkg_dir}/hrpsys)
 

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -570,11 +570,10 @@ class HrpsysConfigurator:
         else:
             return [comp, None, version]
 
-    def findComps(self):
+    def findComps(self, max_timeout_count = 10):
         '''!@brief
         Check if all components in getRTCList() are created
         '''
-        max_timeout_count = 10
         for rn in self.getRTCList():
             rn2 = 'self.' + rn[0]
             if eval(rn2) == None:

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -538,7 +538,7 @@ class HrpsysConfigurator:
                 _, e, _ = sys.exc_info()
                 print(self.configurator_name + '\033[31mFail to deleteComps' + str(e) + '\033[0m')
 
-    def findComp(self, compName, instanceName, max_timeout_count=10):
+    def findComp(self, compName, instanceName, max_timeout_count=10, verbose=True):
         '''!@brief
         Find component(plugin) 
         
@@ -553,32 +553,37 @@ class HrpsysConfigurator:
             comp = rtm.findRTC(instanceName)
             if comp != None:
                 break
-            print(self.configurator_name + " find Comp wait for " + instanceName)
+            if verbose:
+                print(self.configurator_name + " find Comp wait for " + instanceName)
             time.sleep(1)
             timeout_count += 1
         if comp and comp.ref:
             version = comp.ref.get_component_profile().version
-        print(self.configurator_name + " find Comp    : %s = %s (%s)" % (instanceName, comp, version))
+        if verbose:
+            print(self.configurator_name + " find Comp    : %s = %s (%s)" % (instanceName, comp, version))
         if comp == None:
-            print(self.configurator_name + " Cannot find component: %s (%s)" % (instanceName, compName))
+            if verbose:
+                print(self.configurator_name + " Cannot find component: %s (%s)" % (instanceName, compName))
             return [None, None, None]
         comp_svc_port = comp.service("service0")
         if comp_svc_port:
             comp_svc = narrow(comp_svc_port, compName + "Service")
-            print(self.configurator_name + " find CompSvc : %s_svc = %s"%(instanceName, comp_svc))
+            if verbose:
+                print(self.configurator_name + " find CompSvc : %s_svc = %s"%(instanceName, comp_svc))
             return [comp, comp_svc, version]
         else:
             return [comp, None, version]
 
-    def findComps(self, max_timeout_count = 10):
+    def findComps(self, max_timeout_count = 10, verbose=True):
         '''!@brief
         Check if all components in getRTCList() are created
         '''
         for rn in self.getRTCList():
             rn2 = 'self.' + rn[0]
             if eval(rn2) == None:
-                create_str = "[self." + rn[0] + ", self." + rn[0] + "_svc, self." + rn[0] + "_version] = self.findComp(\"" + rn[1] + "\",\"" + rn[0] + "\"," + str(max_timeout_count) + ")"
-                print(self.configurator_name + create_str)
+                create_str = "[self." + rn[0] + ", self." + rn[0] + "_svc, self." + rn[0] + "_version] = self.findComp(\"" + rn[1] + "\",\"" + rn[0] + "\"," + str(max_timeout_count) + "," + str(verbose) + ")"
+                if verbose:
+                    print(self.configurator_name + create_str)
                 exec(create_str)
                 if eval(rn2) == None:
                     max_timeout_count = 0

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -553,7 +553,7 @@ class HrpsysConfigurator:
             comp = rtm.findRTC(instanceName)
             if comp != None:
                 break
-            print(self.configurator_name + " find Comp wait for" + instanceName)
+            print(self.configurator_name + " find Comp wait for " + instanceName)
             time.sleep(1)
             timeout_count += 1
         if comp and comp.ref:

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -645,7 +645,7 @@ class HrpsysConfigurator:
                            self.tc, self.el]
         return filter(lambda c: c != None, controller_list)  # only return existing controllers
 
-    def getRTCInstanceList(self):
+    def getRTCInstanceList(self, verbose=True):
         '''!@brief
         Get list of RTC Instance
         '''
@@ -656,7 +656,8 @@ class HrpsysConfigurator:
                 if eval(r): 
                     ret.append(eval(r))
                 else:
-                    print(self.configurator_name + '\033[31mFail to find instance ('+str(rtc)+') for getRTCInstanceList\033[0m')
+                    if verbose:
+                        print(self.configurator_name + '\033[31mFail to find instance ('+str(rtc)+') for getRTCInstanceList\033[0m')
             except Exception:
                 _, e, _ = sys.exc_info()
                 print(self.configurator_name + '\033[31mFail to getRTCInstanceList'+str(e)+'\033[0m')

--- a/python/hrpsyspy
+++ b/python/hrpsyspy
@@ -1,0 +1,50 @@
+#!/usr/bin/env python
+
+from hrpsys.hrpsys_config import *
+import OpenHRP
+
+import argparse, code
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="hrpsys command line interpreters, try `hrpsyspy -- --host xxxx --port xxxx `")
+    parser.add_argument('--host', help='corba name server hostname', default='localhost')
+    parser.add_argument('--port', help='corba name server port number', default=15005)
+    parser.add_argument('--robot', help='robot modlule name (RobotHardware0) for real robot)', default='RobotHardware0')
+    args, unknown = parser.parse_known_args()
+
+    if args.host:
+        rtm.nshost = args.host
+    if args.port:
+        rtm.nsport = args.port
+    rh_name = args.robot
+
+    hcf = HrpsysConfigurator()
+    hcf.getRTCList = hcf.getRTCListUnstable
+    # estimate robot hardware name
+    hcf.waitForRTCManager(args.host)
+    if rh_name in [x.name() for x in hcf.ms.get_components()]:
+        pass
+    else:
+        for x in hcf.ms.get_components():
+            try: # see findService() in rtm.py
+                for pp in x.ref.get_component_profile().port_profiles:
+                    ifs = pp.interfaces
+                    for aif in ifs:
+                        if aif.instance_name == "service0" and aif.type_name == "RobotHardwareService" and aif.polarity == PROVIDED:
+                            rh_name = x.name()
+            except:
+                pass
+    hcf.waitForRobotHardware(rh_name)
+    hcf.checkSimulationMode()
+    hcf.findComps(max_timeout_count=0, verbose=False)
+    rtc = hcf.getRTCInstanceList(verbose=False)
+    print('\033[33;1mStarting hrpsys python interface for %s\033[0m'%(rtc[0].name()))
+    print('\033[32;1m Installed rtc are ...\033[0m'),
+    for r in rtc[1:]:
+        print('\033[32;1m %s \033[0m'%(r.name())),
+    print('\033[32;1m\033[0m')
+    print("\033[32;1m Use 'hcf' instance to access to the hrpsys controller\033[0m")
+
+# start ipython
+from IPython import embed
+embed()
+

--- a/python/hrpsyspy.in
+++ b/python/hrpsyspy.in
@@ -1,7 +1,0 @@
-#!/bin/bash
-
-export PYTHONPATH=@python_dist_pkg_dir@:$PYTHONPATH
-
-ipython $@
-
-


### PR DESCRIPTION
hrpsyspyは使われていますでしょうか？
https://github.com/start-jsk/rtmros_common/pull/569
やhttps://github.com/start-jsk/rtmros_common/blob/master/hrpsys_tools/scripts/hrpsys_tools_config.py
などいろいろあるんですが，なかなかつ使われない（忘れてしまう？）ので，hrpsys-baseに入れたらいい気がしています．とりあえず引数なしで立ち上げてもいい感じでhcfを作ってくれるようになりました．
![screenshot from 2015-04-14 19 01 02](https://cloud.githubusercontent.com/assets/493276/7134749/d18ea98e-e2da-11e4-99a8-0469082038d4.png)


- [python/hrpsyspy] rewrite hrpsyspy, now you can just call hrpsyspy to create hcf instance
- [hrpsys_config.py] add verbose option to findCOmps()
- [hrpsys_config.py] add max_timeout_count to findComps()
- [hrpsys_config.py] fix print message
- [hrpsys_config.py] add verbose option to getRTCInstanceList()