### PR TITLE
[hrpsys_config.py] add MaxLength option for setupLogger

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -732,13 +732,16 @@ class HrpsysConfigurator:
             connectPorts(artc.port(sen_name), self.log.port(log_name))
 
     # public method to configure default logger data ports
-    def setupLogger(self):
+    def setupLogger(self, maxLength=4000):
         '''!@brief
         Setup logging function.
+        @param maxLength : max length of data from DataLogger.h #define DEFAULT_MAX_LOG_LENGTH (200*20)
+                           if the robot running at 200hz (5msec) 4000 means 20 secs
         '''
         if self.log == None:
             print(self.configurator_name + "\033[31m  setupLogger : self.log is not defined, please check rtcd.conf or rtcd arguments\033[0m")
             return
+        self.log_svc.maxLength(maxLength);
         #
         for pn in ['q', 'dq', 'tau']:
             self.connectLoggerPort(self.rh, pn)


### PR DESCRIPTION
内部のプログラムで恐縮ですが以下のようなコードを見つけたので，PRにしてみまいｓた．
setupLogger()で引数としてmaxLengthを指定できたら，それでOKということでよいでしょうか．

また， `# Stop all rtcs other than DataLogger for fast connecting of logger data port`
とあるのは，`init` で，`setupLogger()`を，`activateComps`の前に持ってくればいいでしょうか？
@fkanehiro の方ではどうされていますか．

```
     def setupLogger(self):
+        # Stop all rtcs other than DataLogger for fast connecting of logger data ports.
+        rtcList = self.getRTCInstanceList()
+        for r in rtcList:
+            if r.name() != "log":
+                r.stop()
         HrpsysConfigurator.setupLogger(self)
+        # Start all rtcs again
+        for r in rtcList:
+            if r.name() != "log":
+                r.start()
         #default = 4000 too shoort!
         #self.log_svc.maxLength(400000) # 2000 min
         self.log_svc.maxLength(int((5 * 60) / 0.004)) # 5 min, controller 0.004[s]
```