### PR TITLE
added lock to prevent multithread access to waitInterpolationOfGroup

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -344,7 +344,10 @@ case $TEST_PACKAGE in
         if [ -e /opt/ros/hydro/share/hironx_ros_bridge/test/test_hironx_ros_bridge.py ]; then
             sudo sed -i "s@test_tf_and_controller@_test_tf_and_controller@" /opt/ros/hydro/share/hironx_ros_bridge/test/test_hironx_ros_bridge.py
         fi
-
+        #https://github.com/start-jsk/rtmros_hironx/pull/358
+        if [ -e /opt/ros/hydro/lib/python2.7/dist-packages/hironx_ros_bridge/hironx_client.py ]; then
+            sudo wget https://raw.githubusercontent.com/k-okada/rtmros_hironx/stop_unfinished_battle/hironx_ros_bridge/src/hironx_ros_bridge/hironx_client.py -O /opt/ros/hydro/lib/python2.7/dist-packages/hironx_ros_bridge/hironx_client.py
+        fi
         travis_time_end
 
         sudo /etc/init.d/omniorb4-nameserver stop || echo "stop omniserver just in case..."

--- a/.travis.sh
+++ b/.travis.sh
@@ -84,7 +84,7 @@ case $TEST_PACKAGE in
             iob)
                 travis_time_start  install_wget
 
-                sudo apt-get install -qq -y cproto wget
+                sudo apt-get install -qq -y cproto wget diffstat
 
                 travis_time_end
                 travis_time_start  iob_test
@@ -94,7 +94,7 @@ case $TEST_PACKAGE in
                 echo -e "#define pid_t int\n#define size_t int\n#include \"iob.h.315.1.9\"" | cproto -x - | sort > iob.h.stable
                 cat iob.h.current
                 cat iob.h.stable
-                diff iob.h.current iob.h.stable || exit 1
+                diff iob.h.stable iob.h.current | tee >(cat - 1>&2)  | diffstat | grep -c deletion && exit 1
 
                 travis_time_end
                 ;;
@@ -161,6 +161,9 @@ case $TEST_PACKAGE in
         sudo apt-get install -qq -y freeglut3-dev python-tk jython doxygen libboost-all-dev libsdl1.2-dev libglew1.6-dev libqhull-dev libirrlicht-dev libxmu-dev libcv-dev libhighgui-dev libopencv-contrib-dev
         # check rtmros_common
 
+        if [ "$TEST_PACKAGE" == "hrpsys-base" ]; then
+            TEST_PACKAGE="hrpsys"
+        fi
         travis_time_end
         travis_time_start  install_$TEST_PACKAGE
 
@@ -232,6 +235,12 @@ case $TEST_PACKAGE in
             # do not copile hrpsys because we wan to use them
             sed -i "1imacro(dummy_install)\nmessage(\"install(\${ARGN})\")\nendmacro()" src/hrpsys/CMakeLists.txt
             sed -i "s@install(@dummy_install(@g" src/hrpsys/CMakeLists.txt
+            sed -i "\$iinstall(DIRECTORY test launch sample DESTINATION share/hrpsys USE_SOURCE_PERMISSIONS)" src/hrpsys/CMakeLists.txt
+            sed -i "\$iinstall(FILES package.xml DESTINATION share/hrpsys/)" src/hrpsys/CMakeLists.txt
+            sed -i "\$iinstall(CODE \"execute_process(COMMAND cmake -E make_directory share/hrpsys WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/hrpsys)\")" src/hrpsys/CMakeLists.txt
+            sed -i "\$iinstall(CODE \"execute_process(COMMAND cmake -E create_symlink ../../../hrpsys/idl     share/hrpsys/idl WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/hrpsys)\")" src/hrpsys/CMakeLists.txt
+            sed -i "\$iinstall(CODE \"execute_process(COMMAND cmake -E create_symlink ../../../hrpsys/samples share/hrpsys/samples WORKING_DIRECTORY \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/hrpsys)\")" src/hrpsys/CMakeLists.txt
+            cat src/hrpsys/CMakeLists.txt
 
             travis_time_end
             travis_time_start  compile_new_version
@@ -250,7 +259,10 @@ case $TEST_PACKAGE in
             wstool set hrpsys http://github.com/start-jsk/hrpsys -v 315.1.9 --git -y
             wstool update
             #
+            sed -i "1imacro(dummy_macro)\nmessage(\"dummy(\${ARGN})\")\nendmacro()" hrpsys/catkin.cmake
+            sed -i "s@install(DIRECTORY test share@dummy_macro(DIRECTORY test share@" hrpsys/catkin.cmake
             sed -i "s@find_package(catkin REQUIRED COMPONENTS rostest mk openrtm_aist openhrp3)@find_package(catkin REQUIRED COMPONENTS rostest mk)\nset(openrtm_aist_PREFIX /opt/ros/hydro/)\nset(openhrp3_PREFIX /opt/ros/hydro/)@"  hrpsys/catkin.cmake
+            cat hrpsys/catkin.cmake
             sed -i "s@NUM_OF_CPUS = \$(shell grep -c '^processor' /proc/cpuinfo)@NUM_OF_CPUS = 2@" hrpsys/Makefile.hrpsys-base
             sed -i "s@touch installed@@" hrpsys/Makefile.hrpsys-base
             cat hrpsys/Makefile.hrpsys-base
@@ -258,6 +270,7 @@ case $TEST_PACKAGE in
             git clone http://github.com/fkanehiro/hrpsys-base --depth 1 -b 315.1.9 ../build_isolated/hrpsys/build/hrpsys-base-source
             # we use latest hrpsys_ocnfig.py for this case, so do not install them
             sed -i -e 's/\(add_subdirectory(python)\)/#\1/' ../build_isolated/hrpsys/build/hrpsys-base-source/CMakeLists.txt
+            sed -i -e 's/\(add_subdirectory(test)\)/#\1/' ../build_isolated/hrpsys/build/hrpsys-base-source/CMakeLists.txt
             find ../build_isolated/hrpsys/build/hrpsys-base-source -name CMakeLists.txt -exec sed -i "s@PCL_FOUND@0@" {} \; # disable PCL
             find ../build_isolated/hrpsys/build/hrpsys-base-source -name CMakeLists.txt -exec sed -i "s@OCTOMAP_FOUND@0@" {} \; # disable OCTOMAP
             find ../build_isolated/hrpsys/build/hrpsys-base-source -name CMakeLists.txt -exec sed -i "s@IRRLIGHT_FOUND@0@" {} \; # disable IRRLIGHT
@@ -300,6 +313,10 @@ case $TEST_PACKAGE in
             trap error ERR
 
             #cp ~/catkin_ws/src/hrpsys/package.xml install_isolated/share/hrpsys/ # old hrpsys did not do this
+            mkdir -p install_isolated/share/hrpsys/share/hrpsys/
+            cp -r ~/catkin_ws/install_isolated/share/hrpsys/idl install_isolated/share/hrpsys/share/hrpsys/
+            cp -r ~/catkin_ws/install_isolated/share/hrpsys/{test,launch,samples} install_isolated/share/hrpsys/ # cp latest script
+
             source install_isolated/setup.bash
 
             #echo $ROS_PACKAGE_PATH
@@ -338,7 +355,13 @@ case $TEST_PACKAGE in
         else
             for test_file in `find $pkg_path/test -iname "*.test" -print`; do
                 travis_time_start $(echo $test_file | sed 's@.*/\([a-zA-Z0-9-]*\).test$@\1@' | sed 's@-@_@g')
-                rostest $test_file && travis_time_end || (travis_time_end 31; export EXIT_STATUS=$?)
+                export TMP_EXIT_STATUS=0
+                rostest $test_file && travis_time_end || export TMP_EXIT_STATUS=$?
+                if [ "$TMP_EXIT_STATUS" != 0 ]; then
+                    export EXIT_STATUS=$TMP_EXIT_STATUS
+                    find ~/.ros/test_results -type f -iname "*`basename $test_file .test`.xml" -print -exec echo "=== {} ===" \; -exec cat {} \;
+                    travis_time_end 31
+                fi
             done
         fi
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,8 +17,8 @@ env:
     - TEST_TYPE=python      TEST_PACKAGE=hrpsys
     - TEST_TYPE=iob         TEST_PACKAGE=hrpsys
     - TEST_TYPE=stable_rtc  TEST_PACKAGE=hrpsys
-    - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys
-    - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hrpsys
+    - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys-base
+    - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hrpsys-base
     - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys-tools
     - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hrpsys-tools
     - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys-ros-bridge

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,6 +152,7 @@ install(FILES
   DESTINATION lib/pkgconfig)
 
 add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")
+add_definitions(-DROBOT_IOB_VERSION=2)
 
 if(COMPILE_JAVA_STUFF)
   add_subdirectory(jython)

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -28,10 +28,21 @@ module OpenHRP
     };
 
     /**
+     * @struct StepParam
+     * @brief Step parameter for one step
+     */
+    struct StepParam
+    {
+      /// Step height [m]
+      double step_height;
+    };
+
+    /**
      * @struct FootstepSequence
      * @brief Sequence of foot step.
      */
     typedef sequence<Footstep> FootstepSequence;
+    typedef sequence<StepParam> StepParamSequence;
 
     /**
      * @enum SupportLegState
@@ -177,6 +188,13 @@ module OpenHRP
      * @return true if set successfully, false otherwise
      */
     boolean setFootSteps(in FootstepSequence fs);
+
+    /**
+     * @brief Set footsteps. Returns without waiting for whole steps to be executed.
+     * @param fs is sequence of FootStepWithParam structure.
+     * @return true if set successfully, false otherwise
+     */
+    boolean setFootStepsWithParam(in FootstepSequence fs, in StepParamSequence sps);
 
     /**
      * @brief Wait for whole footsteps are executed.

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -126,13 +126,13 @@ module OpenHRP
       DblArray3 stair_trajectory_way_point_offset;
       /// Gravitational acceleration [m/s^2]
       double gravitational_acceleration;
-      /// Toe position offset [mm] in end-effector frame x axis
+      /// Toe position offset [m] in end-effector frame x axis
       double toe_pos_offset_x;
-      /// Heel position offset [mm] in end-effector frame x axis
+      /// Heel position offset [m] in end-effector frame x axis
       double heel_pos_offset_x;
-      /// Toe ZMP offset [mm] in end-effector frame x axis
+      /// Toe ZMP offset [m] in end-effector frame x axis
       double toe_zmp_offset_x;
-      /// Heel ZMP offset [mm] in end-effector frame x axis
+      /// Heel ZMP offset [m] in end-effector frame x axis
       double heel_zmp_offset_x;
       /// Maximum toe angle [deg] for toe-off motion
       double toe_angle;

--- a/idl/RobotHardwareService.idl
+++ b/idl/RobotHardwareService.idl
@@ -164,6 +164,12 @@ module OpenHRP
     boolean readDigitalOutput(out OctSequence dOut);
 
     /* robot status version 2.0 */
+    struct BatteryState
+    {
+      double			voltage;  ///< voltage of power supply[V]
+      double			current;  ///< current[A] 
+      double                    soc;  	  ///< state of charge[%]
+    };
     /**
      * @brief status of the robot
      */
@@ -187,9 +193,9 @@ module OpenHRP
       sequence<DblSequence6>	force;    ///< forces[N] and torques[Nm]
       sequence<DblSequence3>	rateGyro; ///< angular velocities[rad/s]
       sequence<DblSequence3>	accel;    ///< accelerations[m/(s^2)]
+      sequence<BatteryState>    batteries;///< battery states
       double			voltage;  ///< voltage of power supply[V]
       double			current;  ///< current[A] 
-      double                    battery;  ///< remingin battery level[%]
     };
 
     /**

--- a/idl/RobotHardwareService.idl
+++ b/idl/RobotHardwareService.idl
@@ -54,7 +54,6 @@ module OpenHRP
       sequence<DblSequence3>	accel;    ///< accelerations[m/(s^2)]
       double			voltage;  ///< voltage of power supply[V]
       double			current;  ///< current[A] 
-      double			battery;  ///< remingin battery level[%]
     };
 
     /**
@@ -163,5 +162,41 @@ module OpenHRP
      * @return true if applicable, false otherwise
      */
     boolean readDigitalOutput(out OctSequence dOut);
+
+    /* robot status version 2.0 */
+    /**
+     * @brief status of the robot
+     */
+    struct RobotState2
+    {
+      DblSequence		angle;  ///< current joint angles[rad]
+      DblSequence		command;///< reference joint angles[rad]
+      DblSequence		torque; ///< joint torques[Nm]
+      /**
+       * @brief servo statuses(32bit+extra states)
+       * 
+       * 0: calib status ( 1 => done )\n 
+       * 1: servo status ( 1 => on )\n
+       * 2: power status ( 1 => supplied )\n
+       * 3-18: servo alarms (see @ref iob.h)\n
+       * 19-23: unused
+       * 24-31: driver temperature (deg)
+       */
+      LongSequenceSequence		servoState;
+      
+      sequence<DblSequence6>	force;    ///< forces[N] and torques[Nm]
+      sequence<DblSequence3>	rateGyro; ///< angular velocities[rad/s]
+      sequence<DblSequence3>	accel;    ///< accelerations[m/(s^2)]
+      double			voltage;  ///< voltage of power supply[V]
+      double			current;  ///< current[A] 
+      double                    battery;  ///< remingin battery level[%]
+    };
+
+    /**
+     * @brief get status of the robot
+     * @param rs status of the robot
+     */
+    void getStatus2(out RobotState2 rs);
+
   };
 };

--- a/launch/samplerobot-drc-testbed.launch
+++ b/launch/samplerobot-drc-testbed.launch
@@ -7,10 +7,13 @@ $ ipython -i `rospack find hrpsys`/samples/SampleRobot/samplerobot_terrain_walk.
 >>> demoSlopeUpDown()
 
    -->
-  <arg name="MODEL" default="SlopeUpDown" />
+  <arg name="GUI" default="true" />
+  <arg name="corbaport" default="15005" />
   <include file="$(find hrpsys)/launch/samplerobot.launch" >
     <arg name="CONTROLLER_PERIOD" value="200" />
     <arg name="PROJECT_FILE"      value="$(find hrpsys)/samples/SampleRobot/SampleRobot.DRCTestbed.xml" />
+    <arg name="GUI" default="$(arg GUI)" />
+    <arg name="corbaport" default="$(arg corbaport)" />
   </include>
 </launch>
 

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -562,10 +562,15 @@ int number_of_substeps()
     return 5;
 }
 
-int read_power(double *voltage, double *current, double *battery)
+int read_power(double *voltage, double *current)
 {
     *voltage = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*1+48;
     *current = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+1;
+    return TRUE;
+}
+
+int read_battery(double *battery)
+{
     *battery = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+50;
     return TRUE;
 }

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -570,9 +570,16 @@ int read_power(double *voltage, double *current)
 }
 
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
-int read_battery(double *battery)
+int number_of_batteries()
 {
-    *battery = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+50;
+    return 1;
+}
+
+int read_battery(int id, double *voltage, double *current, double *soc)
+{
+    *voltage = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*1+48;
+    *current = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+1;
+    *soc = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+50;
     return TRUE;
 }
 #endif

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -569,11 +569,13 @@ int read_power(double *voltage, double *current)
     return TRUE;
 }
 
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
 int read_battery(double *battery)
 {
     *battery = ((double)random()-RAND_MAX/2)/(RAND_MAX/2)*0.5+50;
     return TRUE;
 }
+#endif
 
 int read_driver_temperature(int id, unsigned char *v)
 {

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -572,10 +572,18 @@ extern "C"{
      * @brief		read status of power source
      * @param v		voltage[V]
      * @param a		current[A]
+     * @return		TRUE or FALSE
+     */
+    int read_power(double *v, double *a);
+    //@}
+
+    //@{
+    /**
+     * @brief		read status of battery source this is new API since 315.4.0
      * @param b		remaining battery level[%]
      * @return		TRUE or FALSE
      */
-    int read_power(double *v, double *a, double *b);
+    int read_battery(double *b) /* {} */; // if you are compiling against old libiob.so, please uncomment to dummy define this function.
     //@}
 
     /**

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -580,11 +580,20 @@ extern "C"{
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     //@{
     /**
+     * @brief get the number of batteries
+     * @return the number of batteries
+     */
+    int number_of_batteries();
+
+    /**
      * @brief		read status of battery source this is new API since 315.4.0
+     * @param id	battery id
+     * @param v		voltage[V]
+     * @param a		current[A]
      * @param b		remaining battery level[%]
      * @return		TRUE or FALSE
      */
-    int read_battery(double *b) /* {} */; // if you are compiling against old libiob.so, please uncomment to dummy define this function.
+    int read_battery(int id, double *v, double *a, double *b) /* {} */; // if you are compiling against old libiob.so, please uncomment to dummy define this function.
     //@}
 #endif
 

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -577,6 +577,7 @@ extern "C"{
     int read_power(double *v, double *a);
     //@}
 
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     //@{
     /**
      * @brief		read status of battery source this is new API since 315.4.0
@@ -585,6 +586,7 @@ extern "C"{
      */
     int read_battery(double *b) /* {} */; // if you are compiling against old libiob.so, please uncomment to dummy define this function.
     //@}
+#endif
 
     /**
      * @name thermometer

--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -438,6 +438,9 @@ void BodyRTC::getStatus(OpenHRP::RobotHardwareService::RobotState* rs) {
     //readPowerStatus(rs->voltage, rs->current);
 }
 
+void BodyRTC::getStatus2(OpenHRP::RobotHardwareService::RobotState2* rs) {
+}
+
 bool BodyRTC::setServoErrorLimit(const char *i_jname, double i_limit)
 {
     Link *l = NULL;
@@ -603,6 +606,10 @@ void RobotHardwareServicePort::getStatus(OpenHRP::RobotHardwareService::RobotSta
     m_robot->getStatus(rs);
 }
 
+void RobotHardwareServicePort::getStatus2(OpenHRP::RobotHardwareService::RobotState2_out rs) {
+    rs = new OpenHRP::RobotHardwareService::RobotState2();
+    m_robot->getStatus2(rs);
+}
 
 CORBA::Boolean RobotHardwareServicePort::power(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus turnon) {
     m_robot->power(jname, turnon == OpenHRP::RobotHardwareService::SWITCH_ON);

--- a/lib/util/BodyRTC.h
+++ b/lib/util/BodyRTC.h
@@ -26,6 +26,7 @@ public:
     RobotHardwareServicePort();
     ~RobotHardwareServicePort();
     void getStatus(OpenHRP::RobotHardwareService::RobotState_out rs);
+    void getStatus2(OpenHRP::RobotHardwareService::RobotState2_out rs);
     CORBA::Boolean power(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus ss);
     CORBA::Boolean servo(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus ss);
     void setServoGainPercentage(const char *jname, double limit);
@@ -71,7 +72,7 @@ public:
     static void moduleInit(RTC::Manager*);
 
     void getStatus(OpenHRP::RobotHardwareService::RobotState* rs);
-
+    void getStatus2(OpenHRP::RobotHardwareService::RobotState2* rs);
 
     bool preOneStep();
     bool postOneStep();

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -673,10 +673,10 @@ class HrpsysConfigurator:
     # private method to replace $(OPENHRP_DIR) or $(PROJECT_DIR)
     def parseUrl(self, url):
         if '$(OPENHRP_DIR)' in url:
-            path = subprocess.Popen(['pkg-config', 'openhrp3.1', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip().decode('utf-8')
+            path = subprocess.Popen(['pkg-config', 'openhrp3.1', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip()
             url = url.replace('$(OPENHRP_DIR)', path)
         if '$(PROJECT_DIR)' in url:
-            path = subprocess.Popen(['pkg-config', 'hrpsys-base', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip().decode('utf-8')
+            path = subprocess.Popen(['pkg-config', 'hrpsys-base', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip()
             url = url.replace('$(PROJECT_DIR)', path)
         return url
 

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -670,13 +670,13 @@ class HrpsysConfigurator:
                 print(self.configurator_name + '\033[31mFail to getRTCInstanceList'+str(e)+'\033[0m')
         return ret
 
-    # private method to replace $(OPENHRP_DIR) or $(PROJECT_DIR)
+    # private method to replace $(PROJECT_DIR)
+    # PROJECT_DIR=(OpenHRP3  installed directory)/share/OpenHRP-3.1/sample/project
+    # see http://www.openrtp.jp/openhrp3/3.1.0.beta/jp/install_ubuntu.html
     def parseUrl(self, url):
-        if '$(OPENHRP_DIR)' in url:
-            path = subprocess.Popen(['pkg-config', 'openhrp3.1', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip()
-            url = url.replace('$(OPENHRP_DIR)', path)
         if '$(PROJECT_DIR)' in url:
-            path = subprocess.Popen(['pkg-config', 'hrpsys-base', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip()
+            path = subprocess.Popen(['pkg-config', 'openhrp3.1', '--variable=prefix'], stdout=subprocess.PIPE).communicate()[0].rstrip()
+            path = os.path.join(path, 'share/OpenHRP-3.1/sample/project')
             url = url.replace('$(PROJECT_DIR)', path)
         return url
 

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -11,6 +11,8 @@ import socket
 import time
 import subprocess
 
+import threading
+
 # copy from transformations.py, Christoph Gohlke, The Regents of the University of California
 
 import numpy
@@ -31,6 +33,7 @@ _NEXT_AXIS = [1, 2, 0, 1]
 # epsilon for testing whether a number is close to zero
 _EPS = numpy.finfo(float).eps * 4.0
 
+_LOCK = threading.Lock()
 
 def euler_matrix(ai, aj, ak, axes='sxyz'):
     """Return homogeneous rotation matrix from Euler angles and axis sequence.
@@ -1017,7 +1020,9 @@ class HrpsysConfigurator:
 
         @param gname str: Name of the joint group.
         '''
+        _LOCK.acquire(True) # blocking wait
         self.seq_svc.waitInterpolationOfGroup(gname)
+        _LOCK.release()
 
     def getJointAngles(self):
         '''!@brief

--- a/python/rtm.py
+++ b/python/rtm.py
@@ -99,32 +99,45 @@ class RTcomponent:
     # \brief activate this component
     # \param self this object
     # \param ec execution context used to activate this component
-    def start(self, ec=None):
+    # \param timeout maximum duration to wait for activation
+    # \return True if activated successfully, False otherwise
+    def start(self, ec=None, timeout=3.0):
         if ec == None:
             ec = self.ec
         if ec != None:
             ec.activate_component(self.ref)
-            while self.isInactive(ec):
+            tm = 0 
+            while tm < timeout:
+                if self.isActive(ec):
+                    return True
                 time.sleep(0.01)
+                tm += 0.01
+        return False
 
     ##
     # \brief deactivate this component
     # \param self this object
     # \param ec execution context used to deactivate this component
-    def stop(self, ec=None):
+    # \param timeout maximum duration to wait for deactivation
+    # \return True if deactivated successfully, False otherwise
+    def stop(self, ec=None, timeout=3.0):
         if ec == None:
             ec = self.ec
         if ec != None:
             ec.deactivate_component(self.ref)
-            while self.isActive(ec):
+            tm = 0
+            while tm < timeout:
+                if self.isInactive(ec):
+                    return True
                 time.sleep(0.01)
+                time += 0.01
+        return False
 
     ##
     # \brief get life cycle state of the main execution context
     # \param self this object
     # \param ec execution context from which life cycle state is obtained
-    # \return one of LifeCycleState value or None if the main execution
-    # context is not set
+    # \return one of LifeCycleState value or None if the main execution context is not set
     def getLifeCycleState(self, ec=None):
         if ec == None:
             ec = self.ec

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1014,6 +1014,8 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_heel_angle(i_param.heel_angle);
   gg->set_toe_pos_offset_x(i_param.toe_pos_offset_x);
   gg->set_heel_pos_offset_x(i_param.heel_pos_offset_x);
+  gg->set_toe_zmp_offset_x(i_param.toe_zmp_offset_x);
+  gg->set_heel_zmp_offset_x(i_param.heel_zmp_offset_x);
   bool set_toe_heel_phase_ratio = true;
   double sum_ratio = 0.0;
   if (i_param.toe_heel_phase_ratio.length() == gg->get_NUM_TH_PHASES()) {
@@ -1054,8 +1056,8 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   tmpv = gg->get_stair_trajectory_way_point_offset();
   std::cerr << "[" << m_profile.instance_name << "]   stair_trajectory_way_point_offset = " << tmpv.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   gravitational_acceleration = " << gg->get_gravitational_acceleration() << "[m/s^2]" << std::endl;
-  std::cerr << "[" << m_profile.instance_name << "]   toe_pos_offset_x = " << gg->get_toe_pos_offset_x() << "[mm]" << std::endl;
-  std::cerr << "[" << m_profile.instance_name << "]   heel_pos_offset_x = " << gg->get_heel_pos_offset_x() << "[mm]" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   toe_pos_offset_x = " << gg->get_toe_pos_offset_x() << "[mm], heel_pos_offset_x = " << gg->get_heel_pos_offset_x() << "[mm]" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   toe_zmp_offset_x = " << gg->get_toe_zmp_offset_x() << "[mm], heel_zmp_offset_x = " << gg->get_heel_zmp_offset_x() << "[mm]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   toe_angle = " << gg->get_toe_angle() << "[deg]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   heel_angle = " << gg->get_heel_angle() << "[deg]" << std::endl;
   if (i_param.toe_heel_phase_ratio.length() == gg->get_NUM_TH_PHASES() && set_toe_heel_phase_ratio) {
@@ -1096,6 +1098,8 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   i_param.heel_angle = gg->get_heel_angle();
   i_param.toe_pos_offset_x = gg->get_toe_pos_offset_x();
   i_param.heel_pos_offset_x = gg->get_heel_pos_offset_x();
+  i_param.toe_zmp_offset_x = gg->get_toe_zmp_offset_x();
+  i_param.heel_zmp_offset_x = gg->get_heel_zmp_offset_x();
   double ratio[gg->get_NUM_TH_PHASES()];
   gg->get_toe_heel_phase_ratio(ratio);
   for (int i = 0; i < gg->get_NUM_TH_PHASES(); i++) i_param.toe_heel_phase_ratio[i] = ratio[i];

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -529,12 +529,6 @@ void AutoBalancer::getTargetParameters()
       for (size_t i = 0; i < 2; i++)
         for (size_t j = 0; j < 3; j++)
           default_zmp_offsets[i](j) = default_zmp_offsets_output[i*3+j];
-      m_limbCOPOffset[contact_states_index_map["rleg"]].data.x = default_zmp_offsets[0](0);
-      m_limbCOPOffset[contact_states_index_map["rleg"]].data.y = default_zmp_offsets[0](1);
-      m_limbCOPOffset[contact_states_index_map["rleg"]].data.z = default_zmp_offsets[0](2);
-      m_limbCOPOffset[contact_states_index_map["lleg"]].data.x = default_zmp_offsets[1](0);
-      m_limbCOPOffset[contact_states_index_map["lleg"]].data.y = default_zmp_offsets[1](1);
-      m_limbCOPOffset[contact_states_index_map["lleg"]].data.z = default_zmp_offsets[1](2);
       if (DEBUGP) {
         std::cerr << "[" << m_profile.instance_name << "] default_zmp_offsets (interpolated)" << std::endl;
         std::cerr << "[" << m_profile.instance_name << "]   rleg = " << default_zmp_offsets[0].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
@@ -575,6 +569,12 @@ void AutoBalancer::getTargetParameters()
       }
       m_controlSwingSupportTime.data[contact_states_index_map["rleg"]] = gg->get_current_swing_time(0);
       m_controlSwingSupportTime.data[contact_states_index_map["lleg"]] = gg->get_current_swing_time(1);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg()]].data.x = gg->get_swing_foot_zmp_offset()(0);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg()]].data.y = gg->get_swing_foot_zmp_offset()(1);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg()]].data.z = gg->get_swing_foot_zmp_offset()(2);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg()]].data.x = gg->get_support_foot_zmp_offset()(0);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg()]].data.y = gg->get_support_foot_zmp_offset()(1);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg()]].data.z = gg->get_support_foot_zmp_offset()(2);
     } else {
       tmp_fix_coords = fix_leg_coords;
       // double support by default
@@ -583,6 +583,12 @@ void AutoBalancer::getTargetParameters()
       // controlSwingSupportTime is not used while double support period, 1.0 is neglected
       m_controlSwingSupportTime.data[contact_states_index_map["rleg"]] = 1.0;
       m_controlSwingSupportTime.data[contact_states_index_map["lleg"]] = 1.0;
+      m_limbCOPOffset[contact_states_index_map["rleg"]].data.x = default_zmp_offsets[0](0);
+      m_limbCOPOffset[contact_states_index_map["rleg"]].data.y = default_zmp_offsets[0](1);
+      m_limbCOPOffset[contact_states_index_map["rleg"]].data.z = default_zmp_offsets[0](2);
+      m_limbCOPOffset[contact_states_index_map["lleg"]].data.x = default_zmp_offsets[1](0);
+      m_limbCOPOffset[contact_states_index_map["lleg"]].data.y = default_zmp_offsets[1](1);
+      m_limbCOPOffset[contact_states_index_map["lleg"]].data.z = default_zmp_offsets[1](2);
     }
     // Tempolarily modify tmp_fix_coords
     // This will be removed after seq outputs adequate waistRPY discussed in https://github.com/fkanehiro/hrpsys-base/issues/272

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1008,10 +1008,20 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_heel_angle(i_param.heel_angle);
   gg->set_toe_pos_offset_x(i_param.toe_pos_offset_x);
   gg->set_heel_pos_offset_x(i_param.heel_pos_offset_x);
+  bool set_toe_heel_phase_ratio = true;
+  double sum_ratio = 0.0;
   if (i_param.toe_heel_phase_ratio.length() == gg->get_NUM_TH_PHASES()) {
       double ratio[gg->get_NUM_TH_PHASES()];
-      for (int i = 0; i < gg->get_NUM_TH_PHASES(); i++) ratio[i] = i_param.toe_heel_phase_ratio[i];
-      gg->set_toe_heel_phase_ratio(ratio);
+      for (int i = 0; i < gg->get_NUM_TH_PHASES(); i++) {
+          ratio[i] = i_param.toe_heel_phase_ratio[i];
+          sum_ratio += ratio[i];
+      }
+      if (std::fabs(sum_ratio-1.0) < 1e-3) {
+          gg->set_toe_heel_phase_ratio(ratio);
+          set_toe_heel_phase_ratio = true;
+      } else {
+          set_toe_heel_phase_ratio = false;
+      }
   }
   gg->set_use_toe_joint(i_param.use_toe_joint);
 
@@ -1042,14 +1052,16 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   std::cerr << "[" << m_profile.instance_name << "]   heel_pos_offset_x = " << gg->get_heel_pos_offset_x() << "[mm]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   toe_angle = " << gg->get_toe_angle() << "[deg]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   heel_angle = " << gg->get_heel_angle() << "[deg]" << std::endl;
-  if (i_param.toe_heel_phase_ratio.length() == gg->get_NUM_TH_PHASES()) {
+  if (i_param.toe_heel_phase_ratio.length() == gg->get_NUM_TH_PHASES() && set_toe_heel_phase_ratio) {
       double ratio[gg->get_NUM_TH_PHASES()];
       gg->get_toe_heel_phase_ratio(ratio);
       std::cerr << "[" << m_profile.instance_name << "]   toe_heel_phase_ratio = [";
       for (int i = 0; i < gg->get_NUM_TH_PHASES(); i++) std::cerr << ratio[i] << " ";
       std::cerr << "]" << std::endl;
   } else {
-      std::cerr << "[" << m_profile.instance_name << "]   toe_heel_phase_ratio is not set. Required length = " << gg->get_NUM_TH_PHASES() << " != input length " << i_param.toe_heel_phase_ratio.length() << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   toe_heel_phase_ratio is not set. "
+                << "Required length = " << gg->get_NUM_TH_PHASES() << " != input length " << i_param.toe_heel_phase_ratio.length()
+                << ", or sum_ratio = " << sum_ratio << " is not 1.0." << std::endl;
   }
   std::cerr << "[" << m_profile.instance_name << "]   use_toe_joint = " << (gg->get_use_toe_joint()?"true":"false") << std::endl;
   return true;

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -558,15 +558,15 @@ void AutoBalancer::getTargetParameters()
       gg->get_swing_support_mid_coords(tmp_fix_coords);
       // TODO : assume biped
       switch (gg->get_current_support_state()) {
-      case 0:
+      case gait_generator::BOTH:
         m_contactStates.data[contact_states_index_map["rleg"]] = true;
         m_contactStates.data[contact_states_index_map["lleg"]] = true;
         break;
-      case 1:
+      case gait_generator::RLEG:
         m_contactStates.data[contact_states_index_map["rleg"]] = true;
         m_contactStates.data[contact_states_index_map["lleg"]] = false;
         break;
-      case 2:
+      case gait_generator::LLEG:
         m_contactStates.data[contact_states_index_map["rleg"]] = false;
         m_contactStates.data[contact_states_index_map["lleg"]] = true;
         break;
@@ -1174,9 +1174,9 @@ bool AutoBalancer::getFootstepParam(OpenHRP::AutoBalancerService::FootstepParam&
     i_param.support_leg = OpenHRP::AutoBalancerService::LLEG;
   }
   switch ( gg->get_current_support_state() ) {
-  case 0: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::BOTH; break;
-  case 1: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::RLEG; break;
-  case 2: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::LLEG; break;
+  case gait_generator::BOTH: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::BOTH; break;
+  case gait_generator::RLEG: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::RLEG; break;
+  case gait_generator::LLEG: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::LLEG; break;
   default: break;
   }
   return true;

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -923,6 +923,14 @@ bool AutoBalancer::goStop ()
 
 bool AutoBalancer::setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs)
 {
+  OpenHRP::AutoBalancerService::StepParamSequence sps;
+  sps.length(fs.length());
+  for (size_t i = 0; i < sps.length(); i++) sps[i].step_height = gg->get_default_step_height();
+  setFootStepsWithParam(fs, sps);
+}
+
+bool AutoBalancer::setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps)
+{
   if (!gg_is_walking) {
     std::cerr << "[" << m_profile.instance_name << "] setFootSteps" << std::endl;
     coordinates tmpfs, initial_support_coords, initial_input_coords, fstrans;
@@ -957,7 +965,7 @@ bool AutoBalancer::setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequ
     std::cerr << "[" << m_profile.instance_name << "] print footsteps " << std::endl;
     gg->clear_footstep_node_list();
     for (size_t i = 0; i < fs_vec.size(); i++) {
-        gg->append_footstep_node(leg_name_vec[i], fs_vec[i]);
+        gg->append_footstep_node(leg_name_vec[i], fs_vec[i], sps[i].step_height);
     }
     gg->append_finalize_footstep();
     gg->print_footstep_list();

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -93,6 +93,7 @@ class AutoBalancer
   bool goVelocity(const double& vx, const double& vy, const double& vth);
   bool goStop();
   bool setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs);
+  bool setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps);
   void waitFootSteps();
   bool startAutoBalancer(const ::OpenHRP::AutoBalancerService::StrSequence& limbs);
   bool stopAutoBalancer();

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -29,6 +29,11 @@ CORBA::Boolean AutoBalancerService_impl::setFootSteps(const OpenHRP::AutoBalance
   return m_autobalancer->setFootSteps(fs);
 }
 
+CORBA::Boolean AutoBalancerService_impl::setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps)
+{
+  return m_autobalancer->setFootStepsWithParam(fs, sps);
+}
+
 void AutoBalancerService_impl::waitFootSteps()
 {
   return m_autobalancer->waitFootSteps();

--- a/rtc/AutoBalancer/AutoBalancerService_impl.h
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.h
@@ -19,6 +19,7 @@ public:
   CORBA::Boolean goVelocity( CORBA::Double vx,  CORBA::Double vy,  CORBA::Double vth);
   CORBA::Boolean goStop();
   CORBA::Boolean setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs);
+  CORBA::Boolean setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps);
   void waitFootSteps();
   CORBA::Boolean startAutoBalancer(const OpenHRP::AutoBalancerService::StrSequence& limbs);
   CORBA::Boolean stopAutoBalancer();

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -143,9 +143,9 @@ namespace rats
   {
       double tmp_ip_ratio;
       size_t current_count = total_count - gp_count;
-      if (current_count == toe_heel_phase_count[start_phase]) {
+      if (thp.is_phase_starting(current_count, start_phase)) {
           toe_heel_interpolator->set(&start);
-          toe_heel_interpolator->go(&goal, _dt * (toe_heel_phase_count[goal_phase]-toe_heel_phase_count[start_phase]));
+          toe_heel_interpolator->go(&goal, thp.get_phase_period(start_phase, goal_phase, _dt));
       }
       toe_heel_interpolator->get(&tmp_ip_ratio, true);
       return tmp_ip_ratio;
@@ -157,25 +157,25 @@ namespace rats
       size_t current_count = total_count - gp_count;
       double dif_angle = 0.0;
       hrp::Vector3 ee_local_pivot_pos(hrp::Vector3(0,0,0));
-      if ( (toe_heel_phase_count[SOLE0] <= current_count) && (current_count < toe_heel_phase_count[SOLE2TOE]) ) {
+      if ( thp.is_between_phases(current_count, SOLE0, SOLE2TOE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE0, SOLE2TOE, 0.0, toe_angle);
           ee_local_pivot_pos(0) = toe_pos_offset_x;
-      } else if ( (toe_heel_phase_count[SOLE2HEEL] <= current_count) && (current_count < toe_heel_phase_count[HEEL2SOLE]) ) {
+      } else if ( thp.is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE2HEEL, HEEL2SOLE, -1 * heel_angle, 0.0);
           ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
-      } else if ( (toe_heel_phase_count[SOLE2TOE] <= current_count) && (current_count < toe_heel_phase_count[SOLE2HEEL]) ) {
+      } else if ( thp.is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
           // If SOLE1 phase does not exist, interpolate toe => heel smoothly, without 0 velocity phase.
-          if ( toe_heel_phase_count[TOE2SOLE] == toe_heel_phase_count[SOLE1] ) {
+          if ( thp.is_no_SOLE1_phase() ) {
               dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, SOLE2HEEL, toe_angle, -1 * heel_angle);
               double tmpd = (-1*heel_angle-toe_angle);
               if (std::fabs(tmpd) > 1e-5) {
                   ee_local_pivot_pos(0) = (-1 * heel_pos_offset_x - toe_pos_offset_x) * (dif_angle - toe_angle) / tmpd + toe_pos_offset_x;
               }
           } else {
-              if ( (toe_heel_phase_count[SOLE2TOE] <= current_count) && (current_count < toe_heel_phase_count[TOE2SOLE]) ) {
+              if ( thp.is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, TOE2SOLE, toe_angle, 0.0);
                   ee_local_pivot_pos(0) = toe_pos_offset_x;
-              } else if ( (toe_heel_phase_count[SOLE1] <= current_count) && (current_count < toe_heel_phase_count[SOLE2HEEL]) ) {
+              } else if ( thp.is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE1, SOLE2HEEL, 0.0, -1 * heel_angle);
                   ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
               }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -16,9 +16,9 @@ namespace rats
   {
     hrp::Vector3 rzmp;
     hrp::Vector3 dz0, dz1, ret_zmp;
-    leg_type spl = (fnl[fs_index].l_r == WC_RLEG) ? WC_LLEG :WC_RLEG;
-    dz0 = _support_leg_coords.rot * ((spl == WC_RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]);
-    dz1 = _swing_leg_coords.rot * ((spl == WC_RLEG)? default_zmp_offsets[1] : default_zmp_offsets[0]);
+    leg_type spl = (fnl[fs_index].l_r == RLEG) ? LLEG :RLEG;
+    dz0 = _support_leg_coords.rot * ((spl == RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]);
+    dz1 = _swing_leg_coords.rot * ((spl == RLEG)? default_zmp_offsets[1] : default_zmp_offsets[0]);
     dz0 += _support_leg_coords.pos;
     dz1 += _swing_leg_coords.pos;
     rzmp = (dz0 + dz1) / 2.0;
@@ -30,7 +30,7 @@ namespace rats
   {
     hrp::Vector3 rzmp;
     coordinates tmp(fnl[fs_index-1].worldcoords);
-    rzmp = tmp.rot * ((fnl[fs_index-1].l_r == WC_RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]) + tmp.pos;
+    rzmp = tmp.rot * ((fnl[fs_index-1].l_r == RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]) + tmp.pos;
     refzmp_cur_list.push_back( rzmp );
     if (fs_index < fnl.size()) fs_index++;
   };
@@ -107,9 +107,9 @@ namespace rats
       ret = tmp_ratio;
       tmp_current_swing_time = current_swing_len * _dt;
     }
-    current_swing_time[support_leg==WC_RLEG?0:1] = (gp_count + 0.5 * default_double_support_ratio * one_step_len) * _dt;
-    current_swing_time[support_leg==WC_RLEG?1:0] = tmp_current_swing_time;
-    //std::cerr << "sl " << support_leg << " " << current_swing_time[support_leg==WC_RLEG?0:1] << " " << current_swing_time[support_leg==WC_RLEG?1:0] << " " << tmp_current_swing_time << " " << gp_count << std::endl;
+    current_swing_time[support_leg==RLEG?0:1] = (gp_count + 0.5 * default_double_support_ratio * one_step_len) * _dt;
+    current_swing_time[support_leg==RLEG?1:0] = tmp_current_swing_time;
+    //std::cerr << "sl " << support_leg << " " << current_swing_time[support_leg==RLEG?0:1] << " " << current_swing_time[support_leg==RLEG?1:0] << " " << tmp_current_swing_time << " " << gp_count << std::endl;
     return ret;
   };
 
@@ -355,26 +355,26 @@ namespace rats
       set_velocity_param(dp(0)/default_step_time, dp(1)/default_step_time, rad2deg(dr(2))/default_step_time);
       append_footstep_list_velocity_mode();
       foot_midcoords = footstep_node_list.back().worldcoords;
-      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[(footstep_node_list.back().l_r == WC_RLEG) ? 0 : 1] * -1.0);
+      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[(footstep_node_list.back().l_r == RLEG) ? 0 : 1] * -1.0);
       foot_midcoords.difference(dp, dr, goal_foot_midcoords);
       dp = foot_midcoords.rot.transpose() * dp;
       dr = foot_midcoords.rot.transpose() * dr;
     }
 
     /* finalize */
-    append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == WC_RLEG ? WC_LLEG : WC_RLEG));
-    append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == WC_RLEG ? WC_LLEG : WC_RLEG));
+    append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == RLEG ? LLEG : RLEG));
+    append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == RLEG ? LLEG : RLEG));
   };
 
   void gait_generator::go_single_step_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,
                                                              const std::string& tmp_swing_leg,
                                                              const coordinates& _support_leg_coords)
   {
-    leg_type _swing_leg = (tmp_swing_leg == "rleg") ? WC_RLEG : WC_LLEG;
-    step_node sn0((_swing_leg == WC_RLEG) ? WC_LLEG : WC_RLEG, _support_leg_coords, lcg.get_default_step_height());
+    leg_type _swing_leg = (tmp_swing_leg == "rleg") ? RLEG : LLEG;
+    step_node sn0((_swing_leg == RLEG) ? LLEG : RLEG, _support_leg_coords, lcg.get_default_step_height());
     footstep_node_list.push_back(sn0);
     step_node sn1(_swing_leg, _support_leg_coords, lcg.get_default_step_height());
-    hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[(_swing_leg == WC_RLEG) ? 0 : 1] + hrp::Vector3(goal_x, goal_y, goal_z));
+    hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[(_swing_leg == RLEG) ? 0 : 1] + hrp::Vector3(goal_x, goal_y, goal_z));
     sn1.worldcoords.pos += sn1.worldcoords.rot * trs;
     sn1.worldcoords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
     footstep_node_list.push_back(sn1);
@@ -386,7 +386,7 @@ namespace rats
   {
     velocity_mode_flg = VEL_DOING;
     /* initialize */
-    leg_type current_leg = (vel_y > 0.0) ? WC_RLEG : WC_LLEG;
+    leg_type current_leg = (vel_y > 0.0) ? RLEG : LLEG;
     clear_footstep_node_list();
     set_velocity_param (vel_x, vel_y, vel_theta);
     append_go_pos_step_node(_foot_midcoords, current_leg);
@@ -403,7 +403,7 @@ namespace rats
   void gait_generator::calc_foot_midcoords_trans_vector_velocity_mode (coordinates& foot_midcoords, hrp::Vector3& trans, double& dth, const step_node& sn)
   {
     foot_midcoords = sn.worldcoords;
-    hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[(sn.l_r == WC_RLEG) ? 0 : 1] * -1.0);
+    hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[(sn.l_r == RLEG) ? 0 : 1] * -1.0);
     foot_midcoords.pos += foot_midcoords.rot * tmpv;
     double dx = vel_param.velocity_x + offset_vel_param.velocity_x, dy = vel_param.velocity_y + offset_vel_param.velocity_y;
     dth = vel_param.velocity_theta + offset_vel_param.velocity_theta;
@@ -419,14 +419,14 @@ namespace rats
     /* inside step limitation */
     if (use_inside_step_limitation) {
       if (vel_param.velocity_y > 0) {
-        if (sn.l_r == WC_LLEG) dy *= 0.5;
+        if (sn.l_r == LLEG) dy *= 0.5;
       } else {
-        if (sn.l_r == WC_RLEG) dy *= 0.5;
+        if (sn.l_r == RLEG) dy *= 0.5;
       }
       if (vel_param.velocity_theta > 0) {
-        if (sn.l_r == WC_LLEG) dth *= 0.5;
+        if (sn.l_r == LLEG) dth *= 0.5;
       } else {
-        if (sn.l_r == WC_RLEG) dth *= 0.5;
+        if (sn.l_r == RLEG) dth *= 0.5;
       }
     }
     trans = hrp::Vector3(dx * default_step_time, dy * default_step_time, 0);
@@ -442,7 +442,7 @@ namespace rats
 
     foot_midcoords.pos += foot_midcoords.rot * trans;
     foot_midcoords.rotate(dth, hrp::Vector3(0,0,1));
-    append_go_pos_step_node(foot_midcoords, (( footstep_node_list.back().l_r == WC_RLEG ) ? WC_LLEG : WC_RLEG));
+    append_go_pos_step_node(foot_midcoords, (( footstep_node_list.back().l_r == RLEG ) ? LLEG : RLEG));
   };
 
   void gait_generator::calc_next_coords_velocity_mode (std::vector<coordinates>& ret, const size_t idx)
@@ -458,7 +458,7 @@ namespace rats
         ret[i].pos += ret[i].rot * trans;
         ret[i].rotate(dth, hrp::Vector3(0,0,1));
       }
-      ret[i].pos += ret[i].rot * footstep_param.leg_default_translate_pos[(footstep_node_list[idx-1].l_r == WC_RLEG) ? (1 + i)%2 : i%2];
+      ret[i].pos += ret[i].rot * footstep_param.leg_default_translate_pos[(footstep_node_list[idx-1].l_r == RLEG) ? (1 + i)%2 : i%2];
     }
   };
 

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -17,8 +17,8 @@ namespace rats
     hrp::Vector3 rzmp;
     hrp::Vector3 dz0, dz1, ret_zmp;
     leg_type spl = (fnl[fs_index].l_r == RLEG) ? LLEG :RLEG;
-    dz0 = _support_leg_coords.rot * ((spl == RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]);
-    dz1 = _swing_leg_coords.rot * ((spl == RLEG)? default_zmp_offsets[1] : default_zmp_offsets[0]);
+    dz0 = _support_leg_coords.rot * default_zmp_offsets[spl];
+    dz1 = _swing_leg_coords.rot * default_zmp_offsets[spl == RLEG ? LLEG : RLEG];
     dz0 += _support_leg_coords.pos;
     dz1 += _swing_leg_coords.pos;
     rzmp = (dz0 + dz1) / 2.0;
@@ -30,7 +30,7 @@ namespace rats
   {
     hrp::Vector3 rzmp;
     coordinates tmp(fnl[fs_index-1].worldcoords);
-    rzmp = tmp.rot * ((fnl[fs_index-1].l_r == RLEG)? default_zmp_offsets[0] : default_zmp_offsets[1]) + tmp.pos;
+    rzmp = tmp.rot * default_zmp_offsets[fnl[fs_index-1].l_r] + tmp.pos;
     refzmp_cur_list.push_back( rzmp );
     if (fs_index < fnl.size()) fs_index++;
   };
@@ -107,8 +107,8 @@ namespace rats
       ret = tmp_ratio;
       tmp_current_swing_time = current_swing_len * _dt;
     }
-    current_swing_time[support_leg==RLEG?0:1] = (gp_count + 0.5 * default_double_support_ratio * one_step_len) * _dt;
-    current_swing_time[support_leg==RLEG?1:0] = tmp_current_swing_time;
+    current_swing_time[support_leg] = (gp_count + 0.5 * default_double_support_ratio * one_step_len) * _dt;
+    current_swing_time[support_leg==RLEG ? LLEG : RLEG] = tmp_current_swing_time;
     //std::cerr << "sl " << support_leg << " " << current_swing_time[support_leg==RLEG?0:1] << " " << current_swing_time[support_leg==RLEG?1:0] << " " << tmp_current_swing_time << " " << gp_count << std::endl;
     return ret;
   };
@@ -355,7 +355,7 @@ namespace rats
       set_velocity_param(dp(0)/default_step_time, dp(1)/default_step_time, rad2deg(dr(2))/default_step_time);
       append_footstep_list_velocity_mode();
       foot_midcoords = footstep_node_list.back().worldcoords;
-      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[(footstep_node_list.back().l_r == RLEG) ? 0 : 1] * -1.0);
+      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list.back().l_r] * -1.0);
       foot_midcoords.difference(dp, dr, goal_foot_midcoords);
       dp = foot_midcoords.rot.transpose() * dp;
       dr = foot_midcoords.rot.transpose() * dr;
@@ -374,7 +374,7 @@ namespace rats
     step_node sn0((_swing_leg == RLEG) ? LLEG : RLEG, _support_leg_coords, lcg.get_default_step_height());
     footstep_node_list.push_back(sn0);
     step_node sn1(_swing_leg, _support_leg_coords, lcg.get_default_step_height());
-    hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[(_swing_leg == RLEG) ? 0 : 1] + hrp::Vector3(goal_x, goal_y, goal_z));
+    hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[_swing_leg] + hrp::Vector3(goal_x, goal_y, goal_z));
     sn1.worldcoords.pos += sn1.worldcoords.rot * trs;
     sn1.worldcoords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
     footstep_node_list.push_back(sn1);
@@ -403,7 +403,7 @@ namespace rats
   void gait_generator::calc_foot_midcoords_trans_vector_velocity_mode (coordinates& foot_midcoords, hrp::Vector3& trans, double& dth, const step_node& sn)
   {
     foot_midcoords = sn.worldcoords;
-    hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[(sn.l_r == RLEG) ? 0 : 1] * -1.0);
+    hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[sn.l_r] * -1.0);
     foot_midcoords.pos += foot_midcoords.rot * tmpv;
     double dx = vel_param.velocity_x + offset_vel_param.velocity_x, dy = vel_param.velocity_y + offset_vel_param.velocity_y;
     dth = vel_param.velocity_theta + offset_vel_param.velocity_theta;

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -23,7 +23,7 @@ namespace rats
     dz1 += _swing_leg_coords.pos;
     rzmp = (dz0 + dz1) / 2.0;
     refzmp_cur_list.push_back( rzmp );
-    support_leg_list.push_back( fnl[fs_index].l_r );
+    swing_leg_list.push_back( fnl[fs_index].l_r );
     fs_index++;
   };
 
@@ -33,7 +33,7 @@ namespace rats
     coordinates tmp(fnl[fs_index-1].worldcoords);
     rzmp = tmp.rot * default_zmp_offsets[fnl[fs_index-1].l_r] + tmp.pos;
     refzmp_cur_list.push_back( rzmp );
-    support_leg_list.push_back( fnl[fs_index-1].l_r == RLEG ? LLEG : RLEG);
+    swing_leg_list.push_back( fnl[fs_index-1].l_r == RLEG ? LLEG : RLEG);
     if (fs_index < fnl.size()) fs_index++;
   };
 
@@ -41,7 +41,7 @@ namespace rats
   {
     size_t cnt = one_step_len - refzmp_count;
     double margine_count = 0.5 * default_double_support_ratio * one_step_len;
-    swing_foot_zmp_offset = default_zmp_offsets[support_leg_list[refzmp_index]];
+    swing_foot_zmp_offset = default_zmp_offsets[swing_leg_list[refzmp_index]];
     if ( cnt < margine_count ) {
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
       hrp::Vector3 prev_support_zmp = (is_start_double_support_phase() ? refzmp_cur_list[refzmp_index] : refzmp_cur_list[refzmp_index-1]);

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -143,9 +143,9 @@ namespace rats
   {
       double tmp_ip_ratio;
       size_t current_count = total_count - gp_count;
-      if (thp.is_phase_starting(current_count, start_phase)) {
+      if (thp_ptr->is_phase_starting(current_count, start_phase)) {
           toe_heel_interpolator->set(&start);
-          toe_heel_interpolator->go(&goal, thp.get_phase_period(start_phase, goal_phase, _dt));
+          toe_heel_interpolator->go(&goal, thp_ptr->get_phase_period(start_phase, goal_phase, _dt));
       }
       toe_heel_interpolator->get(&tmp_ip_ratio, true);
       return tmp_ip_ratio;
@@ -157,25 +157,25 @@ namespace rats
       size_t current_count = total_count - gp_count;
       double dif_angle = 0.0;
       hrp::Vector3 ee_local_pivot_pos(hrp::Vector3(0,0,0));
-      if ( thp.is_between_phases(current_count, SOLE0, SOLE2TOE) ) {
+      if ( thp_ptr->is_between_phases(current_count, SOLE0, SOLE2TOE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE0, SOLE2TOE, 0.0, toe_angle);
           ee_local_pivot_pos(0) = toe_pos_offset_x;
-      } else if ( thp.is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
+      } else if ( thp_ptr->is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE2HEEL, HEEL2SOLE, -1 * heel_angle, 0.0);
           ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
-      } else if ( thp.is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
+      } else if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
           // If SOLE1 phase does not exist, interpolate toe => heel smoothly, without 0 velocity phase.
-          if ( thp.is_no_SOLE1_phase() ) {
+          if ( thp_ptr->is_no_SOLE1_phase() ) {
               dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, SOLE2HEEL, toe_angle, -1 * heel_angle);
               double tmpd = (-1*heel_angle-toe_angle);
               if (std::fabs(tmpd) > 1e-5) {
                   ee_local_pivot_pos(0) = (-1 * heel_pos_offset_x - toe_pos_offset_x) * (dif_angle - toe_angle) / tmpd + toe_pos_offset_x;
               }
           } else {
-              if ( thp.is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
+              if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, TOE2SOLE, toe_angle, 0.0);
                   ee_local_pivot_pos(0) = toe_pos_offset_x;
-              } else if ( thp.is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
+              } else if ( thp_ptr->is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE1, SOLE2HEEL, 0.0, -1 * heel_angle);
                   ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
               }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -23,7 +23,7 @@ namespace rats
     dz1 += _swing_leg_coords.pos;
     rzmp = (dz0 + dz1) / 2.0;
     refzmp_cur_list.push_back( rzmp );
-    support_leg_list.push_back( BOTH );
+    support_leg_list.push_back( fnl[fs_index].l_r );
     fs_index++;
   };
 
@@ -33,7 +33,7 @@ namespace rats
     coordinates tmp(fnl[fs_index-1].worldcoords);
     rzmp = tmp.rot * default_zmp_offsets[fnl[fs_index-1].l_r] + tmp.pos;
     refzmp_cur_list.push_back( rzmp );
-    support_leg_list.push_back( fnl[fs_index-1].l_r );
+    support_leg_list.push_back( fnl[fs_index-1].l_r == RLEG ? LLEG : RLEG);
     if (fs_index < fnl.size()) fs_index++;
   };
 
@@ -41,11 +41,7 @@ namespace rats
   {
     size_t cnt = one_step_len - refzmp_count;
     double margine_count = 0.5 * default_double_support_ratio * one_step_len;
-    if (support_leg_list[refzmp_index] == BOTH) {
-        swing_foot_zmp_offset = hrp::Vector3::Zero();
-    } else {
-        swing_foot_zmp_offset = default_zmp_offsets[support_leg_list[refzmp_index]];
-    }
+    swing_foot_zmp_offset = default_zmp_offsets[support_leg_list[refzmp_index]];
     if ( cnt < margine_count ) {
       double ratio = (-0.5 / margine_count) * (cnt - margine_count);
       ret = (1 - ratio) * refzmp_cur_list[refzmp_index] + ratio * ((refzmp_index > 0) ? refzmp_cur_list[refzmp_index-1] : refzmp_cur_list[refzmp_index]);

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -43,11 +43,15 @@ namespace rats
     double margine_count = 0.5 * default_double_support_ratio * one_step_len;
     swing_foot_zmp_offset = default_zmp_offsets[support_leg_list[refzmp_index]];
     if ( cnt < margine_count ) {
+      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
+      hrp::Vector3 prev_support_zmp = (is_start_double_support_phase() ? refzmp_cur_list[refzmp_index] : refzmp_cur_list[refzmp_index-1]);
       double ratio = (-0.5 / margine_count) * (cnt - margine_count);
-      ret = (1 - ratio) * refzmp_cur_list[refzmp_index] + ratio * ((refzmp_index > 0) ? refzmp_cur_list[refzmp_index-1] : refzmp_cur_list[refzmp_index]);
+      ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_len - margine_count ) {
+      hrp::Vector3 current_support_zmp = (is_end_double_support_phase() ? refzmp_cur_list[refzmp_index] : refzmp_cur_list[refzmp_index+1]);
+      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = (0.5 / margine_count) * (cnt - (one_step_len - margine_count));
-      ret = (1 - ratio) * refzmp_cur_list[refzmp_index] + ratio * ((refzmp_index + 1 <= refzmp_cur_list.size() - 1) ? refzmp_cur_list[refzmp_index+1] : refzmp_cur_list[refzmp_index]);
+      ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else {
       ret = refzmp_cur_list[refzmp_index];
     }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -237,7 +237,7 @@ namespace rats
       }
       if (gp_index < fnl.size() - 1) {
         if (force_height_zero) current_step_height = 0.0;
-        else current_step_height = default_step_height;
+        else current_step_height = fnl[gp_index].step_height;
       } else {
         current_step_height = 0.0;
       }
@@ -371,9 +371,9 @@ namespace rats
                                                              const coordinates& _support_leg_coords)
   {
     leg_type _swing_leg = (tmp_swing_leg == "rleg") ? WC_RLEG : WC_LLEG;
-    step_node sn0((_swing_leg == WC_RLEG) ? WC_LLEG : WC_RLEG, _support_leg_coords);
+    step_node sn0((_swing_leg == WC_RLEG) ? WC_LLEG : WC_RLEG, _support_leg_coords, lcg.get_default_step_height());
     footstep_node_list.push_back(sn0);
-    step_node sn1(_swing_leg, _support_leg_coords);
+    step_node sn1(_swing_leg, _support_leg_coords, lcg.get_default_step_height());
     hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[(_swing_leg == WC_RLEG) ? 0 : 1] + hrp::Vector3(goal_x, goal_y, goal_z));
     sn1.worldcoords.pos += sn1.worldcoords.rot * trs;
     sn1.worldcoords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
@@ -475,7 +475,7 @@ namespace rats
       if ( footstep_node_list.size() - 1 >= idx + i) /* if footstep_node_list[idx] and footstep_node_list[idx+1]  exists */
         footstep_node_list[idx + i].worldcoords = cv[i];
       else
-        footstep_node_list.push_back(step_node(footstep_node_list[lcg.get_gp_index()-1 + i].l_r, cv[i]));
+        footstep_node_list.push_back(step_node(footstep_node_list[lcg.get_gp_index()-1 + i].l_r, cv[i], lcg.get_default_step_height()));
     }
 
     /* remove steps after newly added steps */

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -294,7 +294,7 @@ namespace rats
       prev_que_rzmp = rzmp;
       prev_que_sfzo = sfzo;
     }
-    bool solved = preview_controller_ptr->update(refzmp, cog, rzmp, (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
+    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset, rzmp, sfzo, (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
     /* update refzmp */
     if ( lcg.get_gp_index() > 0 && lcg.get_gp_count() == static_cast<size_t>(one_step_len / 2) - 1 ) {
       if (velocity_mode_flg != VEL_IDLING) {
@@ -509,7 +509,7 @@ namespace rats
     bool not_solved = true;
     while (not_solved) {
       bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo, default_double_support_ratio, one_step_len);
-      not_solved = !preview_controller_ptr->update(refzmp, cog, rzmp, refzmp_exist_p);
+      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset, rzmp, sfzo, refzmp_exist_p);
       rg.update_refzmp(footstep_node_list, one_step_len);
     }
   };

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -50,7 +50,7 @@ namespace rats
     //if (cnt==0) std::cerr << "z " << refzmp_index << " " << refzmp_cur_list.size() << " " << fs_index << " " << (refzmp_index == refzmp_cur_list.size()-2) << " " << is_final_double_support_set << std::endl;
     if (use_toe_heel_transition && !(is_start_double_support_phase() || is_end_double_support_phase())) {
         if (thp_ptr->is_between_phases(cnt, SOLE0)) {
-            double ratio = thp_ptr->get_phase_ratio(cnt, SOLE0);
+            double ratio = thp_ptr->get_phase_ratio(cnt+1, SOLE0);
             swing_foot_zmp_offset(0) = (1-ratio)*swing_foot_zmp_offset(0) + ratio*toe_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, HEEL2SOLE, SOLE2)) {
             double ratio = thp_ptr->get_phase_ratio(cnt, HEEL2SOLE, SOLE2);
@@ -79,7 +79,7 @@ namespace rats
       if ( !(is_start_double_support_phase() || is_end_double_support_phase()) ) {
           current_support_zmp += (((refzmp_index == refzmp_cur_list.size()-2) && is_final_double_support_set) ? zmp_diff * 0.5 : zmp_diff) * foot_x_axis_list[refzmp_index+1];
       }
-      double ratio = (0.5 / margine_count) * (cnt - (one_step_len - margine_count));
+      double ratio = (0.5 / margine_count) * (cnt - 1 - (one_step_len - margine_count));
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else {
       ret = refzmp_cur_list[refzmp_index];

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -196,14 +196,14 @@ namespace rats
           ee_local_pivot_pos(0) = toe_pos_offset_x;
       } else if ( thp_ptr->is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE2HEEL, HEEL2SOLE, -1 * heel_angle, 0.0);
-          ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
+          ee_local_pivot_pos(0) = heel_pos_offset_x;
       } else if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
           // If SOLE1 phase does not exist, interpolate toe => heel smoothly, without 0 velocity phase.
           if ( thp_ptr->is_no_SOLE1_phase() ) {
               dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, SOLE2HEEL, toe_angle, -1 * heel_angle);
               double tmpd = (-1*heel_angle-toe_angle);
               if (std::fabs(tmpd) > 1e-5) {
-                  ee_local_pivot_pos(0) = (-1 * heel_pos_offset_x - toe_pos_offset_x) * (dif_angle - toe_angle) / tmpd + toe_pos_offset_x;
+                  ee_local_pivot_pos(0) = (heel_pos_offset_x - toe_pos_offset_x) * (dif_angle - toe_angle) / tmpd + toe_pos_offset_x;
               }
           } else {
               if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
@@ -211,7 +211,7 @@ namespace rats
                   ee_local_pivot_pos(0) = toe_pos_offset_x;
               } else if ( thp_ptr->is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE1, SOLE2HEEL, 0.0, -1 * heel_angle);
-                  ee_local_pivot_pos(0) = -1 * heel_pos_offset_x;
+                  ee_local_pivot_pos(0) = heel_pos_offset_x;
               }
           }
       }

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -24,10 +24,11 @@ namespace rats
     {
       leg_type l_r;
       coordinates worldcoords;
-      step_node (const leg_type _l_r, const coordinates& _worldcoords)
-        : l_r(_l_r), worldcoords(_worldcoords) {};
-      step_node (const std::string& _l_r, const coordinates& _worldcoords)
-        : l_r((_l_r == "rleg") ? WC_RLEG : WC_LLEG), worldcoords(_worldcoords) {};
+      double step_height;
+      step_node (const leg_type _l_r, const coordinates& _worldcoords, const double _step_height)
+        : l_r(_l_r), worldcoords(_worldcoords), step_height(_step_height) {};
+      step_node (const std::string& _l_r, const coordinates& _worldcoords, const double _step_height)
+        : l_r((_l_r == "rleg") ? WC_RLEG : WC_LLEG), worldcoords(_worldcoords), step_height(_step_height) {};
     };
     friend std::ostream &operator<<(std::ostream &os, const step_node &sn)
     {
@@ -37,6 +38,7 @@ namespace rats
       os << (sn.worldcoords.pos).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
       os << "  rot =" << std::endl;
       os << (sn.worldcoords.rot).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
+      os << "  step_height = " << sn.step_height << "[m]" << std::endl;
       return os;
     };
 
@@ -447,7 +449,7 @@ namespace rats
     void append_go_pos_step_node (const coordinates& _foot_midcoords,
                                   const leg_type _l_r)
     {
-      step_node sn(_l_r, _foot_midcoords);
+      step_node sn(_l_r, _foot_midcoords, lcg.get_default_step_height());
       sn.worldcoords.pos += sn.worldcoords.rot * footstep_param.leg_default_translate_pos[(_l_r == WC_RLEG) ? 0 : 1];
       footstep_node_list.push_back(sn);
     };
@@ -487,7 +489,11 @@ namespace rats
     bool proc_one_tick ();
     void append_footstep_node (const std::string& _leg, const coordinates& _fs)
     {
-      footstep_node_list.push_back(step_node((_leg == "rleg") ? WC_RLEG : WC_LLEG, _fs));
+        footstep_node_list.push_back(step_node((_leg == "rleg") ? WC_RLEG : WC_LLEG, _fs, lcg.get_default_step_height()));
+    };
+    void append_footstep_node (const std::string& _leg, const coordinates& _fs, const double _step_height)
+    {
+        footstep_node_list.push_back(step_node((_leg == "rleg") ? WC_RLEG : WC_LLEG, _fs, _step_height));
     };
     void clear_footstep_node_list () { footstep_node_list.clear(); };
     void go_pos_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -121,6 +121,7 @@ namespace rats
         return refzmp_cur_list.size() > refzmp_index;
       };
       const hrp::Vector3& get_refzmp_cur () { return refzmp_cur_list.front(); };
+      const hrp::Vector3& get_default_zmp_offset (const leg_type lt) { return default_zmp_offsets[lt]; };
     };
 
     class delay_hoffarbib_trajectory_generator
@@ -566,6 +567,7 @@ namespace rats
     const hrp::Vector3& get_cog () { return cog; };
     const hrp::Vector3& get_refzmp () { return refzmp;};
     const hrp::Vector3& get_swing_foot_zmp_offset () { return swing_foot_zmp_offset;};
+    const hrp::Vector3& get_support_foot_zmp_offset () { return rg.get_default_zmp_offset(lcg.get_support_leg());};
     const std::string get_footstep_front_leg () const { return footstep_node_list[0].l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_footstep_back_leg () const { return footstep_node_list.back().l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_support_leg() const { return lcg.get_support_leg() == RLEG ? "rleg" : "lleg";};

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -133,7 +133,7 @@ namespace rats
     public:
 #endif
       std::vector<hrp::Vector3> refzmp_cur_list;
-      std::vector<leg_type> support_leg_list;
+      std::vector<leg_type> swing_leg_list;
       std::vector<hrp::Vector3> default_zmp_offsets; /* (list rleg lleg) */
       size_t fs_index, refzmp_index, refzmp_count;
       void calc_current_refzmp (hrp::Vector3& ret, hrp::Vector3& swing_foot_zmp_offset, const double default_double_support_ratio, const size_t one_step_len) const;
@@ -154,7 +154,7 @@ namespace rats
       void remove_refzmp_cur_list_over_length (const size_t len)
       {
         while ( refzmp_cur_list.size() > len) refzmp_cur_list.pop_back();
-        while ( support_leg_list.size() > len) support_leg_list.pop_back();
+        while ( swing_leg_list.size() > len) swing_leg_list.pop_back();
       };
       void set_indices (const size_t idx) { fs_index = refzmp_index = idx; };
       void set_refzmp_count(const size_t _refzmp_count) { refzmp_count = _refzmp_count; };
@@ -164,7 +164,7 @@ namespace rats
         set_indices(0);
         set_refzmp_count(_refzmp_count);
         refzmp_cur_list.clear();
-        support_leg_list.clear();
+        swing_leg_list.clear();
       };
       void push_refzmp_from_footstep_list_for_dual (const std::vector<step_node>& fnl,
                                                     const coordinates& _support_leg_coords,

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -339,7 +339,7 @@ namespace rats
       orbit_type default_orbit_type;
       rectangle_delay_hoffarbib_trajectory_generator rdtg;
       stair_delay_hoffarbib_trajectory_generator sdtg;
-      toe_heel_phase_counter thp;
+      toe_heel_phase_counter* thp_ptr;
       interpolator* foot_ratio_interpolator;
       // Parameters for toe-heel contact
       interpolator* toe_heel_interpolator;
@@ -365,9 +365,10 @@ namespace rats
 #ifndef HAVE_MAIN
     public:
 #endif
-      leg_coords_generator(const double __dt)
+      leg_coords_generator(const double __dt, toe_heel_phase_counter* _thp_ptr)
         : swing_leg_dst_coords(), support_leg_coords(), swing_leg_coords(), swing_leg_src_coords(),
           default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), rot_ratio(0), _dt(__dt), gp_index(0), gp_count(0), support_leg(RLEG), default_orbit_type(CYCLOID),
+          thp_ptr(_thp_ptr),
           foot_ratio_interpolator(NULL), toe_heel_interpolator(NULL),
           toe_pos_offset_x(0.0), heel_pos_offset_x(0.0), toe_angle(0.0), heel_angle(0.0), foot_dif_rot_angle(0.0), use_toe_joint(false)
       {
@@ -387,6 +388,7 @@ namespace rats
             delete toe_heel_interpolator;
             toe_heel_interpolator = NULL;
         }
+        thp_ptr = NULL;
       };
       void set_default_step_height (const double _tmp) { default_step_height = _tmp; };
       void set_default_top_ratio (const double _tmp) { default_top_ratio = _tmp; };
@@ -412,7 +414,7 @@ namespace rats
         swing_leg_src_coords = _swing_leg_src_coords;
         support_leg_coords = _support_leg_coords;
         total_count = gp_count = one_step_len;
-        thp.set_total_count(total_count);
+        thp_ptr->set_total_count(total_count);
         gp_index = 0;
         current_step_height = 0.0;
         rdtg.reset(one_step_len, default_double_support_ratio);
@@ -464,9 +466,9 @@ namespace rats
 
     /* member variables for gait_generator */
     std::vector<step_node> footstep_node_list;
+    toe_heel_phase_counter thp;
     refzmp_generator rg;
     leg_coords_generator lcg;
-    toe_heel_phase_counter thp;
     footstep_parameter footstep_param;
     velocity_mode_parameter vel_param, offset_vel_param;
     hrp::Vector3 cog, refzmp, prev_que_rzmp, swing_foot_zmp_offset, prev_que_sfzo; /* cog by calculating proc_one_tick */
@@ -507,7 +509,7 @@ namespace rats
                     /* arguments for footstep_parameter */
                     const std::vector<hrp::Vector3>& _leg_pos,
                     const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
-      : footstep_node_list(), rg(), lcg(_dt),
+      : footstep_node_list(), thp(), rg(), lcg(_dt, &thp),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
         swing_foot_zmp_offset(hrp::Vector3::Zero()), prev_que_sfzo(hrp::Vector3::Zero()),

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -79,14 +79,15 @@ namespace rats
     public:
 #endif
       std::vector<hrp::Vector3> refzmp_cur_list;
+      std::vector<leg_type> support_leg_list;
       std::vector<hrp::Vector3> default_zmp_offsets; /* (list rleg lleg) */
       size_t fs_index, refzmp_index, refzmp_count;
-      void calc_current_refzmp (hrp::Vector3& ret, const double default_double_support_ratio, const size_t one_step_len) const;
+      void calc_current_refzmp (hrp::Vector3& ret, hrp::Vector3& swing_foot_zmp_offset, const double default_double_support_ratio, const size_t one_step_len) const;
 #ifndef HAVE_MAIN
     public:
 #endif
       refzmp_generator()
-        : refzmp_cur_list(), default_zmp_offsets(),
+        : refzmp_cur_list(), support_leg_list(), default_zmp_offsets(),
           fs_index(0), refzmp_index(0), refzmp_count(0)
       {
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
@@ -97,6 +98,7 @@ namespace rats
       void remove_refzmp_cur_list_over_length (const size_t len)
       {
         while ( refzmp_cur_list.size() > len) refzmp_cur_list.pop_back();
+        while ( support_leg_list.size() > len) support_leg_list.pop_back();
       };
       void set_indices (const size_t idx) { fs_index = refzmp_index = idx; };
       void set_refzmp_count(const size_t _refzmp_count) { refzmp_count = _refzmp_count; };
@@ -106,15 +108,16 @@ namespace rats
         set_indices(0);
         set_refzmp_count(_refzmp_count);
         refzmp_cur_list.clear();
+        support_leg_list.clear();
       };
       void push_refzmp_from_footstep_list_for_dual (const std::vector<step_node>& fnl,
                                                     const coordinates& _support_leg_coords,
                                                     const coordinates& _swing_leg_coords);
       void push_refzmp_from_footstep_list_for_single (const std::vector<step_node>& fnl);
       void update_refzmp (const std::vector<step_node>& fnl, const size_t one_step_len);
-      bool get_current_refzmp (hrp::Vector3& rzmp, const double default_double_support_ratio, const size_t one_step_len) const
+      bool get_current_refzmp (hrp::Vector3& rzmp, hrp::Vector3& swing_foot_zmp_offset, const double default_double_support_ratio, const size_t one_step_len) const
       {
-        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, default_double_support_ratio, one_step_len);
+        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offset, default_double_support_ratio, one_step_len);
         return refzmp_cur_list.size() > refzmp_index;
       };
       const hrp::Vector3& get_refzmp_cur () { return refzmp_cur_list.front(); };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -385,6 +385,7 @@ namespace rats
       const coordinates& get_swing_leg_src_coords() const { return swing_leg_src_coords; };
       const coordinates& get_swing_leg_dst_coords() const { return swing_leg_dst_coords; };
       leg_type get_support_leg() const { return support_leg;};
+      leg_type get_swing_leg() const { return support_leg == RLEG ? LLEG : RLEG;};
       double get_default_step_height () const { return default_step_height;};
       void get_swing_support_mid_coords(coordinates& ret) const
       {
@@ -450,7 +451,7 @@ namespace rats
                                   const leg_type _l_r)
     {
       step_node sn(_l_r, _foot_midcoords, lcg.get_default_step_height());
-      sn.worldcoords.pos += sn.worldcoords.rot * footstep_param.leg_default_translate_pos[(_l_r == RLEG) ? 0 : 1];
+      sn.worldcoords.pos += sn.worldcoords.rot * footstep_param.leg_default_translate_pos[_l_r];
       footstep_node_list.push_back(sn);
     };
     void overwrite_refzmp_queue(const std::vector<coordinates>& cv);
@@ -489,11 +490,11 @@ namespace rats
     bool proc_one_tick ();
     void append_footstep_node (const std::string& _leg, const coordinates& _fs)
     {
-        footstep_node_list.push_back(step_node((_leg == "rleg") ? RLEG : LLEG, _fs, lcg.get_default_step_height()));
+        footstep_node_list.push_back(step_node(_leg, _fs, lcg.get_default_step_height()));
     };
     void append_footstep_node (const std::string& _leg, const coordinates& _fs, const double _step_height)
     {
-        footstep_node_list.push_back(step_node((_leg == "rleg") ? RLEG : LLEG, _fs, _step_height));
+        footstep_node_list.push_back(step_node(_leg, _fs, _step_height));
     };
     void clear_footstep_node_list () { footstep_node_list.clear(); };
     void go_pos_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
@@ -563,7 +564,7 @@ namespace rats
     const std::string get_footstep_front_leg () const { return footstep_node_list[0].l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_footstep_back_leg () const { return footstep_node_list.back().l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_support_leg() const { return lcg.get_support_leg() == RLEG ? "rleg" : "lleg";};
-    const std::string get_swing_leg() const { return lcg.get_support_leg() == RLEG ? "lleg" : "rleg";};
+    const std::string get_swing_leg() const { return lcg.get_swing_leg() == RLEG ? "rleg" : "lleg";};
     const coordinates& get_swing_leg_coords() const { return lcg.get_swing_leg_coords(); };
     const coordinates& get_support_leg_coords() const { return lcg.get_support_leg_coords(); };
     const coordinates& get_swing_leg_src_coords() const { return lcg.get_swing_leg_src_coords(); };
@@ -571,7 +572,7 @@ namespace rats
     const coordinates get_dst_foot_midcoords() const /* get foot_midcoords calculated from swing_leg_dst_coords */
     {
       coordinates tmp(lcg.get_swing_leg_dst_coords());
-      tmp.pos += tmp.rot * hrp::Vector3(-1*footstep_param.leg_default_translate_pos[(lcg.get_support_leg() == RLEG) ? 1 : 0]);
+      tmp.pos += tmp.rot * hrp::Vector3(-1*footstep_param.leg_default_translate_pos[lcg.get_swing_leg()]);
       return tmp;
     };
     void get_swing_support_mid_coords(coordinates& ret) const { lcg.get_swing_support_mid_coords(ret); };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -137,6 +137,8 @@ namespace rats
       std::vector<hrp::Vector3> default_zmp_offsets; /* (list rleg lleg) */
       size_t fs_index, refzmp_index, refzmp_count;
       void calc_current_refzmp (hrp::Vector3& ret, hrp::Vector3& swing_foot_zmp_offset, const double default_double_support_ratio, const size_t one_step_len) const;
+      const bool is_start_double_support_phase () const { return refzmp_index == 0; };
+      const bool is_end_double_support_phase () const { return refzmp_index == refzmp_cur_list.size() - 1; };
 #ifndef HAVE_MAIN
     public:
 #endif

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -14,11 +14,11 @@ namespace rats
 
   public:
     enum orbit_type {SHUFFLING, CYCLOID, RECTANGLE, STAIR};
+    enum leg_type {RLEG, LLEG, BOTH};
 
 #ifndef HAVE_MAIN
   private:
 #endif
-    enum leg_type {LLEG, RLEG};
 
     struct step_node
     {
@@ -392,17 +392,17 @@ namespace rats
 	mid_coords(tmp, rot_ratio, swing_leg_src_coords, swing_leg_dst_coords);
         mid_coords(ret, 0.5, tmp, support_leg_coords);
       };
-      size_t get_current_support_state () const
+      leg_type get_current_support_state () const
       {
 	if ( current_step_height > 0.0 ) {
 	  if ( 0.0 < swing_ratio && swing_ratio < 1.0 ) {
-	    if ( get_support_leg() == RLEG ) return 1; // rleg
-	    else return 2;
+	    if ( get_support_leg() == RLEG ) return RLEG;
+	    else return LLEG;
 	  } else {
-	    return 0;
+	    return BOTH;
 	  }
 	} else {
-	  return 0;
+	  return BOTH;
 	}
       };
       orbit_type get_default_orbit_type () const { return default_orbit_type; };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -18,7 +18,7 @@ namespace rats
 #ifndef HAVE_MAIN
   private:
 #endif
-    enum leg_type {WC_LLEG, WC_RLEG};
+    enum leg_type {LLEG, RLEG};
 
     struct step_node
     {
@@ -28,12 +28,12 @@ namespace rats
       step_node (const leg_type _l_r, const coordinates& _worldcoords, const double _step_height)
         : l_r(_l_r), worldcoords(_worldcoords), step_height(_step_height) {};
       step_node (const std::string& _l_r, const coordinates& _worldcoords, const double _step_height)
-        : l_r((_l_r == "rleg") ? WC_RLEG : WC_LLEG), worldcoords(_worldcoords), step_height(_step_height) {};
+        : l_r((_l_r == "rleg") ? RLEG : LLEG), worldcoords(_worldcoords), step_height(_step_height) {};
     };
     friend std::ostream &operator<<(std::ostream &os, const step_node &sn)
     {
       os << "footstep" << std::endl;
-      os << "  name = [" << ((sn.l_r==WC_LLEG)?std::string("lleg"):std::string("rleg")) << "]" << std::endl;
+      os << "  name = [" << ((sn.l_r==LLEG)?std::string("lleg"):std::string("rleg")) << "]" << std::endl;
       os << "  pos =" << std::endl;
       os << (sn.worldcoords.pos).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
       os << "  rot =" << std::endl;
@@ -311,7 +311,7 @@ namespace rats
 #endif
       leg_coords_generator(const double __dt)
         : swing_leg_dst_coords(), support_leg_coords(), swing_leg_coords(), swing_leg_src_coords(),
-          default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), rot_ratio(0), _dt(__dt), gp_index(0), gp_count(0), support_leg(WC_RLEG), default_orbit_type(CYCLOID),
+          default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), rot_ratio(0), _dt(__dt), gp_index(0), gp_count(0), support_leg(RLEG), default_orbit_type(CYCLOID),
           foot_ratio_interpolator(NULL), toe_heel_interpolator(NULL),
           toe_pos_offset_x(0.0), heel_pos_offset_x(0.0), toe_angle(0.0), heel_angle(0.0), foot_dif_rot_angle(0.0), use_toe_joint(false)
       {
@@ -396,7 +396,7 @@ namespace rats
       {
 	if ( current_step_height > 0.0 ) {
 	  if ( 0.0 < swing_ratio && swing_ratio < 1.0 ) {
-	    if ( get_support_leg() == WC_RLEG ) return 1; // rleg
+	    if ( get_support_leg() == RLEG ) return 1; // rleg
 	    else return 2;
 	  } else {
 	    return 0;
@@ -450,7 +450,7 @@ namespace rats
                                   const leg_type _l_r)
     {
       step_node sn(_l_r, _foot_midcoords, lcg.get_default_step_height());
-      sn.worldcoords.pos += sn.worldcoords.rot * footstep_param.leg_default_translate_pos[(_l_r == WC_RLEG) ? 0 : 1];
+      sn.worldcoords.pos += sn.worldcoords.rot * footstep_param.leg_default_translate_pos[(_l_r == RLEG) ? 0 : 1];
       footstep_node_list.push_back(sn);
     };
     void overwrite_refzmp_queue(const std::vector<coordinates>& cv);
@@ -489,17 +489,17 @@ namespace rats
     bool proc_one_tick ();
     void append_footstep_node (const std::string& _leg, const coordinates& _fs)
     {
-        footstep_node_list.push_back(step_node((_leg == "rleg") ? WC_RLEG : WC_LLEG, _fs, lcg.get_default_step_height()));
+        footstep_node_list.push_back(step_node((_leg == "rleg") ? RLEG : LLEG, _fs, lcg.get_default_step_height()));
     };
     void append_footstep_node (const std::string& _leg, const coordinates& _fs, const double _step_height)
     {
-        footstep_node_list.push_back(step_node((_leg == "rleg") ? WC_RLEG : WC_LLEG, _fs, _step_height));
+        footstep_node_list.push_back(step_node((_leg == "rleg") ? RLEG : LLEG, _fs, _step_height));
     };
     void clear_footstep_node_list () { footstep_node_list.clear(); };
     void go_pos_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
                                        const coordinates& _foot_midcoords) {
       go_pos_param_2_footstep_list(goal_x, goal_y, goal_theta,
-                                   _foot_midcoords, (goal_y > 0.0 ? WC_RLEG : WC_LLEG));
+                                   _foot_midcoords, (goal_y > 0.0 ? RLEG : LLEG));
     }
     void go_pos_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
                                        const coordinates& _foot_midcoords, const leg_type start_leg);
@@ -560,10 +560,10 @@ namespace rats
     /* parameter getting */
     const hrp::Vector3& get_cog () { return cog; };
     const hrp::Vector3& get_refzmp () { return refzmp;};
-    const std::string get_footstep_front_leg () const { return footstep_node_list[0].l_r == WC_RLEG ? "rleg" : "lleg"; };
-    const std::string get_footstep_back_leg () const { return footstep_node_list.back().l_r == WC_RLEG ? "rleg" : "lleg"; };
-    const std::string get_support_leg() const { return lcg.get_support_leg() == WC_RLEG ? "rleg" : "lleg";};
-    const std::string get_swing_leg() const { return lcg.get_support_leg() == WC_RLEG ? "lleg" : "rleg";};
+    const std::string get_footstep_front_leg () const { return footstep_node_list[0].l_r == RLEG ? "rleg" : "lleg"; };
+    const std::string get_footstep_back_leg () const { return footstep_node_list.back().l_r == RLEG ? "rleg" : "lleg"; };
+    const std::string get_support_leg() const { return lcg.get_support_leg() == RLEG ? "rleg" : "lleg";};
+    const std::string get_swing_leg() const { return lcg.get_support_leg() == RLEG ? "lleg" : "rleg";};
     const coordinates& get_swing_leg_coords() const { return lcg.get_swing_leg_coords(); };
     const coordinates& get_support_leg_coords() const { return lcg.get_support_leg_coords(); };
     const coordinates& get_swing_leg_src_coords() const { return lcg.get_swing_leg_src_coords(); };
@@ -571,7 +571,7 @@ namespace rats
     const coordinates get_dst_foot_midcoords() const /* get foot_midcoords calculated from swing_leg_dst_coords */
     {
       coordinates tmp(lcg.get_swing_leg_dst_coords());
-      tmp.pos += tmp.rot * hrp::Vector3(-1*footstep_param.leg_default_translate_pos[(lcg.get_support_leg() == WC_RLEG) ? 1 : 0]);
+      tmp.pos += tmp.rot * hrp::Vector3(-1*footstep_param.leg_default_translate_pos[(lcg.get_support_leg() == RLEG) ? 1 : 0]);
       return tmp;
     };
     void get_swing_support_mid_coords(coordinates& ret) const { lcg.get_swing_support_mid_coords(ret); };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -434,7 +434,7 @@ namespace rats
     leg_coords_generator lcg;
     footstep_parameter footstep_param;
     velocity_mode_parameter vel_param, offset_vel_param;
-    hrp::Vector3 cog, refzmp, prev_que_rzmp; /* cog by calculating proc_one_tick */
+    hrp::Vector3 cog, refzmp, prev_que_rzmp, swing_foot_zmp_offset, prev_que_sfzo; /* cog by calculating proc_one_tick */
     double dt; /* control loop [s] */
     double default_step_time;
     double default_double_support_ratio;
@@ -475,6 +475,7 @@ namespace rats
       : footstep_node_list(), rg(), lcg(_dt),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
+        swing_foot_zmp_offset(hrp::Vector3::Zero()), prev_que_sfzo(hrp::Vector3::Zero()),
         dt(_dt), default_step_time(1.0), default_double_support_ratio(0.2), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         one_step_len(default_step_time / dt), finalize_count(0),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
@@ -564,6 +565,7 @@ namespace rats
     /* parameter getting */
     const hrp::Vector3& get_cog () { return cog; };
     const hrp::Vector3& get_refzmp () { return refzmp;};
+    const hrp::Vector3& get_swing_foot_zmp_offset () { return swing_foot_zmp_offset;};
     const std::string get_footstep_front_leg () const { return footstep_node_list[0].l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_footstep_back_leg () const { return footstep_node_list.back().l_r == RLEG ? "rleg" : "lleg"; };
     const std::string get_support_leg() const { return lcg.get_support_leg() == RLEG ? "rleg" : "lleg";};

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -85,7 +85,11 @@ namespace rats
 #endif
       refzmp_generator()
         : refzmp_cur_list(), default_zmp_offsets(),
-          fs_index(0), refzmp_index(0), refzmp_count(0) {};
+          fs_index(0), refzmp_index(0), refzmp_count(0)
+      {
+          default_zmp_offsets.push_back(hrp::Vector3::Zero());
+          default_zmp_offsets.push_back(hrp::Vector3::Zero());
+      };
       ~refzmp_generator() {};
       /*  */
       void remove_refzmp_cur_list_over_length (const size_t len)

--- a/rtc/AutoBalancer/PreviewController.cpp
+++ b/rtc/AutoBalancer/PreviewController.cpp
@@ -5,7 +5,7 @@ using namespace hrp;
 using namespace rats;
 
 template <std::size_t dim>
-void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr)
+void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr, const hrp::Vector3& _qdata)
 {
   zmp_z = pr(2);
   Eigen::Matrix<double, 2, 1> tmpv;
@@ -13,9 +13,11 @@ void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr)
   tmpv(1,0) = pr(1);
   p.push_back(tmpv);
   pz.push_back(pr(2));
+  qdata.push_back(_qdata);
   if ( p.size() > 1 + delay ) {
     p.pop_front();
     pz.pop_front();
+    qdata.pop_front();
   }
   if ( is_doing() ) calc_x_k();
 }

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -5,232 +5,172 @@
 using namespace rats;
 #include <cstdio>
 
-void test0 ()
+class testGaitGenerator
 {
-  double dt = 0.005; /* [s] */
-  std::vector<hrp::Vector3> leg_pos; /* default footstep transformations are necessary */
-  leg_pos.push_back(hrp::Vector3(0,1e-3*-105,0)); /* rleg */
-  leg_pos.push_back(hrp::Vector3(0,1e-3* 105,0)); /* lleg */
-  gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+protected:
+    double dt; /* [s] */
+    std::vector<hrp::Vector3> leg_pos; /* default footstep transformations are necessary */
+    hrp::Vector3 cog;
+private:
+    void plot_walk_pattern (gait_generator& gg, const double dt)
+    {
+        /* make step and dump */
+        size_t i = 0;
+        std::string fname("/tmp/plot.dat");
+        FILE* fp = fopen(fname.c_str(), "w");
+        while ( gg.proc_one_tick() ) {
+            //std::cerr << gg.lcg.gp_count << std::endl;
+            // if ( gg.lcg.gp_index == 4 && gg.lcg.gp_count == 100) {
+            //   //std::cerr << gg.lcg.gp_index << std::endl;
+            //   gg.update_refzmp_queue(coordinates(hrp::Vector3(150, 105, 0)), coordinates(hrp::Vector3(150, -105, 0)));
+            // }
+            fprintf(fp, "%f ", i * dt);
+            for (size_t ii = 0; ii < 3; ii++) {
+                double cogpos;
+                if (ii==2) {
+                    coordinates tmpc;
+                    gg.get_swing_support_mid_coords(tmpc);
+                    cogpos = tmpc.pos(2)+gg.get_cog()(2);
+                } else {
+                    cogpos = gg.get_cog()(ii);
+                }
+                fprintf(fp, "%f %f %f %f ",
+                        gg.get_refzmp()(ii),
+                        cogpos,
+                        gg.get_support_leg_coords().pos(ii),
+                        gg.get_swing_leg_coords().pos(ii));
+            }
+            fprintf(fp, "\n");
+            i++;
+        }
+        fclose(fp);
 
-  /* this is c++ version example of test3, test6, test7 and test8 in euslib/demo/nozawa/motion/test-gait-generator.l */
+        /* plot */
+        FILE* gp = popen("gnuplot", "w");
+        fprintf(gp, "set multiplot layout 3, 1\n");
+        std::string titles[3] = {"X", "Y", "Z"};
+        for (size_t ii = 0; ii < 3; ii++) {
+            fprintf(gp, "set title \"%s\"\n", titles[ii].c_str());
+            fprintf(gp, "set xlabel \"Time [s]\"\n");
+            fprintf(gp, "set ylabel \"[m]\"\n");
+            //fprintf(gp, "plot \"%s\" using 1:%d with lines title \"refzmp\", \"%s\" using 1:%d with lines title \"cog\", \"%s\" using 1:%d with lines title \"support\", \"%s\" using 1:%d with lines title \"swing\"\n",
+            //        fname.c_str(), ( ii * 4 + 2), fname.c_str(), ( ii * 4 + 3), fname.c_str(), ( ii * 4 + 4), fname.c_str(), ( ii * 4 + 5));
+            fprintf(gp, "plot \"%s\" using 1:%d with lines title \"refzmp\", \"%s\" using 1:%d with lines title \"cog\"\n",
+                    fname.c_str(), ( ii * 4 + 2), fname.c_str(), ( ii * 4 + 3));
+        }
+        fflush(gp);
+        double tmp;
+        std::cin >> tmp;
+        pclose(gp);
+    };
 
-  // std::cerr << "test3" << std::endl;
-  // gg.go_pos_param_2_footstep_list(300, 100, 20, coordinates());
-  // gg.print_footstep_list();
-
-  // std::cerr << "test6" << std::endl;
-  // gg.go_pos_param_2_footstep_list(500, 0, 0, coordinates());
-  // gg.print_footstep_list();
-
-  // std::cerr << "test7" << std::endl;
-  // gg.go_pos_param_2_footstep_list(0, 500, 0, coordinates());
-  // gg.print_footstep_list();
-
-  // std::cerr << "test8" << std::endl;
-  // gg.go_pos_param_2_footstep_list(0, 0, 90, coordinates());
-  // gg.print_footstep_list();
-
-  // {
-  //   /* this is c++ version example of test5 in euslib/demo/nozawa/motion/test-gait-generator.l */
-  //   /* default parameter */
-  //   std::vector<hrp::Vector3> default_zmp_offsets;
-  //   default_zmp_offsets.push_back(hrp::Vector3(0));
-  //   default_zmp_offsets.push_back(hrp::Vector3(0));
-
-  //   /* initialize gait_generator instance */
-  //   robot_ptr rb(getenv("ROBOT"));
-  //   rb->reset_pose();
-  //   rb->fix_leg_to_coords(":both", coordinates());
-  //   hrp::Vector3 cog(rb->calc_com());
-  //   gg.set_default_zmp_offsets(default_zmp_offsets);
-  //   gg.set_default_step_time(1.5);
-  //   coordinates initial_support_leg_coords(hrp::Vector3(0, 105, 0)), initial_swing_leg_dst_coords(hrp::Vector3(0, -105, 0));
-  //   /* initialize sample footstep_list */
-  //   gg.clear_footstep_node_list();
-  //   gg.append_footstep_node("rleg", initial_swing_leg_dst_coords);
-  //   gg.append_footstep_node("lleg", initial_support_leg_coords);
-  //   gg.append_footstep_node("rleg", coordinates(hrp::Vector3(50, -105, 0)));
-  //   gg.append_footstep_node("lleg", coordinates(hrp::Vector3(100, 105, 0)));
-  //   gg.append_footstep_node("rleg", coordinates(hrp::Vector3(150, -105, 0)));
-  //   gg.append_footstep_node("lleg", coordinates(hrp::Vector3(200, 105, 0)));
-  //   gg.append_footstep_node("rleg", coordinates(hrp::Vector3(250, -105, 0)));
-  //   gg.append_footstep_node("lleg", coordinates(hrp::Vector3(250, 105, 0)));
-  //   gg.initialize_gait_parameter(cog, initial_support_leg_coords, initial_swing_leg_dst_coords);
-  //   while ( !gg.proc_one_tick() );
-  //   gg.print_footstep_list();
-
-  //   /* make step and dump */
-  //   size_t i = 0;
-  //   std::string fname("/tmp/plot.dat");
-  //   FILE* fp = fopen(fname.c_str(), "w");
-  //   while ( gg.proc_one_tick() ) {
-  //     fprintf(fp, "%f ", i * dt);
-  //     for (size_t ii = 0; ii < 3; ii++) {
-  //       fprintf(fp, "%f %f %f %f ",
-  //               gg.get_refzmp()(ii),
-  //               gg.get_cog()(ii),
-  //               gg.get_support_leg_coords().pos(ii),
-  //               gg.get_swing_leg_coords().pos(ii));
-  //     }
-  //     fprintf(fp, "\n");
-  //     i++;
-  //   }
-  //   fclose(fp);
-
-  //   /* plot */
-  //   FILE* gp[3];
-  //   std::string titles[3] = {"X", "Y", "Z"};
-  //   for (size_t ii = 0; ii < 3; ii++) {
-  //     gp[ii] = popen("gnuplot", "w");
-  //     fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
-  //     fprintf(gp[ii], "plot \"%s\" using 1:%d with lines title \"refzmp\"\n", fname.c_str(), ( ii * 4 + 2));
-  //     fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"cog\"\n", fname.c_str(), ( ii * 4 + 3));
-  //     fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"support\"\n", fname.c_str(), ( ii * 4 + 4));
-  //     fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"swing\"\n", fname.c_str(), ( ii * 4 + 5));
-  //     fflush(gp[ii]);
-  //   }
-  //   double tmp;
-  //   std::cin >> tmp;
-  //   for (size_t j = 0; j < 3; j++) pclose(gp[j]);
-  // }
-
-  {
-    /* this is update sample */
-    /* default parameter */
-    std::vector<hrp::Vector3> default_zmp_offsets;
-    default_zmp_offsets.push_back(hrp::Vector3::Zero());
-    default_zmp_offsets.push_back(hrp::Vector3::Zero());
-
-    /* initialize gait_generator instance */
-    //robot_ptr rb(getenv("ROBOT"));
-    //rb->reset_pose();
-    //rb->fix_leg_to_coords(":both", coordinates());
-    //hrp::Vector3 cog(rb->calc_com());
-    hrp::Vector3 cog(6.785, 1.54359, 806.831);// param for HRP2JSK reset-pose cog
-    cog *= 1e-3;
-    gg.set_default_zmp_offsets(default_zmp_offsets);
-    gg.set_default_step_time(1.0);
-    coordinates initial_support_leg_coords(hrp::Vector3(0, 1e-3*105, 0)), initial_swing_leg_dst_coords(hrp::Vector3(0, 1e-3*-105, 0));
-    /* initialize sample footstep_list */
-    gg.clear_footstep_node_list();
-    gg.append_footstep_node("rleg", initial_swing_leg_dst_coords);
-    gg.append_footstep_node("lleg", initial_support_leg_coords);
-    gg.append_footstep_node("rleg", coordinates(hrp::Vector3(50*1e-3, -105*1e-3, 0)));
-    gg.append_footstep_node("lleg", coordinates(hrp::Vector3(100*1e-3, 105*1e-3, 0)));
-    gg.append_footstep_node("rleg", coordinates(hrp::Vector3(150*1e-3, -105*1e-3, 0)));
-    gg.append_footstep_node("lleg", coordinates(hrp::Vector3(200*1e-3, 105*1e-3, 0)));
-    gg.append_footstep_node("rleg", coordinates(hrp::Vector3(250*1e-3, -105*1e-3, 0)));
-    gg.append_footstep_node("lleg", coordinates(hrp::Vector3(250*1e-3, 105*1e-3, 0)));
-    gg.initialize_gait_parameter(cog, initial_support_leg_coords, initial_swing_leg_dst_coords);
-    while ( !gg.proc_one_tick() );
-    gg.print_footstep_list();
-
-    /* make step and dump */
-    size_t i = 0;
-    std::string fname("/tmp/plot.dat");
-    FILE* fp = fopen(fname.c_str(), "w");
-    while ( gg.proc_one_tick() ) {
-      //std::cerr << gg.lcg.gp_count << std::endl;
-      // if ( gg.lcg.gp_index == 4 && gg.lcg.gp_count == 100) {
-      //   //std::cerr << gg.lcg.gp_index << std::endl;
-      //   gg.update_refzmp_queue(coordinates(hrp::Vector3(150, 105, 0)), coordinates(hrp::Vector3(150, -105, 0)));
-      // }
-      fprintf(fp, "%f ", i * dt);
-      for (size_t ii = 0; ii < 3; ii++) {
-        fprintf(fp, "%f %f %f %f ",
-                gg.get_refzmp()(ii),
-                gg.get_cog()(ii),
-                gg.get_support_leg_coords().pos(ii),
-                gg.get_swing_leg_coords().pos(ii));
-      }
-      fprintf(fp, "\n");
-      i++;
+    void gen_and_plot_walk_pattern(gait_generator& gg)
+    {
+        coordinates initial_support_leg_coords(gg.get_footstep_front_leg()=="rleg"?leg_pos[1]:leg_pos[0]);
+        coordinates initial_swing_leg_dst_coords(gg.get_footstep_front_leg()!="rleg"?leg_pos[1]:leg_pos[0]);
+        gg.initialize_gait_parameter(cog, initial_support_leg_coords, initial_swing_leg_dst_coords);
+        while ( !gg.proc_one_tick() );
+        gg.print_footstep_list();
+        plot_walk_pattern(gg, dt);
     }
-    fclose(fp);
 
-    /* plot */
-    FILE* gp[3];
-    std::string titles[3] = {"X", "Y", "Z"};
-    for (size_t ii = 0; ii < 3; ii++) {
-      gp[ii] = popen("gnuplot", "w");
-      fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
-      fprintf(gp[ii], "plot \"%s\" using 1:%d with lines title \"refzmp\"\n", fname.c_str(), ( ii * 4 + 2));
-      fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"cog\"\n", fname.c_str(), ( ii * 4 + 3));
-      // fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"support\"\n", fname.c_str(), ( ii * 4 + 4));
-      // fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"swing\"\n", fname.c_str(), ( ii * 4 + 5));
-      fflush(gp[ii]);
-    }
-    double tmp;
-    std::cin >> tmp;
-    for (size_t j = 0; j < 3; j++) pclose(gp[j]);
-  }
+public:
+    testGaitGenerator() {};
+    virtual ~testGaitGenerator() {};
+
+    void test0 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])));
+        gg.append_footstep_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])));
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])));
+        gg.append_footstep_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])));
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])));
+        gen_and_plot_walk_pattern(gg);
+    };
+
+    void test1 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.go_pos_param_2_footstep_list(200*1e-3, 100*1e-3, 20, coordinates());
+        gen_and_plot_walk_pattern(gg);
+    };
+
+    void test2 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.go_pos_param_2_footstep_list(300*1e-3, 0, 0, coordinates());
+        gen_and_plot_walk_pattern(gg);
+    };
+
+    void test3 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.go_pos_param_2_footstep_list(0, 150*1e-3, 0, coordinates());
+        gen_and_plot_walk_pattern(gg);
+    };
+
+    void test4 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.go_pos_param_2_footstep_list(0, 0, 30, coordinates());
+        gen_and_plot_walk_pattern(gg);
+    };
+
+    void test5 ()
+    {
+        gait_generator gg(dt, leg_pos, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+        /* initialize sample footstep_list */
+        gg.clear_footstep_node_list();
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])));
+        gg.append_footstep_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])));
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 100*1e-3)+leg_pos[0])));
+        gg.append_footstep_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 200*1e-3)+leg_pos[1])));
+        gg.append_footstep_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[0])));
+        gg.append_footstep_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[1])));
+        gen_and_plot_walk_pattern(gg);
+    };
 };
 
-// // go_pos->footstep_list
-// void test1 (const double xx, const double yy, const double th, const std::string start_leg = "",
-//             const double stride_x = 150, const double stride_y = 50, const double stride_th = 10)
-// {
-//   robot_ptr rb(getenv("ROBOT"));
-//   rb->reset_pose();
-//   rb->fix_leg_to_coords(":both", coordinates());
-//   double dt = 0.005; /* [s] */
-//   std::vector<hrp::Vector3> leg_pos; /* default footstep transformations are necessary */
-//   leg_pos.push_back(rb->get_end_coords("rleg").pos); /* rleg */
-//   leg_pos.push_back(rb->get_end_coords("lleg").pos); /* lleg */
-//   gait_generator gg(dt, leg_pos, stride_x, stride_y, stride_th); // for HRP2
-//   if ( start_leg == "" ) {
-//     gg.go_pos_param_2_footstep_list(xx, yy, th, coordinates());
-//   } else {
-//     gg.go_pos_param_2_footstep_list(xx, yy, th, coordinates(), (start_leg == "rleg" ? gait_generator::WC_RLEG : gait_generator::WC_LLEG));
-//   }
-//   gg.print_footstep_list();
-// }
-
-// void test2 ()
-// {
-//   robot_ptr rb(getenv("ROBOT"));
-//   rb->reset_pose();
-//   rb->fix_leg_to_coords(":both", coordinates());
-//   double dt = 0.005; /* [s] */
-//   std::vector<hrp::Vector3> leg_pos; /* default footstep transformations are necessary */
-//   leg_pos.push_back(rb->get_end_coords("rleg").pos); /* rleg */
-//   leg_pos.push_back(rb->get_end_coords("lleg").pos); /* lleg */
-//   gait_generator gg(dt, leg_pos, 150, 50, 10); // for HRP2
-//   coordinates spc, swc;
-//   std::string leg = "rleg";
-//   double goal_x = 0.15, goal_y = 0, goal_z = 0, goal_theta = 0;
-//   rb->get_end_coords(spc, (leg == "rleg") ? "lleg" : "rleg");
-//   rb->get_end_coords(swc, (leg == "rleg") ? "rleg" : "lleg");
-//   gg.clear_footstep_node_list();
-//   gg.go_single_step_param_2_footstep_list(goal_x * 1000.0, goal_y * 1000.0, goal_z * 1000.0, goal_theta,
-//                                           leg, spc);
-//   std::vector<hrp::Vector3> default_zmp_offsets;
-//   default_zmp_offsets.push_back(hrp::Vector3(0));
-//   default_zmp_offsets.push_back(hrp::Vector3(0));
-//   gg.set_default_zmp_offsets(default_zmp_offsets);
-//   gg.initialize_gait_parameter(rb->calc_com(), swc, spc);
-//   std::vector<hrp::Vector3> cog_v, spc_v, swc_v;
-//   while ( !gg.proc_one_tick() );
-//   while ( gg.proc_one_tick() ) {
-//     std::cerr << "(list :cog ";
-//     print_vector(std::cerr, gg.get_cog(), false);
-//     std::cerr << " " << gg.get_support_leg() << " ";
-//     gg.get_support_leg_coords().print_eus_coordinates(std::cerr, false);
-//     std::cerr << " " << gg.get_swing_leg() << " ";
-//     gg.get_swing_leg_coords().print_eus_coordinates(std::cerr, false);
-//     std::cerr << " )" << std::endl;
-//   }
-// }
+class testGaitGeneratorHRP2JSK : public testGaitGenerator
+{
+ public:
+    testGaitGeneratorHRP2JSK ()
+        {
+            dt = 0.004;
+            cog = 1e-3*hrp::Vector3(6.785, 1.54359, 806.831);
+            leg_pos.push_back(hrp::Vector3(0,1e-3*-105,0)); /* rleg */
+            leg_pos.push_back(hrp::Vector3(0,1e-3* 105,0)); /* lleg */
+        };
+};
 
 int main(int argc, char* argv[])
 {
-  if (argc == 1) {
-    test0();
-  }//  else {
-  //   if (argc == 4) test1(atof(argv[1]), atof(argv[2]), atof(argv[3]));
-  //   else test1(atof(argv[1]), atof(argv[2]), atof(argv[3]), std::string(argv[4]));
-  // }
+  if (argc == 2) {
+      if (std::string(argv[1]) == "--test0") {
+          testGaitGeneratorHRP2JSK().test0();
+      } else if (std::string(argv[1]) == "--test1") {
+          testGaitGeneratorHRP2JSK().test1();
+      } else if (std::string(argv[1]) == "--test2") {
+          testGaitGeneratorHRP2JSK().test2();
+      } else if (std::string(argv[1]) == "--test3") {
+          testGaitGeneratorHRP2JSK().test3();
+      } else if (std::string(argv[1]) == "--test4") {
+          testGaitGeneratorHRP2JSK().test4();
+      } else if (std::string(argv[1]) == "--test5") {
+          testGaitGeneratorHRP2JSK().test5();
+      }
+  }
   return 0;
 }
 

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -34,12 +34,14 @@ private:
                 } else {
                     cogpos = gg.get_cog()(ii);
                 }
-                fprintf(fp, "%f %f %f %f %f ",
+                fprintf(fp, "%f %f %f %f %f %f ",
                         gg.get_refzmp()(ii),
                         cogpos,
                         gg.get_support_leg_coords().pos(ii),
                         gg.get_swing_leg_coords().pos(ii),
-                        gg.get_swing_foot_zmp_offset()(ii));
+                        gg.get_support_foot_zmp_offset()(ii),
+                        gg.get_swing_foot_zmp_offset()(ii)
+                        );
             }
             fprintf(fp, "\n");
             i++;
@@ -50,7 +52,7 @@ private:
         FILE* gp = popen("gnuplot", "w");
         fprintf(gp, "set multiplot layout 3, 1\n");
         std::string titles[3] = {"X", "Y", "Z"};
-        int data_size = 5;
+        int data_size = 6;
         for (size_t ii = 0; ii < 3; ii++) {
             fprintf(gp, "set title \"%s\"\n", titles[ii].c_str());
             fprintf(gp, "set xlabel \"Time [s]\"\n");
@@ -59,8 +61,8 @@ private:
                     fname.c_str(), ( ii * data_size + 2), fname.c_str(), ( ii * data_size + 3));
             // fprintf(gp, ",\"%s\" using 1:%d with lines title \"support\", \"%s\" using 1:%d with lines title \"swing\"",
             //         fname.c_str(), ( ii * data_size + 4), fname.c_str(), ( ii * data_size + 5));
-            fprintf(gp, ",\"%s\" using 1:%d with lines title \"swing zmpoff\"",
-                    fname.c_str(), ( ii * data_size + 6));
+            // fprintf(gp, ",\"%s\" using 1:%d with lines title \"support zmpoff\", \"%s\" using 1:%d with lines title \"swing zmpoff\" ",
+            //         fname.c_str(), ( ii * data_size + 6), fname.c_str(), ( ii * data_size + 7));
             fprintf(gp, "\n");
         }
         fflush(gp);

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -49,14 +49,16 @@ private:
         FILE* gp = popen("gnuplot", "w");
         fprintf(gp, "set multiplot layout 3, 1\n");
         std::string titles[3] = {"X", "Y", "Z"};
+        int data_size = 4;
         for (size_t ii = 0; ii < 3; ii++) {
             fprintf(gp, "set title \"%s\"\n", titles[ii].c_str());
             fprintf(gp, "set xlabel \"Time [s]\"\n");
             fprintf(gp, "set ylabel \"[m]\"\n");
-            //fprintf(gp, "plot \"%s\" using 1:%d with lines title \"refzmp\", \"%s\" using 1:%d with lines title \"cog\", \"%s\" using 1:%d with lines title \"support\", \"%s\" using 1:%d with lines title \"swing\"\n",
-            //        fname.c_str(), ( ii * 4 + 2), fname.c_str(), ( ii * 4 + 3), fname.c_str(), ( ii * 4 + 4), fname.c_str(), ( ii * 4 + 5));
-            fprintf(gp, "plot \"%s\" using 1:%d with lines title \"refzmp\", \"%s\" using 1:%d with lines title \"cog\"\n",
-                    fname.c_str(), ( ii * 4 + 2), fname.c_str(), ( ii * 4 + 3));
+            fprintf(gp, "plot \"%s\" using 1:%d with lines title \"refzmp\", \"%s\" using 1:%d with lines title \"cog\"",
+                    fname.c_str(), ( ii * data_size + 2), fname.c_str(), ( ii * data_size + 3));
+            // fprintf(gp, ",\"%s\" using 1:%d with lines title \"support\", \"%s\" using 1:%d with lines title \"swing\"\n",
+            //         fname.c_str(), ( ii * data_size + 4), fname.c_str(), ( ii * data_size + 5));
+            fprintf(gp, "\n");
         }
         fflush(gp);
         double tmp;

--- a/rtc/AutoBalancer/testPreviewController.cpp
+++ b/rtc/AutoBalancer/testPreviewController.cpp
@@ -45,8 +45,8 @@ int main()
   bool r = true;
   size_t index = 0;
   while (r) {
-    hrp::Vector3 p, x;
-    r = df.update(p, x, ref_zmp_list.front(), !ref_zmp_list.empty());
+    hrp::Vector3 p, x, qdata;
+    r = df.update(p, x, qdata, ref_zmp_list.front(), qdata, !ref_zmp_list.empty());
     if (r) {
       index++;
       df.get_cart_zmp(cart_zmp);

--- a/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
+++ b/rtc/KalmanFilter/testKalmanFilterEstimation.cpp
@@ -61,13 +61,13 @@ int main(int argc, char *argv[])
   // Test kalman filter
   RPYKalmanFilter rpy_kf;
   rpy_kf.setParam(dt, Q_angle, Q_rate, R_angle);
-  hrp::Vector3 rate, acc, rpy, rpyRaw, rpyAct;
+  hrp::Vector3 rate, acc, rpy, rpyRaw, baseRpyCurrent, rpyAct;
   double time, time2=0.0;
   while(!ratef.eof()){
     posef >> time >> time >> time >> time >> rpyAct[0] >> rpyAct[1] >> rpyAct[2]; // Neglect translation in .pose file
     ratef >> time >> rate[0] >> rate[1] >> rate[2];
     accf >> time >> acc[0] >> acc[1] >> acc[2];
-    rpy_kf.main_one(rpy, rpyRaw, acc, rate, 0.0);
+    rpy_kf.main_one(rpy, rpyRaw, baseRpyCurrent, acc, rate, 0.0, hrp::Matrix33::Identity());
     // rad->deg
     rpy*=180/3.14159;
     rpyAct*=180/3.14159;

--- a/rtc/OccupancyGridMap3D/OccupancyGridMap3D.cpp
+++ b/rtc/OccupancyGridMap3D/OccupancyGridMap3D.cpp
@@ -159,6 +159,7 @@ RTC::ReturnCode_t OccupancyGridMap3D::onActivated(RTC::UniqueId ec_id)
 {
   std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
 
+  Guard guard(m_mutex);
   if (m_knownMapPath != ""){
       m_knownMap = new OcTree(m_cwd+m_knownMapPath);
       m_updateOut.write();
@@ -198,6 +199,7 @@ RTC::ReturnCode_t OccupancyGridMap3D::onActivated(RTC::UniqueId ec_id)
 RTC::ReturnCode_t OccupancyGridMap3D::onDeactivated(RTC::UniqueId ec_id)
 {
   std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  Guard guard(m_mutex);
   delete m_map;
   if (m_knownMap) delete m_knownMap;
   return RTC::RTC_OK;

--- a/rtc/RobotHardware/RobotHardwareService_impl.cpp
+++ b/rtc/RobotHardware/RobotHardwareService_impl.cpp
@@ -81,7 +81,11 @@ void RobotHardwareService_impl::getStatus2(OpenHRP::RobotHardwareService::RobotS
 
     GetStatus
 
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     m_robot->readPowerStatus(rs->voltage, rs->current, rs->battery);
+#else
+    m_robot->readPowerStatus(rs->voltage, rs->current);
+#endif
 }
 
 CORBA::Boolean RobotHardwareService_impl::power(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus ss)

--- a/rtc/RobotHardware/RobotHardwareService_impl.cpp
+++ b/rtc/RobotHardware/RobotHardwareService_impl.cpp
@@ -13,60 +13,73 @@ RobotHardwareService_impl::~RobotHardwareService_impl()
 {
 }
 
+#define GetStatus                                                       \
+                                                                        \
+    rs->angle.length(m_robot->numJoints());                             \
+    m_robot->readJointAngles(rs->angle.get_buffer());                   \
+                                                                        \
+    rs->command.length(m_robot->numJoints());                           \
+    m_robot->readJointCommands(rs->command.get_buffer());               \
+                                                                        \
+    rs->torque.length(m_robot->numJoints());                            \
+    if (!m_robot->readJointTorques(rs->torque.get_buffer())){           \
+        for (unsigned int i=0; i<rs->torque.length(); i++){             \
+            rs->torque[i] = 0.0;                                        \
+        }                                                               \
+    }                                                                   \
+                                                                        \
+    rs->servoState.length(m_robot->numJoints());                        \
+    int v, status;                                                      \
+    for(unsigned int i=0; i < rs->servoState.length(); ++i){            \
+        size_t len = m_robot->lengthOfExtraServoState(i)+1;             \
+        rs->servoState[i].length(len);                                  \
+	status = 0;                                                     \
+        v = m_robot->readCalibState(i);                                 \
+        status |= v<< OpenHRP::RobotHardwareService::CALIB_STATE_SHIFT; \
+        v = m_robot->readPowerState(i);                                 \
+        status |= v<< OpenHRP::RobotHardwareService::POWER_STATE_SHIFT; \
+        v = m_robot->readServoState(i);                                 \
+        status |= v<< OpenHRP::RobotHardwareService::SERVO_STATE_SHIFT; \
+        v = m_robot->readServoAlarm(i);                                 \
+        status |= v<< OpenHRP::RobotHardwareService::SERVO_ALARM_SHIFT; \
+        v = m_robot->readDriverTemperature(i);                          \
+        status |= v<< OpenHRP::RobotHardwareService::DRIVER_TEMP_SHIFT; \
+        rs->servoState[i][0] = status;                                  \
+        m_robot->readExtraServoState(i, (int *)(rs->servoState[i].get_buffer()+1)); \
+    }                                                                   \
+                                                                        \
+    rs->rateGyro.length(m_robot->numSensors(Sensor::RATE_GYRO));        \
+    for (unsigned int i=0; i<rs->rateGyro.length(); i++){               \
+        rs->rateGyro[i].length(3);                                      \
+        m_robot->readGyroSensor(i, rs->rateGyro[i].get_buffer());       \
+    }                                                                   \
+                                                                        \
+    rs->accel.length(m_robot->numSensors(Sensor::ACCELERATION));        \
+    for (unsigned int i=0; i<rs->accel.length(); i++){                  \
+        rs->accel[i].length(3);                                         \
+        m_robot->readAccelerometer(i, rs->accel[i].get_buffer());       \
+    }                                                                   \
+                                                                        \
+    rs->force.length(m_robot->numSensors(Sensor::FORCE));               \
+    for (unsigned int i=0; i<rs->force.length(); i++){                  \
+        rs->force[i].length(6);                                         \
+        m_robot->readForceSensor(i, rs->force[i].get_buffer());         \
+    }
+
 void RobotHardwareService_impl::getStatus(OpenHRP::RobotHardwareService::RobotState_out rs)
 {
     rs = new OpenHRP::RobotHardwareService::RobotState();
 
-    rs->angle.length(m_robot->numJoints());
-    m_robot->readJointAngles(rs->angle.get_buffer());
+    GetStatus
 
-    rs->command.length(m_robot->numJoints());
-    m_robot->readJointCommands(rs->command.get_buffer());
+    m_robot->readPowerStatus(rs->voltage, rs->current);
+}
 
-    rs->torque.length(m_robot->numJoints());
-    if (!m_robot->readJointTorques(rs->torque.get_buffer())){
-        for (unsigned int i=0; i<rs->torque.length(); i++){
-            rs->torque[i] = 0.0;
-        }
-    }
+void RobotHardwareService_impl::getStatus2(OpenHRP::RobotHardwareService::RobotState2_out rs)
+{
+    rs = new OpenHRP::RobotHardwareService::RobotState2();
 
-    rs->servoState.length(m_robot->numJoints());
-    int v, status;
-    for(unsigned int i=0; i < rs->servoState.length(); ++i){
-        size_t len = m_robot->lengthOfExtraServoState(i)+1;
-        rs->servoState[i].length(len);
-	status = 0;
-        v = m_robot->readCalibState(i);
-        status |= v<< OpenHRP::RobotHardwareService::CALIB_STATE_SHIFT;
-        v = m_robot->readPowerState(i);
-        status |= v<< OpenHRP::RobotHardwareService::POWER_STATE_SHIFT;
-        v = m_robot->readServoState(i);
-        status |= v<< OpenHRP::RobotHardwareService::SERVO_STATE_SHIFT;
-        v = m_robot->readServoAlarm(i);
-        status |= v<< OpenHRP::RobotHardwareService::SERVO_ALARM_SHIFT;
-        v = m_robot->readDriverTemperature(i);
-        status |= v<< OpenHRP::RobotHardwareService::DRIVER_TEMP_SHIFT;
-        rs->servoState[i][0] = status;
-        m_robot->readExtraServoState(i, (int *)(rs->servoState[i].get_buffer()+1));
-    }
-
-    rs->rateGyro.length(m_robot->numSensors(Sensor::RATE_GYRO));
-    for (unsigned int i=0; i<rs->rateGyro.length(); i++){
-        rs->rateGyro[i].length(3);
-        m_robot->readGyroSensor(i, rs->rateGyro[i].get_buffer());
-    }
-
-    rs->accel.length(m_robot->numSensors(Sensor::ACCELERATION));
-    for (unsigned int i=0; i<rs->accel.length(); i++){
-        rs->accel[i].length(3);
-        m_robot->readAccelerometer(i, rs->accel[i].get_buffer());
-    }
-
-    rs->force.length(m_robot->numSensors(Sensor::FORCE));
-    for (unsigned int i=0; i<rs->force.length(); i++){
-        rs->force[i].length(6);
-        m_robot->readForceSensor(i, rs->force[i].get_buffer());
-    }
+    GetStatus
 
     m_robot->readPowerStatus(rs->voltage, rs->current, rs->battery);
 }

--- a/rtc/RobotHardware/RobotHardwareService_impl.cpp
+++ b/rtc/RobotHardware/RobotHardwareService_impl.cpp
@@ -64,27 +64,31 @@ RobotHardwareService_impl::~RobotHardwareService_impl()
     for (unsigned int i=0; i<rs->force.length(); i++){                  \
         rs->force[i].length(6);                                         \
         m_robot->readForceSensor(i, rs->force[i].get_buffer());         \
-    }
+    }									\
+									\
+    m_robot->readPowerStatus(rs->voltage, rs->current);
 
 void RobotHardwareService_impl::getStatus(OpenHRP::RobotHardwareService::RobotState_out rs)
 {
     rs = new OpenHRP::RobotHardwareService::RobotState();
 
-    GetStatus
-
-    m_robot->readPowerStatus(rs->voltage, rs->current);
+    GetStatus;
 }
 
 void RobotHardwareService_impl::getStatus2(OpenHRP::RobotHardwareService::RobotState2_out rs)
 {
     rs = new OpenHRP::RobotHardwareService::RobotState2();
 
-    GetStatus
+    GetStatus;
 
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
-    m_robot->readPowerStatus(rs->voltage, rs->current, rs->battery);
-#else
-    m_robot->readPowerStatus(rs->voltage, rs->current);
+    rs->batteries.length(m_robot->numBatteries());
+    for(unsigned int i=0; i<rs->batteries.length(); i++){
+        m_robot->readBatteryState(i, 
+                                  rs->batteries[i].voltage,
+                                  rs->batteries[i].current,
+                                  rs->batteries[i].soc);
+    }
 #endif
 }
 

--- a/rtc/RobotHardware/RobotHardwareService_impl.h
+++ b/rtc/RobotHardware/RobotHardwareService_impl.h
@@ -17,6 +17,7 @@ public:
     virtual ~RobotHardwareService_impl();
 
     void getStatus(OpenHRP::RobotHardwareService::RobotState_out rs);
+    void getStatus2(OpenHRP::RobotHardwareService::RobotState2_out rs);
 
     CORBA::Boolean power(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus ss);
     CORBA::Boolean servo(const char* jname, OpenHRP::RobotHardwareService::SwitchStatus ss);

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -464,14 +464,6 @@ void robot::readPowerStatus(double &o_voltage, double &o_current)
     read_power(&o_voltage, &o_current);
 }
 
-#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
-void robot::readPowerStatus(double &o_voltage, double &o_current, double &o_battery)
-{
-    read_power(&o_voltage, &o_current);
-    read_battery(&o_battery);
-}
-#endif
-
 int robot::readCalibState(int i)
 {
     int v=0;
@@ -734,3 +726,13 @@ bool robot::readDigitalOutput(char *o_dout)
     return read_digital_output(o_dout);
 }
 
+void robot::readBatteryState(unsigned int i_rank, double &voltage, 
+                             double &current, double &soc)
+{
+    read_battery(i_rank, &voltage, &current, &soc);
+}
+
+int robot::numBatteries()
+{
+    return number_of_batteries();
+}

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -464,11 +464,13 @@ void robot::readPowerStatus(double &o_voltage, double &o_current)
     read_power(&o_voltage, &o_current);
 }
 
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
 void robot::readPowerStatus(double &o_voltage, double &o_current, double &o_battery)
 {
     read_power(&o_voltage, &o_current);
     read_battery(&o_battery);
 }
+#endif
 
 int robot::readCalibState(int i)
 {

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -459,9 +459,15 @@ void robot::writeVelocityCommands(const double *i_commands)
     write_command_velocities(i_commands);
 }
 
+void robot::readPowerStatus(double &o_voltage, double &o_current)
+{
+    read_power(&o_voltage, &o_current);
+}
+
 void robot::readPowerStatus(double &o_voltage, double &o_current, double &o_battery)
 {
-    read_power(&o_voltage, &o_current, &o_battery);
+    read_power(&o_voltage, &o_current);
+    read_battery(&o_battery);
 }
 
 int robot::readCalibState(int i)

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -130,7 +130,9 @@ public:
        \param o_battery remaining battery level ( new feature on 315.4.0)
      */
     void readPowerStatus(double &o_voltage, double &o_current);
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     void readPowerStatus(double &o_voltage, double &o_current, double &o_battery);
+#endif
 
     /**
        \brief read array of all joint angles[rad]

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -130,9 +130,16 @@ public:
        \param o_battery remaining battery level ( new feature on 315.4.0)
      */
     void readPowerStatus(double &o_voltage, double &o_current);
-#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
-    void readPowerStatus(double &o_voltage, double &o_current, double &o_battery);
-#endif
+
+    /**
+       \brief read battery state
+       \param i_rank rank of battery
+       \param o_voltage voltage
+       \param o_current current
+       \param o_soc state of charge
+     */
+    void readBatteryState(unsigned int i_rank, double &o_voltage,
+                          double &o_current, double &o_soc);
 
     /**
        \brief read array of all joint angles[rad]
@@ -261,6 +268,7 @@ public:
     int lengthDigitalOutput();
     bool readDigitalOutput(char *o_dout);
 
+    int numBatteries();
 private:
     /**
        \brief calibrate inertia sensor for one sampling period

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -127,8 +127,9 @@ public:
        \brief read voltage and current of the robot power source
        \param o_voltage voltage
        \param o_current current
-       \param o_battery remaining battery level
+       \param o_battery remaining battery level ( new feature on 315.4.0)
      */
+    void readPowerStatus(double &o_voltage, double &o_current);
     void readPowerStatus(double &o_voltage, double &o_current, double &o_battery);
 
     /**

--- a/sample/PA10/PA10.py
+++ b/sample/PA10/PA10.py
@@ -1,4 +1,5 @@
 import rtm
+from hrpsys import OpenHRP
 
 from rtm import *
 from OpenHRP import *

--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -60,5 +60,9 @@ install(FILES
   SampleRobot.DRCTestbed.xml
   DESTINATION share/hrpsys/samples/SampleRobot)
 
+file(GLOB python_scripts RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.py)
+install(PROGRAMS
+    ${python_scripts}
+  DESTINATION share/hrpsys/samples/SampleRobot)
 add_subdirectory(rtc)
 

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def testPoseList(pose_list, initial_pose):
     for pose in pose_list:

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -16,7 +16,7 @@ except:
 def init ():
     global hcf, init_pose, col_safe_pose, col_fail_pose
     hcf = HrpsysConfigurator()
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
     init_pose = [0]*29
     col_safe_pose = [0.0,-0.349066,0.0,0.820305,-0.471239,0.0,0.523599,0.0,0.0,-1.74533,0.15708,-0.113446,0.0,0.0,-0.349066,0.0,0.820305,-0.471239,0.0,0.523599,0.0,0.0,-1.74533,-0.15708,-0.113446,0.0,0.0,0.0,0.0]
     col_fail_pose = [0.0,-0.349066,0.0,0.820305,-0.471239,0.0,0.845363,0.03992,0.250074,-1.32816,0.167513,0.016204,0.0,0.0,-0.349066,0.0,0.820305,-0.471239,0.0,0.523599,0.0,0.0,-1.74533,-0.15708,-0.113446,0.0,0.0,0.0,0.0]

--- a/sample/SampleRobot/samplerobot_data_logger.py
+++ b/sample/SampleRobot/samplerobot_data_logger.py
@@ -18,7 +18,7 @@ def init ():
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
     hcf.log_use_own_ec = True ### use own ec for simulation
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo ():
     init()

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo():
     init()

--- a/sample/SampleRobot/samplerobot_kalman_filter.py
+++ b/sample/SampleRobot/samplerobot_kalman_filter.py
@@ -72,7 +72,7 @@ def test_kf_plot (test_motion_func, optional_out_file_name): # time [s]
     estimated_base_rpy_ret=[]
     for line in open("/tmp/test-kf-samplerobot-{0}.kf_baseRpyCurrent".format(optional_out_file_name), "r"):
         estimated_base_rpy_ret.append(line.split(" ")[0:-1])
-    #  Actual rpy from simualtro : time, posx, posy, posz, roll, pitch, yaw
+    #  Actual rpy from simualtor : time, posx, posy, posz, roll, pitch, yaw
     act_rpy_ret=[]
     for line in open("/tmp/test-kf-samplerobot-{0}.SampleRobot(Robot)0_WAIST".format(optional_out_file_name), "r"):
         act_rpy_ret.append(line.split(" ")[0:-1])

--- a/sample/SampleRobot/samplerobot_kalman_filter.py
+++ b/sample/SampleRobot/samplerobot_kalman_filter.py
@@ -21,6 +21,7 @@ def init ():
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
     hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.connectLoggerPort(hcf.kf, 'baseRpyCurrent')
     # initialize poses
     # pose1 = [0]*29
     # pose2 = [0]*29
@@ -67,6 +68,10 @@ def test_kf_plot (test_motion_func, optional_out_file_name): # time [s]
     estimated_rpy_ret=[]
     for line in open("/tmp/test-kf-samplerobot-{0}.kf_rpy".format(optional_out_file_name), "r"):
         estimated_rpy_ret.append(line.split(" ")[0:-1])
+    #  Estimated base link rpy from KF : time, roll, pitch, yaw
+    estimated_base_rpy_ret=[]
+    for line in open("/tmp/test-kf-samplerobot-{0}.kf_baseRpyCurrent".format(optional_out_file_name), "r"):
+        estimated_base_rpy_ret.append(line.split(" ")[0:-1])
     #  Actual rpy from simualtro : time, posx, posy, posz, roll, pitch, yaw
     act_rpy_ret=[]
     for line in open("/tmp/test-kf-samplerobot-{0}.SampleRobot(Robot)0_WAIST".format(optional_out_file_name), "r"):
@@ -76,15 +81,17 @@ def test_kf_plot (test_motion_func, optional_out_file_name): # time [s]
     tm_list=map (lambda x : int(x[0].split(".")[0])-initial_sec + float(x[0].split(".")[1]) * 1e-6, act_rpy_ret)
     # Plotting
     plt.clf()
+    color_list = ['r', 'g', 'b']
     for idx in range(3):
-        plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+3+idx]) / math.pi, act_rpy_ret))
-        plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+idx]) / math.pi, estimated_rpy_ret), ":")
+        plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+3+idx]) / math.pi, act_rpy_ret), color=color_list[idx])
+        plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+idx]) / math.pi, estimated_rpy_ret), ":", color=color_list[idx])
+        plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+idx]) / math.pi, estimated_base_rpy_ret), "--", color=color_list[idx])
     plt.xlabel("Time [s]")
     plt.ylabel("Angle [deg]")
     plt.title("KF actual-estimated data (motion time = {0})".format(optional_out_file_name))
-    plt.legend(("Actual roll", "Estimated roll",
-                "Actual pitch", "Estimated pitch",
-                "Actual yaw", "Estimated yaw"))
+    plt.legend(("Actual roll", "Estimated roll", "Estimated base roll",
+                "Actual pitch", "Estimated pitch", "Estimated base pitch",
+                "Actual yaw", "Estimated yaw", "Estimated base yaw"))
     plt.savefig("/tmp/test-kf-samplerobot-data-{0}.eps".format(optional_out_file_name))
 
 def test_bending_common (time, poses):

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo():
     import numpy

--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -16,7 +16,7 @@ except:
 def init ():
     global hcf
     hcf = HrpsysConfigurator()
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
     global reset_pose_doc, move_base_pose_doc, doc
     # doc for patterns.
     #  torque and wrenches are non-realistic values, just for testing.

--- a/sample/SampleRobot/samplerobot_soft_error_limiter.py
+++ b/sample/SampleRobot/samplerobot_soft_error_limiter.py
@@ -19,16 +19,16 @@ def init ():
     global hcf, initial_pose, limit_table_list, bodyinfo
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
     initial_pose = [-7.779e-005,  -0.378613,  -0.000209793,  0.832038,  -0.452564,  0.000244781,  0.31129,  -0.159481,  -0.115399,  -0.636277,  0,  0,  0,  -7.77902e-005,  -0.378613,  -0.000209794,  0.832038,  -0.452564,  0.000244781,  0.31129,  0.159481,  0.115399,  -0.636277,  0,  0,  0,  0,  0,  0]
     # load joint limit table from conf file
-    PROJECT_DIR=check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip()
-    f=open("{}/share/hrpsys/samples/SampleRobot/SampleRobot.500.el.conf".format(PROJECT_DIR))
+    HRPSYS_DIR=check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip()
+    f=open("{}/share/hrpsys/samples/SampleRobot/SampleRobot.500.el.conf".format(HRPSYS_DIR))
     limit_table_str=filter(lambda x : x.find("joint_limit_table") > -1 , f.readlines())[0]
     limit_table_list=limit_table_str.split(":")[1:]
     f.close()
     # set bodyinfo
-    bodyinfo=hcf.getBodyInfo("$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    bodyinfo=hcf.getBodyInfo("$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo ():
     init()

--- a/sample/SampleRobot/samplerobot_stabilizer.py
+++ b/sample/SampleRobot/samplerobot_stabilizer.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo():
     init()

--- a/sample/SampleRobot/samplerobot_terrain_walk.py
+++ b/sample/SampleRobot/samplerobot_terrain_walk.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def initPose():
     # set initial pose from base 90mm down pose of sample/controller/SampleController/etc/Sample.pos

--- a/sample/SampleRobot/samplerobot_virtual_force_sensor.py
+++ b/sample/SampleRobot/samplerobot_virtual_force_sensor.py
@@ -17,7 +17,7 @@ def init ():
     global hcf
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
-    hcf.init ("SampleRobot(Robot)0", "$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/model/sample1.wrl")
+    hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
 
 def demo ():
     init()

--- a/sample/SampleRobot/samplerobot_walk.py
+++ b/sample/SampleRobot/samplerobot_walk.py
@@ -32,7 +32,7 @@ def loadPattern(basename, tm=1.0):
 
 def demo():
     init()
-    loadPattern("$(OPENHRP_DIR)/share/OpenHRP-3.1/sample/controller/SampleController/etc/Sample")
+    loadPattern("$(PROJECT_DIR)/../controller/SampleController/etc/Sample")
 
 if __name__ == '__main__':
     demo()

--- a/sample/environments/CMakeLists.txt
+++ b/sample/environments/CMakeLists.txt
@@ -1,7 +1,3 @@
-install(FILES 
-  TerrainFloor.wrl
-  DRCTestbedTerrainUSBlock.wrl
-  DRCTestbedTerrainJPBlock.wrl
-  DRCTestbedStair.wrl
-  DESTINATION share/hrpsys/samples/environments)
+file(GLOB model_files RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *.wrl)
+install(FILES ${model_files} DESTINATION share/hrpsys/samples/environments)
 

--- a/test/test-colcheck.test
+++ b/test/test-colcheck.test
@@ -8,7 +8,11 @@
 
   <node name="start_omninames" pkg="hrpsys" type="start_omninames.sh" args="2809" />
 
-  <node name="colcheck" pkg="hrpsys" type="CollisionDetectorComp" output="screen"  cwd="node" />
+  <node name="modelloader" pkg="openhrp3" type="openhrp-model-loader" output="screen"/>
+
+  <node name="colcheck" pkg="hrpsys" type="CollisionDetectorComp"
+	args='-o "example.CollisionDetector.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf"'
+	output="screen"  cwd="node" />
 
   <test test-name="colcheck" pkg="hrpsys" type="test-colcheck.py" />
 </launch>

--- a/test/test-drc-testbed.test
+++ b/test/test-drc-testbed.test
@@ -1,0 +1,10 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot-drc-testbed.launch" >
+    <arg name="GUI" value="false" />.
+    <arg name="corbaport" value="2809" />
+  </include>
+
+  <test test-name="samplerobot_test" pkg="hrpsys" type="test-samplerobot.py" args="--host 127.0.0.1 --port 2809" retry="2" />
+  <test test-name="samplerobot_walk" pkg="hrpsys" type="samplerobot-walk.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2" />
+</launch>

--- a/test/test-robot-hardware.py
+++ b/test/test-robot-hardware.py
@@ -1,0 +1,39 @@
+#!/usr/bin/env python
+
+PKG = 'hrpsys'
+NAME = 'test_robothardware'
+
+from hrpsys import hrpsys_config
+import OpenHRP
+
+import socket
+import rtm
+
+import unittest
+import rostest
+import sys
+
+class TestHrpsysRobotHardware(unittest.TestCase):
+
+    def test_rh_service(self):
+        try:
+            rh = rh_svc = None
+            rtm.nshost = 'localhost'
+            rtm.nsport = 2809
+            rtm.initCORBA()
+            rh = rtm.findRTC("RobotHardware0")
+            rh_svc = rtm.narrow(rh.service("service0"), "RobotHardwareService")
+            print "RTC(RobotHardware0)={0}, {1}".format(rh,rh_svc)
+            self.assertTrue(rh and rh_svc)
+            rh.start()
+            self.assertTrue(rh.isActive())
+            self.assertTrue(rh_svc.getStatus())
+
+        except Exception as e:
+            print "{0}, RTC(RobotHardware0)={1}, {2}".format(str(e),rh,rh_svc)
+            self.fail()
+            pass
+
+#unittest.main()
+if __name__ == '__main__':
+    rostest.run(PKG, NAME, TestHrpsysRobotHardware, sys.argv)

--- a/test/test-robot-hardware.test
+++ b/test/test-robot-hardware.test
@@ -1,0 +1,16 @@
+<launch>
+  <!-- BEGIN:common setting -->
+  <env name="LANG" value="C" />
+  <env name="ORBgiopMaxMsgSize" value="2147483648" />
+  <!-- env name="PROJECT_DIR" value="$(find hrpsys)" / -->
+  <env name="ROS_HOME" value="$(find hrpsys)/share/hrpsys/samples/PA10/" />
+  <!-- END:common setting -->
+
+  <node name="start_omninames" pkg="hrpsys" type="start_omninames.sh" args="2809" />
+
+  <node name="modelloader" pkg="openhrp3" type="openhrp-model-loader" output="screen"/>
+  <node name="robot_hardware" pkg="hrpsys" type="RobotHardwareComp"
+	args='-o "example.RobotHardware.config_file:$(find hrpsys)/share/hrpsys/samples/PA10/PA10.conf" -o "naming.formats:%n.rtc"'
+	output="screen"  cwd="node" />
+  <test test-name="robot_hardware_py" pkg="hrpsys" type="test-robot-hardware.py" />
+</launch>


### PR DESCRIPTION

Found that waitInterpolationOfGroup freezes when accessed when it is waiting on another group. Added a lock to the python interface to only wait on one group at a time.
