### PR TITLE
Import check_output near the line which check_output is used

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -10,8 +10,6 @@ from hrpsys import *  # load ModelLoader
 import socket
 import time
 
-from subprocess import check_output
-
 # copy from transformations.py, Christoph Gohlke, The Regents of the University of California
 
 import numpy
@@ -670,8 +668,10 @@ class HrpsysConfigurator:
     # private method to replace $(OPENHRP_DIR) or $(PROJECT_DIR)
     def parseUrl(self, url):
         if '$(OPENHRP_DIR)' in url:
+            from subprocess import check_output
             url = url.replace('$(OPENHRP_DIR)', check_output(['pkg-config', 'openhrp3.1', '--variable=prefix']).rstrip())
         if '$(PROJECT_DIR)' in url:
+            from subprocess import check_output
             url = url.replace('$(PROJECT_DIR)', check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip())
         return url
 


### PR DESCRIPTION
古いロボット体内環境（python 2.5.x）でpython 2.7から追加のcheck_outputがないとエラーがでたので修正しました。
例外をうけてcheck_output相当のものをいれる道もありそうですが、古い環境ではパースが現状必要ないため、最小な変更のものにしようと思いました。

よろしくお願いいたします。