### PR TITLE
[.travis.sh] any diff between 315.1.9 and current is not permitted

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -148,7 +148,7 @@ case $TEST_PACKAGE in
                 travis_time_end
                 travis_time_start  compile_hrpsys
 
-                cd ~/build && cmake ${CI_SOURCE_PATH} && make
+                cd ~/build && cmake ${CI_SOURCE_PATH} ${COMPILE_OPTION} && make
 
                 travis_time_end
                 ;;

--- a/.travis.sh
+++ b/.travis.sh
@@ -94,7 +94,7 @@ case $TEST_PACKAGE in
                 echo -e "#define pid_t int\n#define size_t int\n#include \"iob.h.315.1.9\"" | cproto -x - | sort > iob.h.stable
                 cat iob.h.current
                 cat iob.h.stable
-                diff iob.h.stable iob.h.current | tee >(cat - 1>&2)  | diffstat | grep -c deletion && exit 1
+                diff iob.h.stable iob.h.current || exit 1
 
                 travis_time_end
                 ;;

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,6 +14,7 @@ env:
     - secure: "ESSo9YL0lUB0nnlFIL1vV7zpOyZjgTign4IZR735laiylPjOLKW4BkP9JxT5alA9ip72qbpDKI192Ed3sSkWjjQxhM+/HIjtyOy5/F6U5wfvxWudorJeF4zCy4OBD7Bp9JWqucAkRmd5Qe3Djaih69rAK31IFeNhQ2Ebz6RWVGk="
   matrix:
     - TEST_PACKAGE=hrpsys
+    - TEST_PACKAGE=hrpsys   COMPILE_OPTION='-DROBOT_IOB_VERSION=0'
     - TEST_TYPE=python      TEST_PACKAGE=hrpsys
     - TEST_TYPE=iob         TEST_PACKAGE=hrpsys
     - TEST_TYPE=stable_rtc  TEST_PACKAGE=hrpsys

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -152,7 +152,13 @@ install(FILES
   DESTINATION lib/pkgconfig)
 
 add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")
-add_definitions(-DROBOT_IOB_VERSION=2)
+
+option(ROBOT_IOB_VERSION "Supported robot IOB version (lib/io/iob.h)")
+if("${ROBOT_IOB_VERSION}" STREQUAL "OFF")
+  set(ROBOT_IOB_VERSION 2)
+endif()
+add_definitions(-DROBOT_IOB_VERSION=${ROBOT_IOB_VERSION})
+message(STATUS "compile iob with -DROBOT_IOB_VERSION=${ROBOT_IOB_VERSION}")
 
 if(COMPILE_JAVA_STUFF)
   add_subdirectory(jython)

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -729,21 +729,37 @@ bool robot::readDigitalOutput(char *o_dout)
 void robot::readBatteryState(unsigned int i_rank, double &voltage, 
                              double &current, double &soc)
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     read_battery(i_rank, &voltage, &current, &soc);
+#else
+    voltage=0; current=0; soc=0;
+#endif
 }
 
 int robot::numBatteries()
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     return number_of_batteries();
+#else
+    return 0;
+#endif
 }
 
 void robot::readThermometer(unsigned int i_rank, double &o_temp)
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     read_temperature(i_rank, &o_temp);
+#else
+    o_temp=0;
+#endif
 }
 
 int robot::numThermometers()
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     return number_of_thermometers();
+#else
+    return 0;
+#endif
 }
 


### PR DESCRIPTION
- since we use cproto without any -DROBOT_IOB_VERSION, so this should output header file compatible with stable version

this is expected to fail