### PR TITLE
do not check position/limit error when lower limit and upper limit is same

### DIFF
--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -230,7 +230,8 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       double qvel = (m_qRef.data[i] - prev_angle[i]) / dt;
       double lvlimit = m_robot->joint(i)->lvlimit + 0.000175; // 0.01 deg / sec
       double uvlimit = m_robot->joint(i)->uvlimit - 0.000175;
-      if ( servo_state[i] == 1 && ((lvlimit > qvel) || (uvlimit < qvel)) ) {
+      // fixed joint has ulimit = vlimit
+      if ( servo_state[i] == 1 && (uvlimit < uvlimit) && ((lvlimit > qvel) || (uvlimit < qvel)) ) {
         if (loop % debug_print_freq == 0 || debug_print_velocity_first ) {
           std::cerr << "velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
                     << ", lvlimit =" << lvlimit
@@ -270,7 +271,8 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
           llimit = it->second.getLlimit(m_qRef.data[it->second.getTargetJointId()]);
           ulimit = it->second.getUlimit(m_qRef.data[it->second.getTargetJointId()]);
       }
-      bool servo_limit_state = ((llimit > m_qRef.data[i]) || (ulimit < m_qRef.data[i]));
+      // fixed joint have vlimit = ulimit
+      bool servo_limit_state = (llimit < ulimit) && ((llimit > m_qRef.data[i]) || (ulimit < m_qRef.data[i]));
       if ( servo_state[i] == 1 && servo_limit_state ) {
         if (loop % debug_print_freq == 0 || debug_print_position_first) {
           std::cerr << "position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]


### PR DESCRIPTION
some robot has joint which upper limit and lower limit has same value, for example
https://raw.githubusercontent.com/start-jsk/rtmros_hironx/hydro-devel/hironx_ros_bridge/models/kawada-hironx.dae
```
				<joint name="WAIST_JOINT" sid="jointsid0">
					<revolute sid="axis0">
						<axis>0 0 1</axis>
						<limits>
							<min>0</min>
							<max>0</max>
						</limits>
					</revolute>
				</joint>
```
and this outputs 
```
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
[ INFO] [1437357214.104381921, 31.414999999]: [HrpsysSeqStateROSBridge0] @onExecutece 0 is working at 202[Hz] (exec 1776 Hz, dropped 202)
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
position limit over (0), qRef=-8.75e-07, llimit =0, ulimit =0, servo_state = ON, prev_angle = 0
velocity limit over (0), qvel=0, lvlimit =0.000175, uvlimit =-0.000175, servo_state = ON
```
https://travis-ci.org/start-jsk/rtmros_common/jobs/71699630

This PR skips limit check if ulimit and ulimit are same (actually if ulimit < llimit)