### PR TITLE
Reset StateHolder wrench in goActual. Currently zero is assumed.

### DIFF
--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -243,6 +243,11 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
     if (m_requestGoActual || (m_q.data.length() == 0 && m_currentQ.data.length() > 0)){
         m_q = m_currentQ;
         if (m_q.data.length() != m_tq.data.length()) m_tq.data.length(m_q.data.length());
+        // Reset reference wrenches to zero
+        for (unsigned int i=0; i<m_wrenchesIn.size(); i++){
+            m_wrenches[i].data[0] = m_wrenches[i].data[1] = m_wrenches[i].data[2] = 0.0;
+            m_wrenches[i].data[3] = m_wrenches[i].data[4] = m_wrenches[i].data[5] = 0.0;
+        }
     }
 
     if (m_requestGoActual){


### PR DESCRIPTION
StateHolderが指令値をもっていて，goActualのときに実際の関節の値に同期してると思います．
wrench指令値もこのようなときには0にリセットしてよいのではと思ったので，
wrenchを０にしてみました．

よろしくお願いします．