### PR TITLE
Add emergency stop interface for walking

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -204,6 +204,13 @@ module OpenHRP
     boolean goStop();
 
     /**
+     * @brief Stop stepping immediately.
+     * @param
+     * @return true if set successfully, false otherwise
+     */
+    boolean emergencyStop();
+
+    /**
      * @brief Set footsteps. Returns without waiting for whole steps to be executed.
      * @param fs is sequence of FootStep structure.
      * @return true if set successfully, false otherwise

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -953,6 +953,13 @@ bool AutoBalancer::goStop ()
   return true;
 }
 
+bool AutoBalancer::emergencyStop ()
+{
+  gg->emergency_stop();
+  waitFootSteps();
+  return true;
+}
+
 bool AutoBalancer::setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs)
 {
   OpenHRP::AutoBalancerService::StepParamSequence sps;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -92,6 +92,7 @@ class AutoBalancer
   bool goPos(const double& x, const double& y, const double& th);
   bool goVelocity(const double& vx, const double& vy, const double& vth);
   bool goStop();
+  bool emergencyStop ();
   bool setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs);
   bool setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps);
   void waitFootSteps();

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -24,6 +24,11 @@ CORBA::Boolean AutoBalancerService_impl::goStop()
   return m_autobalancer->goStop();
 };
 
+CORBA::Boolean AutoBalancerService_impl::emergencyStop()
+{
+  return m_autobalancer->emergencyStop();
+};
+
 CORBA::Boolean AutoBalancerService_impl::setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs)
 {
   return m_autobalancer->setFootSteps(fs);

--- a/rtc/AutoBalancer/AutoBalancerService_impl.h
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.h
@@ -18,6 +18,7 @@ public:
   CORBA::Boolean goPos( CORBA::Double x,  CORBA::Double y,  CORBA::Double th);
   CORBA::Boolean goVelocity( CORBA::Double vx,  CORBA::Double vy,  CORBA::Double vth);
   CORBA::Boolean goStop();
+  CORBA::Boolean emergencyStop();
   CORBA::Boolean setFootSteps(const OpenHRP::AutoBalancerService::FootstepSequence& fs);
   CORBA::Boolean setFootStepsWithParam(const OpenHRP::AutoBalancerService::FootstepSequence& fs, const OpenHRP::AutoBalancerService::StepParamSequence& sps);
   void waitFootSteps();


### PR DESCRIPTION
AutoBalancerの歩行を緊急停止するものを追加しました。
現状goVelocityで歩いてるときが対象になってます。
よろしくお願いします。