### PR TITLE
Add DRC final stair with sloped ground

### DIFF
--- a/sample/environments/DRCFinalStair.wrl
+++ b/sample/environments/DRCFinalStair.wrl
@@ -1,0 +1,2208 @@
+#VRML V2.0 utf8
+
+# Produced by EusLisp 9.12(bb29754 1.0.6 67007) for Linux64 created on jshiro(Fri May 15 21:14:39 PDT 2015)
+# Date: Tue Jun  2 18:27:07 2015
+
+
+PROTO Joint [
+ exposedField     SFVec3f      center              0 0 0
+ exposedField     MFNode       children            []
+ exposedField     MFFloat      llimit              []
+ exposedField     SFRotation   limitOrientation    0 0 1 0
+ exposedField     SFString     name                ""
+ exposedField     SFRotation   rotation            0 0 1 0
+ exposedField     SFVec3f      scale               1 1 1
+ exposedField     SFRotation   scaleOrientation    0 0 1 0
+ exposedField     MFFloat      stiffness           [ 0 0 0 ]
+ exposedField     SFVec3f      translation         0 0 0
+ exposedField     MFFloat      ulimit              []
+ exposedField     MFFloat      dh                  [0 0 0 0]
+ exposedField     SFString     jointType           ""
+ exposedField     SFInt32      jointId             -1
+ exposedField     SFVec3f     jointAxis           0 0 1
+]
+{
+   Transform {
+      center           IS center
+      children         IS children
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+   }
+}
+
+PROTO Segment [
+ field           SFVec3f     bboxCenter        0 0 0
+ field           SFVec3f     bboxSize          -1 -1 -1
+ exposedField    SFVec3f     centerOfMass      0 0 0
+ exposedField    MFNode      children          [ ]
+ exposedField    SFNode      coord             NULL
+ exposedField    MFNode      displacers        [ ]
+ exposedField    SFFloat     mass              0
+ exposedField    MFFloat     momentsOfInertia  [ 0 0 0 0 0 0 0 0 0 ]
+ exposedField    SFString    name              ""
+ eventIn         MFNode      addChildren
+ eventIn         MFNode      removeChildren
+]
+{
+   Group {
+      addChildren    IS addChildren
+      bboxCenter     IS bboxCenter
+      bboxSize       IS bboxSize
+      children       IS children
+      removeChildren IS removeChildren
+   }
+}
+
+
+PROTO Humanoid [
+ field           SFVec3f    bboxCenter            0 0 0
+ field           SFVec3f    bboxSize              -1 -1 -1
+ exposedField    SFVec3f    center                0 0 0
+ exposedField    MFNode     humanoidBody          [ ]
+ exposedField    MFString   info                  [ ]
+ exposedField    MFNode     joints                [ ]
+ exposedField    SFString   name                  ""
+ exposedField    SFRotation rotation              0 0 1 0
+ exposedField    SFVec3f    scale                 1 1 1
+ exposedField    SFRotation scaleOrientation      0 0 1 0
+ exposedField    MFNode     segments              [ ]
+ exposedField    MFNode     sites                 [ ]
+ exposedField    SFVec3f    translation           0 0 0
+ exposedField    SFString   version               "1.1"
+ exposedField    MFNode     viewpoints            [ ]
+]
+{
+   Transform {
+      bboxCenter       IS bboxCenter
+      bboxSize         IS bboxSize
+      center           IS center
+      rotation         IS rotation
+      scale            IS scale
+      scaleOrientation IS scaleOrientation
+      translation      IS translation
+      children [
+         Group {
+            children IS viewpoints
+         }
+         Group {
+            children IS humanoidBody
+         }
+      ]
+   }
+}
+
+
+PROTO VisionSensor [
+  exposedField SFVec3f    translation       0 0 0
+  exposedField SFRotation rotation              0 0 1 0
+  #exposedField SFRotation orientation       0 0 1 0
+  exposedField SFFloat    fieldOfView       0.785398
+  exposedField SFString   name              ""
+  exposedField SFFloat    frontClipDistance 0.01
+  exposedField SFFloat    backClipDistance  10.0
+  exposedField SFString   type              "NONE"
+  exposedField SFInt32    sensorId          -1
+  exposedField SFInt32    width             320  # 
+  exposedField SFInt32    height            240  # 
+  #exposedField MFNode       children            [] # for me
+]
+{
+  Transform {
+    rotation         IS rotation
+    translation      IS translation
+    #children IS children # for me
+  }
+}
+
+
+PROTO ForceSensor [
+  exposedField SFVec3f maxForce -1 -1 -1
+  exposedField SFVec3f maxTorque -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO Gyro [
+  exposedField SFVec3f maxAngularVelocity -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO AccelerationSensor [
+  exposedField SFVec3f maxAcceleration -1 -1 -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+PROTO PressureSensor [
+  exposedField SFFloat maxPressure -1
+  exposedField SFVec3f translation 0 0 0
+  exposedField SFRotation rotation 0 0 1 0
+  exposedField SFInt32 sensorId -1
+]
+{
+  Transform {
+    translation IS translation
+    rotation IS rotation
+  }
+}
+
+
+NavigationInfo {
+   avatarSize    0.5
+   headlight     TRUE
+   type  ["EXAMINE", "ANY"]
+}
+Viewpoint {
+   position    3 0 0.835
+   orientation 0.5770 0.5775 0.5775 2.0935
+}
+DEF DRCFinalStair Humanoid {
+   humanoidBody [
+    DEF WAIST Joint {
+       jointType "fixed"
+       dh [0 0 0 0]
+       translation 0.000000 0.000000 0.000000
+       rotation 0.0 0.0 1.0 0
+       children [
+          DEF ROOT-LINK_S Segment {
+             centerOfMass 0.0 0.0 0.0
+             mass 0.001
+             momentsOfInertia [ 1.000000e-09 0.0 0.0 0.0 1.000000e-09 0.0 0.0 0.0 1.000000e-09 ]
+             children [
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.500000 0.599780 -0.007798,
+                          0.500000 0.599414 0.002195,
+                          0.500000 -0.599414 -0.051770,
+                          0.500000 -0.599780 -0.041777,
+                          -0.500000 0.599780 -0.007798,
+                          -0.500000 -0.599414 -0.051770,
+                          -0.500000 -0.599780 -0.041777,
+                          -0.500000 0.599414 0.002195,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.300000 0.540000 0.000000,
+                          0.300000 0.540000 0.245000,
+                          0.300000 -0.540000 0.000000,
+                          0.300000 -0.540000 0.245000,
+                          0.000000 0.540000 0.000000,
+                          0.000000 -0.540000 0.000000,
+                          0.000000 -0.540000 0.245000,
+                          0.000000 0.540000 0.245000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.600000 0.540000 0.245000,
+                          0.600000 0.540000 0.485000,
+                          0.600000 -0.540000 0.245000,
+                          0.600000 -0.540000 0.485000,
+                          0.300000 0.540000 0.245000,
+                          0.300000 -0.540000 0.245000,
+                          0.300000 -0.540000 0.485000,
+                          0.300000 0.540000 0.485000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.890000 0.540000 0.485000,
+                          0.890000 0.540000 0.715000,
+                          0.890000 -0.540000 0.485000,
+                          0.890000 -0.540000 0.715000,
+                          0.600000 0.540000 0.485000,
+                          0.600000 -0.540000 0.485000,
+                          0.600000 -0.540000 0.715000,
+                          0.600000 0.540000 0.715000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.090000 0.625000 0.855000,
+                          2.090000 0.625000 0.940000,
+                          2.090000 -1.805000 0.855000,
+                          2.090000 -1.805000 0.940000,
+                          0.890000 0.625000 0.855000,
+                          0.890000 -1.805000 0.855000,
+                          0.890000 -1.805000 0.940000,
+                          0.890000 0.625000 0.940000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.540000 0.000000,
+                          0.000000 0.540000 1.060000,
+                          0.000000 0.500000 0.000000,
+                          0.000000 0.500000 1.060000,
+                          -0.050000 0.540000 0.000000,
+                          -0.050000 0.500000 0.000000,
+                          -0.050000 0.500000 1.060000,
+                          -0.050000 0.540000 1.060000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 -0.500000 -0.000000,
+                          0.000000 -0.500000 1.060000,
+                          0.000000 -0.540000 -0.000000,
+                          0.000000 -0.540000 1.060000,
+                          -0.050000 -0.500000 -0.000000,
+                          -0.050000 -0.540000 -0.000000,
+                          -0.050000 -0.540000 1.060000,
+                          -0.050000 -0.500000 1.060000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.810000 0.540000 0.685000,
+                          0.810000 0.540000 1.680000,
+                          0.810000 0.500000 0.685000,
+                          0.810000 0.500000 1.680000,
+                          0.760000 0.540000 0.685000,
+                          0.760000 0.500000 0.685000,
+                          0.760000 0.500000 1.680000,
+                          0.760000 0.540000 1.680000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.810000 -0.500000 0.685000,
+                          0.810000 -0.500000 1.680000,
+                          0.810000 -0.540000 0.685000,
+                          0.810000 -0.540000 1.680000,
+                          0.760000 -0.500000 0.685000,
+                          0.760000 -0.540000 0.685000,
+                          0.760000 -0.540000 1.680000,
+                          0.760000 -0.500000 1.680000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.029336 0.510000 1.026351,
+                          0.790195 0.510000 1.666639,
+                          -0.033843 0.502679 1.032120,
+                          0.785688 0.502679 1.672408,
+                          -0.040000 0.500000 1.040000,
+                          0.779531 0.500000 1.680288,
+                          -0.046157 0.502679 1.047880,
+                          0.773375 0.502679 1.688168,
+                          -0.050664 0.510000 1.053649,
+                          0.768868 0.510000 1.693937,
+                          -0.052313 0.520000 1.055760,
+                          0.767218 0.520000 1.696048,
+                          -0.050664 0.530000 1.053649,
+                          0.768868 0.530000 1.693937,
+                          -0.046157 0.537321 1.047880,
+                          0.773375 0.537321 1.688168,
+                          -0.040000 0.540000 1.040000,
+                          0.779531 0.540000 1.680288,
+                          -0.033843 0.537321 1.032120,
+                          0.785688 0.537321 1.672408,
+                          -0.027687 0.520000 1.024240,
+                          -0.029336 0.530000 1.026351,
+                          0.790195 0.530000 1.666639,
+                          0.791844 0.520000 1.664528,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.029336 -0.530000 1.026351,
+                          0.790195 -0.530000 1.666639,
+                          -0.033843 -0.537321 1.032120,
+                          0.785688 -0.537321 1.672408,
+                          -0.040000 -0.540000 1.040000,
+                          0.779531 -0.540000 1.680288,
+                          -0.046157 -0.537321 1.047880,
+                          0.773375 -0.537321 1.688168,
+                          -0.050664 -0.530000 1.053649,
+                          0.768868 -0.530000 1.693937,
+                          -0.052313 -0.520000 1.055760,
+                          0.767218 -0.520000 1.696048,
+                          -0.050664 -0.510000 1.053649,
+                          0.768868 -0.510000 1.693937,
+                          -0.046157 -0.502679 1.047880,
+                          0.773375 -0.502679 1.688168,
+                          -0.040000 -0.500000 1.040000,
+                          0.779531 -0.500000 1.680288,
+                          -0.033843 -0.502679 1.032120,
+                          0.785688 -0.502679 1.672408,
+                          -0.027687 -0.520000 1.024240,
+                          -0.029336 -0.510000 1.026351,
+                          0.790195 -0.510000 1.666639,
+                          0.791844 -0.520000 1.664528,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.029336 0.510000 0.576351,
+                          0.790195 0.510000 1.216639,
+                          -0.033843 0.502679 0.582120,
+                          0.785688 0.502679 1.222408,
+                          -0.040000 0.500000 0.590000,
+                          0.779531 0.500000 1.230288,
+                          -0.046157 0.502679 0.597880,
+                          0.773375 0.502679 1.238168,
+                          -0.050664 0.510000 0.603649,
+                          0.768868 0.510000 1.243937,
+                          -0.052313 0.520000 0.605760,
+                          0.767218 0.520000 1.246048,
+                          -0.050664 0.530000 0.603649,
+                          0.768868 0.530000 1.243937,
+                          -0.046157 0.537321 0.597880,
+                          0.773375 0.537321 1.238168,
+                          -0.040000 0.540000 0.590000,
+                          0.779531 0.540000 1.230288,
+                          -0.033843 0.537321 0.582120,
+                          0.785688 0.537321 1.222408,
+                          -0.027687 0.520000 0.574240,
+                          -0.029336 0.530000 0.576351,
+                          0.790195 0.530000 1.216639,
+                          0.791844 0.520000 1.214528,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.029336 -0.530000 0.576351,
+                          0.790195 -0.530000 1.216639,
+                          -0.033843 -0.537321 0.582120,
+                          0.785688 -0.537321 1.222408,
+                          -0.040000 -0.540000 0.590000,
+                          0.779531 -0.540000 1.230288,
+                          -0.046157 -0.537321 0.597880,
+                          0.773375 -0.537321 1.238168,
+                          -0.050664 -0.530000 0.603649,
+                          0.768868 -0.530000 1.243937,
+                          -0.052313 -0.520000 0.605760,
+                          0.767218 -0.520000 1.246048,
+                          -0.050664 -0.510000 0.603649,
+                          0.768868 -0.510000 1.243937,
+                          -0.046157 -0.502679 0.597880,
+                          0.773375 -0.502679 1.238168,
+                          -0.040000 -0.500000 0.590000,
+                          0.779531 -0.500000 1.230288,
+                          -0.033843 -0.502679 0.582120,
+                          0.785688 -0.502679 1.222408,
+                          -0.027687 -0.520000 0.574240,
+                          -0.029336 -0.510000 0.576351,
+                          0.790195 -0.510000 1.216639,
+                          0.791844 -0.520000 1.214528,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 -0.550000 0.887321,
+                          -0.100000 -0.550000 0.887321,
+                          0.000000 -0.557321 0.880000,
+                          -0.100000 -0.557321 0.880000,
+                          -0.000000 -0.560000 0.870000,
+                          -0.100000 -0.560000 0.870000,
+                          -0.000000 -0.557321 0.860000,
+                          -0.100000 -0.557321 0.860000,
+                          -0.000000 -0.550000 0.852679,
+                          -0.100000 -0.550000 0.852679,
+                          -0.000000 -0.540000 0.850000,
+                          -0.100000 -0.540000 0.850000,
+                          -0.000000 -0.530000 0.852679,
+                          -0.100000 -0.530000 0.852679,
+                          -0.000000 -0.522679 0.860000,
+                          -0.100000 -0.522679 0.860000,
+                          0.000000 -0.520000 0.870000,
+                          -0.100000 -0.520000 0.870000,
+                          0.000000 -0.522679 0.880000,
+                          -0.100000 -0.522679 0.880000,
+                          0.000000 -0.540000 0.890000,
+                          0.000000 -0.530000 0.887321,
+                          -0.100000 -0.530000 0.887321,
+                          -0.100000 -0.540000 0.890000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 -0.550000 1.042321,
+                          -0.100000 -0.550000 1.042321,
+                          0.000000 -0.557321 1.035000,
+                          -0.100000 -0.557321 1.035000,
+                          -0.000000 -0.560000 1.025000,
+                          -0.100000 -0.560000 1.025000,
+                          -0.000000 -0.557321 1.015000,
+                          -0.100000 -0.557321 1.015000,
+                          -0.000000 -0.550000 1.007679,
+                          -0.100000 -0.550000 1.007679,
+                          -0.000000 -0.540000 1.005000,
+                          -0.100000 -0.540000 1.005000,
+                          -0.000000 -0.530000 1.007679,
+                          -0.100000 -0.530000 1.007679,
+                          -0.000000 -0.522679 1.015000,
+                          -0.100000 -0.522679 1.015000,
+                          0.000000 -0.520000 1.025000,
+                          -0.100000 -0.520000 1.025000,
+                          0.000000 -0.522679 1.035000,
+                          -0.100000 -0.522679 1.035000,
+                          0.000000 -0.540000 1.045000,
+                          0.000000 -0.530000 1.042321,
+                          -0.100000 -0.530000 1.042321,
+                          -0.100000 -0.540000 1.045000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.082679 -0.550000 0.850000,
+                          -0.082679 -0.550000 1.045000,
+                          -0.090000 -0.557321 0.850000,
+                          -0.090000 -0.557321 1.045000,
+                          -0.100000 -0.560000 0.850000,
+                          -0.100000 -0.560000 1.045000,
+                          -0.110000 -0.557321 0.850000,
+                          -0.110000 -0.557321 1.045000,
+                          -0.117321 -0.550000 0.850000,
+                          -0.117321 -0.550000 1.045000,
+                          -0.120000 -0.540000 0.850000,
+                          -0.120000 -0.540000 1.045000,
+                          -0.117321 -0.530000 0.850000,
+                          -0.117321 -0.530000 1.045000,
+                          -0.110000 -0.522679 0.850000,
+                          -0.110000 -0.522679 1.045000,
+                          -0.100000 -0.520000 0.850000,
+                          -0.100000 -0.520000 1.045000,
+                          -0.090000 -0.522679 0.850000,
+                          -0.090000 -0.522679 1.045000,
+                          -0.080000 -0.540000 0.850000,
+                          -0.082679 -0.530000 0.850000,
+                          -0.082679 -0.530000 1.045000,
+                          -0.080000 -0.540000 1.045000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.530000 0.887321,
+                          -0.100000 0.530000 0.887321,
+                          0.000000 0.522679 0.880000,
+                          -0.100000 0.522679 0.880000,
+                          -0.000000 0.520000 0.870000,
+                          -0.100000 0.520000 0.870000,
+                          -0.000000 0.522679 0.860000,
+                          -0.100000 0.522679 0.860000,
+                          -0.000000 0.530000 0.852679,
+                          -0.100000 0.530000 0.852679,
+                          -0.000000 0.540000 0.850000,
+                          -0.100000 0.540000 0.850000,
+                          -0.000000 0.550000 0.852679,
+                          -0.100000 0.550000 0.852679,
+                          -0.000000 0.557321 0.860000,
+                          -0.100000 0.557321 0.860000,
+                          0.000000 0.560000 0.870000,
+                          -0.100000 0.560000 0.870000,
+                          0.000000 0.557321 0.880000,
+                          -0.100000 0.557321 0.880000,
+                          0.000000 0.540000 0.890000,
+                          0.000000 0.550000 0.887321,
+                          -0.100000 0.550000 0.887321,
+                          -0.100000 0.540000 0.890000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.000000 0.530000 1.042321,
+                          -0.100000 0.530000 1.042321,
+                          0.000000 0.522679 1.035000,
+                          -0.100000 0.522679 1.035000,
+                          -0.000000 0.520000 1.025000,
+                          -0.100000 0.520000 1.025000,
+                          -0.000000 0.522679 1.015000,
+                          -0.100000 0.522679 1.015000,
+                          -0.000000 0.530000 1.007679,
+                          -0.100000 0.530000 1.007679,
+                          -0.000000 0.540000 1.005000,
+                          -0.100000 0.540000 1.005000,
+                          -0.000000 0.550000 1.007679,
+                          -0.100000 0.550000 1.007679,
+                          -0.000000 0.557321 1.015000,
+                          -0.100000 0.557321 1.015000,
+                          0.000000 0.560000 1.025000,
+                          -0.100000 0.560000 1.025000,
+                          0.000000 0.557321 1.035000,
+                          -0.100000 0.557321 1.035000,
+                          0.000000 0.540000 1.045000,
+                          0.000000 0.550000 1.042321,
+                          -0.100000 0.550000 1.042321,
+                          -0.100000 0.540000 1.045000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          -0.082679 0.530000 0.850000,
+                          -0.082679 0.530000 1.045000,
+                          -0.090000 0.522679 0.850000,
+                          -0.090000 0.522679 1.045000,
+                          -0.100000 0.520000 0.850000,
+                          -0.100000 0.520000 1.045000,
+                          -0.110000 0.522679 0.850000,
+                          -0.110000 0.522679 1.045000,
+                          -0.117321 0.530000 0.850000,
+                          -0.117321 0.530000 1.045000,
+                          -0.120000 0.540000 0.850000,
+                          -0.120000 0.540000 1.045000,
+                          -0.117321 0.550000 0.850000,
+                          -0.117321 0.550000 1.045000,
+                          -0.110000 0.557321 0.850000,
+                          -0.110000 0.557321 1.045000,
+                          -0.100000 0.560000 0.850000,
+                          -0.100000 0.560000 1.045000,
+                          -0.090000 0.557321 0.850000,
+                          -0.090000 0.557321 1.045000,
+                          -0.080000 0.540000 0.850000,
+                          -0.082679 0.550000 0.850000,
+                          -0.082679 0.550000 1.045000,
+                          -0.080000 0.540000 1.045000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 23, -1,
+                       5, 3, 23, -1,
+                       7, 5, 23, -1,
+                       9, 7, 23, -1,
+                       11, 9, 23, -1,
+                       13, 11, 23, -1,
+                       15, 13, 23, -1,
+                       17, 15, 23, -1,
+                       19, 17, 23, -1,
+                       23, 22, 19, -1,
+                       21, 20, 0, -1,
+                       18, 21, 0, -1,
+                       16, 18, 0, -1,
+                       14, 16, 0, -1,
+                       12, 14, 0, -1,
+                       10, 12, 0, -1,
+                       8, 10, 0, -1,
+                       6, 8, 0, -1,
+                       4, 6, 0, -1,
+                       0, 2, 4, -1,
+                       23, 1, 0, -1,
+                       0, 20, 23, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 5, 4, -1,
+                       4, 2, 3, -1,
+                       5, 7, 6, -1,
+                       6, 4, 5, -1,
+                       7, 9, 8, -1,
+                       8, 6, 7, -1,
+                       9, 11, 10, -1,
+                       10, 8, 9, -1,
+                       11, 13, 12, -1,
+                       12, 10, 11, -1,
+                       13, 15, 14, -1,
+                       14, 12, 13, -1,
+                       15, 17, 16, -1,
+                       16, 14, 15, -1,
+                       17, 19, 18, -1,
+                       18, 16, 17, -1,
+                       19, 22, 21, -1,
+                       21, 18, 19, -1,
+                       22, 23, 20, -1,
+                       20, 21, 22, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.885000 0.675000 0.905000,
+                          0.885000 0.675000 1.970000,
+                          0.885000 0.625000 0.905000,
+                          0.885000 0.625000 1.970000,
+                          0.850000 0.675000 0.905000,
+                          0.850000 0.625000 0.905000,
+                          0.850000 0.625000 1.970000,
+                          0.850000 0.675000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 0.675000 0.905000,
+                          2.055000 0.675000 1.970000,
+                          2.055000 0.625000 0.905000,
+                          2.055000 0.625000 1.970000,
+                          2.020000 0.675000 0.905000,
+                          2.020000 0.625000 0.905000,
+                          2.020000 0.625000 1.970000,
+                          2.020000 0.675000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 -1.805000 0.905000,
+                          2.055000 -1.805000 1.970000,
+                          2.055000 -1.855000 0.905000,
+                          2.055000 -1.855000 1.970000,
+                          2.020000 -1.805000 0.905000,
+                          2.020000 -1.855000 0.905000,
+                          2.020000 -1.855000 1.970000,
+                          2.020000 -1.805000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          0.885000 -1.805000 0.905000,
+                          0.885000 -1.805000 1.970000,
+                          0.885000 -1.855000 0.905000,
+                          0.885000 -1.855000 1.970000,
+                          0.850000 -1.805000 0.905000,
+                          0.850000 -1.855000 0.905000,
+                          0.850000 -1.855000 1.970000,
+                          0.850000 -1.805000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.090000 0.575000 0.905000,
+                          2.090000 0.575000 1.970000,
+                          2.090000 0.525000 0.905000,
+                          2.090000 0.525000 1.970000,
+                          2.055000 0.575000 0.905000,
+                          2.055000 0.525000 0.905000,
+                          2.055000 0.525000 1.970000,
+                          2.055000 0.575000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.090000 -1.705000 0.905000,
+                          2.090000 -1.705000 1.970000,
+                          2.090000 -1.755000 0.905000,
+                          2.090000 -1.755000 1.970000,
+                          2.055000 -1.705000 0.905000,
+                          2.055000 -1.755000 0.905000,
+                          2.055000 -1.755000 1.970000,
+                          2.055000 -1.705000 1.970000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 0.675000 1.970000,
+                          2.055000 0.675000 2.010000,
+                          2.055000 0.625000 1.970000,
+                          2.055000 0.625000 2.010000,
+                          0.850000 0.675000 1.970000,
+                          0.850000 0.625000 1.970000,
+                          0.850000 0.625000 2.010000,
+                          0.850000 0.675000 2.010000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 0.675000 1.455000,
+                          2.055000 0.675000 1.495000,
+                          2.055000 0.625000 1.455000,
+                          2.055000 0.625000 1.495000,
+                          0.850000 0.675000 1.455000,
+                          0.850000 0.625000 1.455000,
+                          0.850000 0.625000 1.495000,
+                          0.850000 0.675000 1.495000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 -1.805000 1.970000,
+                          2.055000 -1.805000 2.010000,
+                          2.055000 -1.855000 1.970000,
+                          2.055000 -1.855000 2.010000,
+                          0.850000 -1.805000 1.970000,
+                          0.850000 -1.855000 1.970000,
+                          0.850000 -1.855000 2.010000,
+                          0.850000 -1.805000 2.010000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 -1.805000 1.455000,
+                          2.055000 -1.805000 1.495000,
+                          2.055000 -1.855000 1.455000,
+                          2.055000 -1.855000 1.495000,
+                          0.850000 -1.805000 1.455000,
+                          0.850000 -1.855000 1.455000,
+                          0.850000 -1.855000 1.495000,
+                          0.850000 -1.805000 1.495000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 0.625000 1.970000,
+                          2.105000 0.625000 2.010000,
+                          2.105000 -1.805000 1.970000,
+                          2.105000 -1.805000 2.010000,
+                          2.055000 0.625000 1.970000,
+                          2.055000 -1.805000 1.970000,
+                          2.055000 -1.805000 2.010000,
+                          2.055000 0.625000 2.010000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.105000 0.625000 1.455000,
+                          2.105000 0.625000 1.495000,
+                          2.105000 -1.805000 1.455000,
+                          2.105000 -1.805000 1.495000,
+                          2.055000 0.625000 1.455000,
+                          2.055000 -1.805000 1.455000,
+                          2.055000 -1.805000 1.495000,
+                          2.055000 0.625000 1.495000,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 -1.805000 0.872500,
+                          2.055000 -1.805000 0.977500,
+                          2.055000 -1.815000 0.872500,
+                          2.055000 -1.815000 0.977500,
+                          0.850000 -1.805000 0.872500,
+                          0.850000 -1.815000 0.872500,
+                          0.850000 -1.815000 0.977500,
+                          0.850000 -1.805000 0.977500,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+                Shape {
+                   appearance Appearance {
+                      material Material {
+                      }
+                   }
+                   geometry DEF ROOT-LINK-FACES IndexedFaceSet {
+                      creaseAngle 0.8
+                      ccw TRUE
+                      solid TRUE
+                      colorPerVertex FALSE
+                      color Color {
+                         color [
+                          0.742188 0.742188 0.742188,
+                         ]
+                      }
+                      coord DEF ROOT-LINK-COORD Coordinate {
+                         point[
+                          2.055000 0.625000 0.872500,
+                          2.055000 0.625000 0.977500,
+                          2.055000 0.615000 0.872500,
+                          2.055000 0.615000 0.977500,
+                          0.850000 0.625000 0.872500,
+                          0.850000 0.615000 0.872500,
+                          0.850000 0.615000 0.977500,
+                          0.850000 0.625000 0.977500,
+                         ]
+                      }
+                      coordIndex [
+                       3, 1, 7, -1,
+                       7, 6, 3, -1,
+                       5, 4, 0, -1,
+                       0, 2, 5, -1,
+                       7, 1, 0, -1,
+                       0, 4, 7, -1,
+                       1, 3, 2, -1,
+                       2, 0, 1, -1,
+                       3, 6, 5, -1,
+                       5, 2, 3, -1,
+                       6, 7, 4, -1,
+                       4, 5, 6, -1,
+                      ]
+                      colorIndex [
+                       0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 
+                      ]
+                   }
+                }
+             ]
+          } #Segment
+       ]
+    } #WAIST
+   ] # END of HumanoidBody
+
+   joints [
+    USE WAIST
+   ]
+
+   segments [
+    USE ROOT-LINK_S
+   ]
+
+}


### PR DESCRIPTION
地面が傾斜したDRC Final階段を追加しました．
段の高さのみあってて，手すりはついてしまってます．
```
(progn (load "package://drc_task_common/euslisp/drc-testbed-models.l")
       (make-drc-stair-final :add-groud-p t)
       (send *stair* :name "DRCFinalStair")
       (eus2wrl *stair* "/tmp/DRCFinalStair.wrl" :mode :openhrp3 :fixed t))
```
よろしくお願いいたします．