### PR TITLE
install drctestbed.xml to devel

### DIFF
--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -34,6 +34,8 @@ foreach(_idx 0 1 2)
   set(ROBOT_WAIST_TRANSLATION ${_tmp_robot_waist_translation})
   configure_file(SampleRobot.TerrainFloor.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.${_tmp_file_suffix}.xml)
 endforeach()
+configure_file(SampleRobot.DRCTestbed.xml ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.DRCTestbed.xml)
+
 
 install(FILES 
   # files for 500[Hz] = 0.002[s]
@@ -57,6 +59,8 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.SlopeUpDown.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.StairUp.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.StairDown.xml
+  # DRCTestbed
+  ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.DRCTestbed.xml
   DESTINATION share/hrpsys/samples/SampleRobot)
 
 add_subdirectory(rtc)


### PR DESCRIPTION
This is to resolve the problem mentioned in #577 

Since I am not familiar with writing Makefile, I am not sure if it is the correct method.
But now i can rtmlaunch  hrpsys samplerobot-drc-testbed.launch

I also found that files like sample/SampleRobot/samplerobot_stabilizer.py are having the same problem, 
as the result, commands like rosrun hrpsys samplerobot_stabilizer.py written in the [README.md](https://github.com/fkanehiro/hrpsys-base/blob/master/sample/SampleRobot/README.md) can not be excused.

By the way, what is the reason of putting package.xml under devel?