### PR TITLE
Fix SeqOfGroup size bug

### DIFF
--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -465,7 +465,7 @@ bool SequencePlayer::setJointAnglesSequenceOfGroup(const char *gname, const Open
     std::vector<double> v_tms;
     for ( int i = 0; i < angless.length(); i++ ) v_poss.push_back(angless[i].get_buffer());
     for ( int i = 0; i <  times.length();  i++ )  v_tms.push_back(times[i]);
-    return m_seq->setJointAnglesSequenceOfGroup(gname, v_poss, v_tms);
+    return m_seq->setJointAnglesSequenceOfGroup(gname, v_poss, v_tms, angless.length()>0?angless[0].length():0);
 }
 
 bool SequencePlayer::clearJointAnglesOfGroup(const char *gname)
@@ -780,7 +780,7 @@ bool SequencePlayer::removeJointGroup(const char *gname)
     return ret;
 }
 
-bool SequencePlayer::setJointAnglesOfGroup(const char *gname, const double *angles, double tm)
+bool SequencePlayer::setJointAnglesOfGroup(const char *gname, const dSequence& jvs, double tm)
 {
     if ( m_debugLevel > 0 ) {
         std::cerr << __PRETTY_FUNCTION__ << std::endl;
@@ -789,7 +789,7 @@ bool SequencePlayer::setJointAnglesOfGroup(const char *gname, const double *angl
     if (!setInitialState()) return false;
 
     if (!m_seq->resetJointGroup(gname, m_qInit.data.get_buffer())) return false;
-    return m_seq->setJointAnglesOfGroup(gname, angles, tm);
+    return m_seq->setJointAnglesOfGroup(gname, jvs.get_buffer(), jvs.length(), tm);
 }
 
 bool SequencePlayer::playPatternOfGroup(const char *gname, const dSequenceSequence& pos, const dSequence& tm)

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -113,7 +113,7 @@ class SequencePlayer
   bool setInitialState(double tm=0.0);
   bool addJointGroup(const char *gname, const OpenHRP::SequencePlayerService::StrSequence& jnames);
   bool removeJointGroup(const char *gname);
-  bool setJointAnglesOfGroup(const char *gname, const double *angles, double tm);
+  bool setJointAnglesOfGroup(const char *gname, const OpenHRP::dSequence& jvs, double tm);
   bool setJointAnglesSequenceOfGroup(const char *gname, const OpenHRP::dSequenceSequence angless, const OpenHRP::dSequence& times);
     bool clearJointAnglesOfGroup(const char *gname);
   bool playPatternOfGroup(const char *gname, const OpenHRP::dSequenceSequence& pos, const OpenHRP::dSequence& tm);

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -293,7 +293,7 @@ CORBA::Boolean SequencePlayerService_impl::removeJointGroup(const char* gname)
 
 CORBA::Boolean SequencePlayerService_impl::setJointAnglesOfGroup(const char *gname, const dSequence& jvs, CORBA::Double tm)
 {
-    return m_player->setJointAnglesOfGroup(gname, jvs.get_buffer(), tm);
+    return m_player->setJointAnglesOfGroup(gname, jvs, tm);
 }
 
 CORBA::Boolean SequencePlayerService_impl::setJointAnglesSequenceOfGroup(const char *gname, const dSequenceSequence& jvss, const dSequence& tms)

--- a/rtc/SequencePlayer/seqplay.cpp
+++ b/rtc/SequencePlayer/seqplay.cpp
@@ -477,11 +477,15 @@ bool seqplay::resetJointGroup(const char *gname, const double *full)
 	}
 }
 
-bool seqplay::setJointAnglesOfGroup(const char *gname, const double *i_qRef, double i_tm)
+bool seqplay::setJointAnglesOfGroup(const char *gname, const double* i_qRef, const size_t i_qsize, double i_tm)
 {
 	char *s = (char *)gname; while(*s) {*s=toupper(*s);s++;}
 	groupInterpolator *i = groupInterpolators[gname];
 	if (i){
+		if (i_qsize != i->indices.size() ) {
+			std::cerr << "[setJointAnglesOfGroup] group name " << gname << " : size of manipulater is not equal to input. " << i_qsize << " /= " << i->indices.size() << std::endl;
+			return false;
+		}
 		if (i->state == groupInterpolator::created){
 			double q[m_dof], dq[m_dof];
 			interpolators[Q]->get(q, dq, false);
@@ -746,13 +750,17 @@ bool seqplay::setJointAnglesSequenceFull(std::vector<const double*> i_pos, std::
 	return true;
 }
 
-bool seqplay::setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm)
+bool seqplay::setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm, const size_t pos_size)
 {
 	char *s = (char *)gname; while(*s) {*s=toupper(*s);s++;}
 	groupInterpolator *i = groupInterpolators[gname];
 
 	if (! i){
 		std::cerr << "[setJointAnglesOfGroup] group name " << gname << " is not installed" << std::endl;
+		return false;
+	}
+	if (pos_size != i->indices.size() ) {
+		std::cerr << "[setJointAnglesSequenceOfGroup] group name " << gname << " : size of manipulater is not equal to input. " << pos_size << " /= " << i->indices.size() << std::endl;
 		return false;
 	}
 	int len = i->indices.size();

--- a/rtc/SequencePlayer/seqplay.cpp
+++ b/rtc/SequencePlayer/seqplay.cpp
@@ -756,7 +756,7 @@ bool seqplay::setJointAnglesSequenceOfGroup(const char *gname, std::vector<const
 	groupInterpolator *i = groupInterpolators[gname];
 
 	if (! i){
-		std::cerr << "[setJointAnglesOfGroup] group name " << gname << " is not installed" << std::endl;
+		std::cerr << "[setJointAnglesSequenceOfGroup] group name " << gname << " is not installed" << std::endl;
 		return false;
 	}
 	if (pos_size != i->indices.size() ) {

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -31,14 +31,14 @@ public:
     bool addJointGroup(const char *gname, const std::vector<int>& indices);
     bool getJointGroup(const char *gname, std::vector<int>& indices);
     bool removeJointGroup(const char *gname, double time=2.5);
-    bool setJointAnglesOfGroup(const char *gname, const double *i_qRef, double i_tm=0.0);
+    bool setJointAnglesOfGroup(const char *gname, const double* i_qRef, const size_t i_qsize, double i_tm=0.0);
     void clearOfGroup(const char *gname, double i_timeLimit);
     bool playPatternOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm, const double *qInit, unsigned int len);
 
     bool resetJointGroup(const char *gname, const double *full);
     //
     bool setJointAnglesSequence(std::vector<const double*> pos, std::vector<double> tm);
-    bool setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm);
+    bool setJointAnglesSequenceOfGroup(const char *gname, std::vector<const double*> pos, std::vector<double> tm, const size_t pos_size);
     bool setJointAnglesSequenceFull(std::vector<const double*> pos, std::vector<const double*> vel, std::vector<const double*> torques, std::vector<const double*> bpos, std::vector<const double*> brpy, std::vector<const double*> bacc, std::vector<const double*> zmps, std::vector<const double*> wrenches, std::vector<const double*> optionals, std::vector<double> tm);
     bool clearJointAngles();
     bool clearJointAnglesOfGroup(const char *gname);

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -38,53 +38,53 @@ def testPoseList(pose_list, initial_pose):
         hcf.waitInterpolation()
 
 def demoAutoBalancerFixFeet ():
-    print "1. AutoBalancer mode by fixing feet"
+    print >> sys.stderr, "1. AutoBalancer mode by fixing feet"
     hcf.startAutoBalancer();
     hcf.seq_svc.setJointAngles(arm_front_pose, 1.0)
     hcf.waitInterpolation()
     hcf.seq_svc.setJointAngles(initial_pose, 1.0)
     hcf.waitInterpolation()
     hcf.stopAutoBalancer();
-    print "  Start and Stop AutoBalancer by fixing feet=>OK"
+    print >> sys.stderr, "  Start and Stop AutoBalancer by fixing feet=>OK"
 
 def demoAutoBalancerFixFeetHands ():
-    print "2. AutoBalancer mode by fixing hands and feet"
+    print >> sys.stderr, "2. AutoBalancer mode by fixing hands and feet"
     hcf.startAutoBalancer(["rleg", "lleg", "rarm", "larm"])
     hcf.seq_svc.setJointAngles(arm_front_pose, 1.0)
     hcf.waitInterpolation()
     hcf.seq_svc.setJointAngles(initial_pose, 1.0)
     hcf.waitInterpolation()
     hcf.stopAutoBalancer();
-    print "  Start and Stop AutoBalancer by fixing hands and feet=>OK"
+    print >> sys.stderr, "  Start and Stop AutoBalancer by fixing hands and feet=>OK"
 
 def demoAutoBalancerGetParam():
-    print "3. getAutoBalancerParam"
+    print >> sys.stderr, "3. getAutoBalancerParam"
     ret = hcf.abc_svc.getAutoBalancerParam()
     if ret[0]:
-        print "  getAutoBalancerParam() => OK"
+        print >> sys.stderr, "  getAutoBalancerParam() => OK"
 
 def demoAutoBalancerSetParam():
-    print "4. setAutoBalancerParam"
+    print >> sys.stderr, "4. setAutoBalancerParam"
     abcp=hcf.abc_svc.getAutoBalancerParam()[1]
     abcp.default_zmp_offsets = [[0.1,0,0], [0.1,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
     ret=hcf.abc_svc.getAutoBalancerParam()
     if ret[0] and ret[1].default_zmp_offsets == abcp.default_zmp_offsets:
-        print "  setAutoBalancerParam() => OK"
-    print "  default_zmp_offsets setting check in start and stop"
+        print >> sys.stderr, "  setAutoBalancerParam() => OK"
+    print >> sys.stderr, "  default_zmp_offsets setting check in start and stop"
     hcf.startAutoBalancer();
     hcf.stopAutoBalancer();
     abcp.default_zmp_offsets = [[0,0,0], [0,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
 
 def demoAutoBalancerTestPoses():
-    print "5. change base height, base rot x, base rot y, and upper body while AutoBalancer mode"
+    print >> sys.stderr, "5. change base height, base rot x, base rot y, and upper body while AutoBalancer mode"
     hcf.startAutoBalancer();
     testPoseList(pose_list, initial_pose)
     hcf.stopAutoBalancer();
 
 def demoAutoBalancerStartStopCheck():
-    print "6. start stop check"
+    print >> sys.stderr, "6. start stop check"
     abcp=hcf.abc_svc.getAutoBalancerParam()[1]
     abcp.default_zmp_offsets = [[-0.05,0.05,0], [-0.05,0.05,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
@@ -102,7 +102,7 @@ def demoAutoBalancerStartStopCheck():
     hcf.waitInterpolation()
 
 def demoAutoBalancerBalanceAgainstHandForce():
-    print "7. balance against hand force"
+    print >> sys.stderr, "7. balance against hand force"
     hcf.startAutoBalancer();
     hcf.seq_svc.setWrenches([0,0,0,0,0,0,
                              0,0,0,0,0,0,
@@ -117,21 +117,21 @@ def demoAutoBalancerBalanceAgainstHandForce():
     hcf.stopAutoBalancer();
 
 def demoGaitGeneratorGoPos():
-    print "1. goPos"
+    print >> sys.stderr, "1. goPos"
     hcf.startAutoBalancer();
     hcf.abc_svc.goPos(0.1, 0.05, 20)
     hcf.abc_svc.waitFootSteps()
-    print "  goPos()=>OK"
+    print >> sys.stderr, "  goPos()=>OK"
 
 def demoGaitGeneratorGoVelocity():
-    print "2. goVelocity and goStop"
+    print >> sys.stderr, "2. goVelocity and goStop"
     hcf.abc_svc.goVelocity(-0.1, -0.05, -20)
     time.sleep(1)
     hcf.abc_svc.goStop()
-    print "  goVelocity()=>OK"
+    print >> sys.stderr, "  goVelocity()=>OK"
 
 def demoGaitGeneratorSetFootSteps():
-    print "3. setFootSteps"
+    print >> sys.stderr, "3. setFootSteps"
     hcf.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0], [1,0,0,0], "rleg"),
                       OpenHRP.AutoBalancerService.Footstep([0,0.09,0], [1,0,0,0], "lleg")])
     hcf.abc_svc.waitFootSteps()
@@ -140,23 +140,23 @@ def demoGaitGeneratorSetFootSteps():
                       OpenHRP.AutoBalancerService.Footstep([0.3,-0.09,0], [1,0,0,0], "rleg"),
                       OpenHRP.AutoBalancerService.Footstep([0.3,0.09,0], [1,0,0,0], "lleg")])
     hcf.abc_svc.waitFootSteps()
-    print "  setFootSteps()=>OK"
+    print >> sys.stderr, "  setFootSteps()=>OK"
 
 def demoGaitGeneratorChangePoseWhileWalking():
-    print "4. Change base height, base rot x, base rot y, and upper body while walking"
+    print >> sys.stderr, "4. Change base height, base rot x, base rot y, and upper body while walking"
     hcf.abc_svc.waitFootSteps()
     hcf.abc_svc.goVelocity(0,0,0)
     testPoseList(pose_list, initial_pose)
     hcf.abc_svc.goStop()
 
 def demoGaitGeneratorGetParam():
-    print "5. getGaitGeneratorParam"
+    print >> sys.stderr, "5. getGaitGeneratorParam"
     ret = hcf.abc_svc.getGaitGeneratorParam()
     if ret[0]:
-        print "  getGaitGeneratorParam() => OK"
+        print >> sys.stderr, "  getGaitGeneratorParam() => OK"
 
 def demoGaitGeneratorSetParam():
-    print "6. setGaitGeneratorParam"
+    print >> sys.stderr, "6. setGaitGeneratorParam"
     ggp_org = hcf.abc_svc.getGaitGeneratorParam()[1]
     ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
     ggp.default_step_time = 0.9
@@ -167,23 +167,23 @@ def demoGaitGeneratorSetParam():
     hcf.abc_svc.setGaitGeneratorParam(ggp)
     ret = hcf.abc_svc.getGaitGeneratorParam()
     if ret[0] and ret[1].default_step_time == ggp.default_step_time and ret[1].default_step_height == ggp.default_step_height and ret[1].default_double_support_ratio == ggp.default_double_support_ratio and ret[1].default_orbit_type == ggp.default_orbit_type:
-        print "  setGaitGeneratorParam() => OK"
+        print >> sys.stderr, "  setGaitGeneratorParam() => OK"
     hcf.abc_svc.goPos(0.2,0,0)
     hcf.abc_svc.waitFootSteps()
     hcf.abc_svc.setGaitGeneratorParam(ggp_org) # revert parameter
 
 def demoGaitGeneratorNonDefaultStrideStop():
-    print "7. non-default stride"
+    print >> sys.stderr, "7. non-default stride"
     hcf.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0], [1,0,0,0], "rleg"),
                       OpenHRP.AutoBalancerService.Footstep([0.15,0.09,0], [1,0,0,0], "lleg")])
     hcf.abc_svc.waitFootSteps()
     hcf.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0], [1,0,0,0], "rleg"),
                       OpenHRP.AutoBalancerService.Footstep([0,0.09,0], [1,0,0,0], "lleg")])
     hcf.abc_svc.waitFootSteps()
-    print "  Non default Stride()=>OK"
+    print >> sys.stderr, "  Non default Stride()=>OK"
 
 def demoGaitGeneratorToeHeelContact():
-    print "8. Use toe heel contact"
+    print >> sys.stderr, "8. Use toe heel contact"
     ggp=hcf.abc_svc.getGaitGeneratorParam()[1];
     ggp.toe_pos_offset_x = 1e-3*182.0;
     ggp.heel_pos_offset_x = 1e-3*-72.0;
@@ -197,17 +197,17 @@ def demoGaitGeneratorToeHeelContact():
     ggp.toe_angle = 0;
     ggp.heel_angle = 0;
     hcf.abc_svc.setGaitGeneratorParam(ggp);
-    print "  Toe heel contact=>OK"
+    print >> sys.stderr, "  Toe heel contact=>OK"
 
 def demoGaitGeneratorStopStartSyncCheck():
-    print "9. Stop and start auto balancer sync check2"
-    print "  Check 9-1 Sync after setFootSteps"
+    print >> sys.stderr, "9. Stop and start auto balancer sync check2"
+    print >> sys.stderr, "  Check 9-1 Sync after setFootSteps"
     hcf.startAutoBalancer();
     hcf.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0], [1,0,0,0], "rleg"), OpenHRP.AutoBalancerService.Footstep([0.1,0.09,0], [1,0,0,0], "lleg")]);
     hcf.abc_svc.waitFootSteps();
     hcf.stopAutoBalancer();
-    print "    Sync after setFootSteps => OK"
-    print "  Check 9-2 Sync from setJointAngles at the beginning"
+    print >> sys.stderr, "    Sync after setFootSteps => OK"
+    print >> sys.stderr, "  Check 9-2 Sync from setJointAngles at the beginning"
     open_stride_pose = [0.00026722677758058496, -0.3170503560247552, -0.0002054613599000865, 0.8240549352035262, -0.5061434785447525, -8.67443660992421e-05, 0.3112899999999996, -0.15948099999999998, -0.11539900000000003, -0.6362769999999993, 0.0, 0.0, 0.0, 0.00023087433689200683, -0.4751295978345554, -0.00021953834197007937, 0.8048588066686679, -0.3288687069275527, -8.676469399681631e-05, 0.3112899999999996, 0.15948099999999998, 0.11539900000000003, -0.6362769999999993, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
     hcf.seq_svc.setJointAngles(open_stride_pose, 2.0);
     hcf.waitInterpolation();
@@ -215,41 +215,41 @@ def demoGaitGeneratorStopStartSyncCheck():
     hcf.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0], [1,0,0,0], "rleg"), OpenHRP.AutoBalancerService.Footstep([0.1,0.09,0], [1,0,0,0], "lleg")]);
     hcf.abc_svc.waitFootSteps();
     hcf.stopAutoBalancer();
-    print "    Sync from setJointAngle at the beginning => OK"
-    print "  Check 9-3 Sync from setJointAngles"
+    print >> sys.stderr, "    Sync from setJointAngle at the beginning => OK"
+    print >> sys.stderr, "  Check 9-3 Sync from setJointAngles"
     hcf.startAutoBalancer();
     hcf.seq_svc.setJointAngles(initial_pose, 2.0);
     hcf.waitInterpolation();
     hcf.stopAutoBalancer();
-    print "    Sync from setJointAngle => OK"
+    print >> sys.stderr, "    Sync from setJointAngle => OK"
 
 def demoGaitGeneratorEmergencyStop():
-    print "10. Emergency stop"
+    print >> sys.stderr, "10. Emergency stop"
     hcf.startAutoBalancer();
     hcf.abc_svc.goPos(0,0,90);
-    print "  Start goPos and wait for 4 steps"
+    print >> sys.stderr, "  Start goPos and wait for 4 steps"
     for idx in range(4): # Wait for 4 steps including initial double support phase
         # Wait for 1 steps
         hcf.seq_svc.setJointAngles(initial_pose, hcf.abc_svc.getGaitGeneratorParam()[1].default_step_time);
         hcf.waitInterpolation();
-    print "  Emergency stoping"
+    print >> sys.stderr, "  Emergency stoping"
     hcf.abc_svc.emergencyStop();
-    print "  Align foot steps"
+    print >> sys.stderr, "  Align foot steps"
     hcf.abc_svc.goPos(0,0,0);
 
 def demoGaitGeneratorGetRemainingSteps():
-    print "11. Get remaining foot steps"
+    print >> sys.stderr, "11. Get remaining foot steps"
     hcf.abc_svc.goPos(0.3,0.1,15);
     fslist=hcf.abc_svc.getRemainingFootstepSequence()[1]
     while fslist != []:
         fslist=hcf.abc_svc.getRemainingFootstepSequence()[1]
-        print "  Remaining footstep ", len(fslist)
+        print >> sys.stderr, "  Remaining footstep ", len(fslist)
         # Wait for 1 step
         hcf.seq_svc.setJointAngles(initial_pose, hcf.abc_svc.getGaitGeneratorParam()[1].default_step_time);
         hcf.waitInterpolation();
 
 def demoGaitGeneratorChangeStepParam():
-    print "12. Change step param with setFootSteps"
+    print >> sys.stderr, "12. Change step param with setFootSteps"
     ggp_org=hcf.abc_svc.getGaitGeneratorParam()[1];
     # dummy setting
     ggp=hcf.abc_svc.getGaitGeneratorParam()[1];
@@ -286,7 +286,7 @@ def demoGaitGeneratorChangeStepParam():
     hcf.abc_svc.setGaitGeneratorParam(ggp_org);
 
 def demoGaitGeneratorOverwriteFootsteps(overwrite_offset_idx = 1):
-    print "13. Overwrite footsteps during walking."
+    print >> sys.stderr, "13. Overwrite footsteps during walking."
     hcf.startAutoBalancer()
     demoGaitGeneratorOverwriteFootstepsBase("x", overwrite_offset_idx, True) # Overwrite by X direction foot steps
     hcf.seq_svc.setJointAngles(initial_pose, 1.0*overwrite_offset_idx)
@@ -305,15 +305,15 @@ def demoGaitGeneratorOverwriteFootstepsBase(axis, overwrite_offset_idx = 1, init
                           OpenHRP.AutoBalancerService.Footstep([0.3, 0.09,0], [1,0,0,0], "lleg"),
                           OpenHRP.AutoBalancerService.Footstep([0.4,-0.09,0], [1,0,0,0], "rleg"),
                           OpenHRP.AutoBalancerService.Footstep([0.4, 0.09,0], [1,0,0,0], "lleg")]);
-    print "  Overwrite footsteps ", overwrite_offset_idx
+    print >> sys.stderr, "  Overwrite footsteps ", overwrite_offset_idx
     # Get remaining footstep
     [remain_fs, current_fs_idx]=hcf.abc_svc.getRemainingFootstepSequence()[1:]
-    #print remain_fs
-    print "    Remaining legs = ", map(lambda fs : fs.leg, remain_fs)
-    print "    Remaining idx  = ", map(lambda idx : current_fs_idx+idx, range(len(remain_fs)))
+    #print >> sys.stderr, remain_fs
+    print >> sys.stderr, "    Remaining legs = ", map(lambda fs : fs.leg, remain_fs)
+    print >> sys.stderr, "    Remaining idx  = ", map(lambda idx : current_fs_idx+idx, range(len(remain_fs)))
     # Footstep index to be overwritten
     overwrite_fs_idx = current_fs_idx + overwrite_offset_idx
-    print "    Overwrite index = ",overwrite_fs_idx, ", leg = ", remain_fs[overwrite_offset_idx].leg
+    print >> sys.stderr, "    Overwrite index = ",overwrite_fs_idx, ", leg = ", remain_fs[overwrite_offset_idx].leg
     # Calc new footsteps
     import numpy
     support_fs = remain_fs[overwrite_offset_idx-1] # support fs before overwritten fs
@@ -335,7 +335,7 @@ def demoGaitGeneratorOverwriteFootstepsBase(axis, overwrite_offset_idx = 1, init
     hcf.abc_svc.setFootSteps(new_fs, overwrite_fs_idx);
 
 def demoGaitGeneratorHandFixWalking():
-    print "13. walking by fixing"
+    print >> sys.stderr, "13. walking by fixing"
     # abc_svc.startAutoBalancer([AutoBalancerService.AutoBalancerLimbParam("rleg", [0,0,0], [0,0,0,0]),
     #                            AutoBalancerService.AutoBalancerLimbParam("lleg", [0,0,0], [0,0,0,0]),
     #                            AutoBalancerService.AutoBalancerLimbParam("rarm", [0,0,0], [0,0,0,0]),

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -24,78 +24,78 @@ def init ():
 
 # demo functions
 def demoCollisionCheckSafe ():
-    print "1. CollisionCheck in safe pose"
+    print >> sys.stderr, "1. CollisionCheck in safe pose"
     hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:
-        print "  => Safe pose"
+        print >> sys.stderr, "  => Safe pose"
     assert(cs.safe_posture is True)
 
 def demoCollisionCheckFail ():
-    print "2. CollisionCheck in fail pose"
+    print >> sys.stderr, "2. CollisionCheck in fail pose"
     hcf.seq_svc.setJointAngles(col_fail_pose, 1.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if not cs.safe_posture:
-        print "  => Successfully stop fail pose"
+        print >> sys.stderr, "  => Successfully stop fail pose"
     assert((not cs.safe_posture) is True)
     hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:
-        print "  => Successfully return to safe pose"
+        print >> sys.stderr, "  => Successfully return to safe pose"
     assert(cs.safe_posture is True)
 
 def demoCollisionCheckFailWithSetTolerance ():
-    print "3. CollisionCheck in fail pose with 0.1[m] tolerance"
+    print >> sys.stderr, "3. CollisionCheck in fail pose with 0.1[m] tolerance"
     hcf.co_svc.setTolerance("all", 0.1); # [m]
     hcf.seq_svc.setJointAngles(col_fail_pose, 1.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if not cs.safe_posture:
-        print "  => Successfully stop fail pose (0.1[m] tolerance)"
+        print >> sys.stderr, "  => Successfully stop fail pose (0.1[m] tolerance)"
     assert((not cs.safe_posture) is True)
     hcf.co_svc.setTolerance("all", 0.0); # [m]
     hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:
-        print "  => Successfully return to safe pose"
+        print >> sys.stderr, "  => Successfully return to safe pose"
     assert(cs.safe_posture is True)
 
 def demoCollisionDisableEnable ():
-    print "4. CollisionDetection enable and disable"
+    print >> sys.stderr, "4. CollisionDetection enable and disable"
     hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
     hcf.waitInterpolation();
     if hcf.co_svc.disableCollisionDetection():
-        print "  => Successfully disabled when no collision"
+        print >> sys.stderr, "  => Successfully disabled when no collision"
     assert(hcf.co_svc.disableCollisionDetection() is True)
     if hcf.co_svc.enableCollisionDetection():
-        print "  => Successfully enabled when no collision"
+        print >> sys.stderr, "  => Successfully enabled when no collision"
     assert(hcf.co_svc.enableCollisionDetection() is True)
     hcf.seq_svc.setJointAngles(col_fail_pose, 1.0);
     hcf.waitInterpolation();
     if not hcf.co_svc.disableCollisionDetection():
-        print "  => Successfully inhibit disabling when collision"
+        print >> sys.stderr, "  => Successfully inhibit disabling when collision"
     assert((not hcf.co_svc.disableCollisionDetection()) is True)
     hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
     hcf.waitInterpolation();
 
 def demoCollisionMask ():
     if hcf.abc_svc != None:
-        print "5. Collision mask test"
+        print >> sys.stderr, "5. Collision mask test"
         hcf.co_svc.setTolerance("all", 0); # [m]
         hcf.startAutoBalancer()
-        print "  5.1 Collision mask among legs : Check RLEG_ANKLE_R - LLEG_ANKLE_R"
-        print "      Desired behavior : Robot stops when legs collision."
+        print >> sys.stderr, "  5.1 Collision mask among legs : Check RLEG_ANKLE_R - LLEG_ANKLE_R"
+        print >> sys.stderr, "      Desired behavior : Robot stops when legs collision."
         hcf.abc_svc.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0],[1,0,0,0],"rleg"),OpenHRP.AutoBalancerService.Footstep([0,0.0,0],[1,0,0,0],"lleg")])
         hcf.abc_svc.waitFootSteps();
         hcf.abc_svc.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0],[1,0,0,0],"rleg"),OpenHRP.AutoBalancerService.Footstep([0,0.09,0],[1,0,0,0],"lleg")])
         hcf.abc_svc.waitFootSteps();
-        print "  => Successfully mask works. Legs joints stops when collision."
-        print "  5.2 Collision mask between leg and arm : Check RLEG_HIP_R and RARM_WRIST*"
-        print "      Desired behavior : Leg joints moves and arm joints stops when collision."
+        print >> sys.stderr, "  => Successfully mask works. Legs joints stops when collision."
+        print >> sys.stderr, "  5.2 Collision mask between leg and arm : Check RLEG_HIP_R and RARM_WRIST*"
+        print >> sys.stderr, "      Desired behavior : Leg joints moves and arm joints stops when collision."
         hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
         hcf.waitInterpolation();
         hcf.abc_svc.goVelocity(0,0,0);
@@ -104,17 +104,17 @@ def demoCollisionMask ():
         hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
         hcf.waitInterpolation();
         hcf.abc_svc.goStop();
-        print "  => Successfully mask works. Arm joints stops and leg joints moves."
-        print "  5.3 Collision mask between leg and arm : Check RLEG_HIP_R and RARM_WRIST* and RLEG_ANKLE_R and LLEG_ANKLE_R (combination of 5.1 and 5.2)"
-        print "      Desired behavior : First, arm stops and legs moves."
+        print >> sys.stderr, "  => Successfully mask works. Arm joints stops and leg joints moves."
+        print >> sys.stderr, "  5.3 Collision mask between leg and arm : Check RLEG_HIP_R and RARM_WRIST* and RLEG_ANKLE_R and LLEG_ANKLE_R (combination of 5.1 and 5.2)"
+        print >> sys.stderr, "      Desired behavior : First, arm stops and legs moves."
         hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
         hcf.waitInterpolation();
-        print "      Desired behavior : Next, arm keeps stopping and legs stops."
+        print >> sys.stderr, "      Desired behavior : Next, arm keeps stopping and legs stops."
         hcf.abc_svc.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0],[1,0,0,0],"rleg"),OpenHRP.AutoBalancerService.Footstep([0,0.0,0],[1,0,0,0],"lleg")])
         hcf.abc_svc.waitFootSteps();
         hcf.abc_svc.setFootSteps([OpenHRP.AutoBalancerService.Footstep([0,-0.09,0],[1,0,0,0],"rleg"),OpenHRP.AutoBalancerService.Footstep([0,0.09,0],[1,0,0,0],"lleg")])
         hcf.abc_svc.waitFootSteps();
-        print "  => Successfully mask works with combined situation."
+        print >> sys.stderr, "  => Successfully mask works with combined situation."
         hcf.stopAutoBalancer()
 
 def demo():

--- a/sample/SampleRobot/samplerobot_data_logger.py
+++ b/sample/SampleRobot/samplerobot_data_logger.py
@@ -25,23 +25,23 @@ def init ():
     hcf.waitInterpolation()
 
 def demoSaveLog():
-    print "1. Save log"
+    print >> sys.stderr, "1. Save log"
     # Save log files for each ports as /tmp/test-samplerobot-log.*
     #   file names are /tmp/test-samplerobot-log.[RTCName]_[PortName], c.f.,  /tmp/test-samplerobot-log.sh_qOut ... etc
     hcf.saveLog("/tmp/test-samplerobot-log")
     ret = os.path.exists("/tmp/test-samplerobot-log.sh_qOut")
     if ret:
-        print "  save() =>OK"
+        print >> sys.stderr, "  save() =>OK"
     assert(ret is True)
 
 def demoClearLog():
-    print "2. Clear buffer"
+    print >> sys.stderr, "2. Clear buffer"
     hcf.clearLog()
-    print "  clear() =>OK"
+    print >> sys.stderr, "  clear() =>OK"
     assert(True)
 
 def demoSetMaxLogLength():
-    print "3. Set max ring-buffer length : 100 [loop] * 0.002 [s] = 0.2 [s] data"
+    print >> sys.stderr, "3. Set max ring-buffer length : 100 [loop] * 0.002 [s] = 0.2 [s] data"
     hcf.setMaxLogLength(100)
     hcf.seq_svc.setJointAngles(initial_pose, 0.2) # wait
     hcf.waitInterpolation()
@@ -49,7 +49,7 @@ def demoSetMaxLogLength():
     from subprocess import check_output
     ret = check_output(['wc', '-l', '/tmp/test-samplerobot-log.sh_qOut']).split(" ")[0] == '100'
     if ret:
-        print "  maxLength() =>OK"
+        print >> sys.stderr, "  maxLength() =>OK"
     assert(ret is True)
 
 def demo ():

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -27,26 +27,26 @@ def demo():
     hcf.seq_svc.waitInterpolation()
 
     # 1. Getter check
-    print "1. Getter check"
+    print >> sys.stderr "1. Getter check"
     ret1=hcf.ic_svc.getImpedanceControllerParam("rarm")
     if ret1[0]:
-        print "  getImpedanceControllerParam => OK"
+        print >> sys.stderr "  getImpedanceControllerParam => OK"
     # 2. Setter check
-    print "2. Setter check"
+    print >> sys.stderr, "2. Setter check"
     ret1[1].K_r=1.0
     ret1[1].D_r=2.0
     ret1[1].M_r=0.2
     ret2=hcf.ic_svc.setImpedanceControllerParam("rarm", ret1[1])
     ret3=hcf.ic_svc.getImpedanceControllerParam("rarm")
     if ret2:
-        print "  setImpedanceControllerParam => OK"
+        print >> sys.stderr, "  setImpedanceControllerParam => OK"
     # 3. Start impedance
-    print "3. Start impedance"
+    print >> sys.stderr, "3. Start impedance"
     ret4=hcf.ic_svc.startImpedanceController("rarm")
     if ret4:
-        print "  startImpedanceController => OK"
+        print >> sys.stderr, "  startImpedanceController => OK"
     # 4. Set ref force and moment
-    print "4. Set ref force and moment"
+    print >> sys.stderr, "4. Set ref force and moment"
     hcf.seq_svc.setWrenches([0,0,0,0,0,0,
                              0,0,0,0,0,0,
                              0,0,0,0,0,0,
@@ -72,12 +72,12 @@ def demo():
     hcf.seq_svc.waitInterpolation();
     time.sleep(2)
     # 5. Stop impedance
-    print "5. Stop impedance"
+    print >> sys.stderr, "5. Stop impedance"
     ret5=hcf.ic_svc.stopImpedanceController("rarm")
     if ret5:
-        print "  stopImpedanceController => OK"
+        print >> sys.stderr, "  stopImpedanceController => OK"
     # 6. Arm tracking check
-    print "6. Arm tracking check"
+    print >> sys.stderr, "6. Arm tracking check"
     hcf.ic_svc.startImpedanceController("rarm")
     hcf.setJointAngle("RARM_ELBOW", -40.0, 0.5);
     hcf.waitInterpolation()
@@ -85,7 +85,7 @@ def demo():
     hcf.waitInterpolation()
     # 7. World frame check
     if hcf.kinematics_only_mode:
-        print "7. World frame check"
+        print >> sys.stderr, "7. World frame check"
         # tempolarily set use_sh_base_pos_rpy
         icp=hcf.ic_svc.getImpedanceControllerParam("rarm")[1]
         icp.use_sh_base_pos_rpy = True
@@ -100,10 +100,10 @@ def demo():
         hcf.seq_svc.setJointAngles(initial_pose, 2.0)
         hcf.seq_svc.waitInterpolation()
     else:
-        print "7. World frame check is not executed in non-kinematics-only-mode"
+        print >> sys.stderr, "7. World frame check is not executed in non-kinematics-only-mode"
     # 8. World frame ref-force check
     if hcf.kinematics_only_mode:
-        print "8. World frame ref-force check"
+        print >> sys.stderr, "8. World frame ref-force check"
         # tempolarily set use_sh_base_pos_rpy
         icp=hcf.ic_svc.getImpedanceControllerParam("rarm")[1]
         icp.use_sh_base_pos_rpy = True
@@ -136,7 +136,7 @@ def demo():
         hcf.seq_svc.setBaseRpy([0,0,0], 1.0);
         hcf.seq_svc.waitInterpolation();
     else:
-        print "8. World frame ref-force check is not executed in non-kinematics-only-mode"
+        print >> sys.stderr, "8. World frame ref-force check is not executed in non-kinematics-only-mode"
 
 if __name__ == '__main__':
     demo()

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -27,10 +27,10 @@ def demo():
     hcf.seq_svc.waitInterpolation()
 
     # 1. Getter check
-    print >> sys.stderr "1. Getter check"
+    print >> sys.stderr, "1. Getter check"
     ret1=hcf.ic_svc.getImpedanceControllerParam("rarm")
     if ret1[0]:
-        print >> sys.stderr "  getImpedanceControllerParam => OK"
+        print >> sys.stderr, "  getImpedanceControllerParam => OK"
     # 2. Setter check
     print >> sys.stderr, "2. Setter check"
     ret1[1].K_r=1.0

--- a/sample/SampleRobot/samplerobot_kalman_filter.py
+++ b/sample/SampleRobot/samplerobot_kalman_filter.py
@@ -97,7 +97,7 @@ def test_kf_plot (test_motion_func, optional_out_file_name): # time [s]
                     "Actual yaw", "Estimated yaw", "Estimated base yaw"))
         plt.savefig("/tmp/test-kf-samplerobot-data-{0}.eps".format(optional_out_file_name))
     except:
-        print "No plot"
+        print >> sys.stderr, "No plot"
 
 def test_bending_common (time, poses):
     hcf.seq_svc.setJointAngles(poses[1], time*0.25)
@@ -136,14 +136,14 @@ def test_walk ():
     hcf.abc_svc.waitFootSteps()
 
 def demoGetKalmanFilterParameter():
-    print "1. getParameter"
+    print >> sys.stderr, "1. getParameter"
     ret=hcf.kf_svc.getKalmanFilterParam()
     if ret[0]:
-        print "  getKalmanFilterParam() => OK"
+        print >> sys.stderr, "  getKalmanFilterParam() => OK"
     assert(ret[0])
 
 def demoSetKalmanFilterParameter():
-    print "2. setParameter"
+    print >> sys.stderr, "2. setParameter"
     kfp=hcf.kf_svc.getKalmanFilterParam()[1]
     kfp.Q_angle = 0.001;
     kfp.Q_rate = 0.003;
@@ -152,7 +152,7 @@ def demoSetKalmanFilterParameter():
     kfp2=hcf.kf_svc.getKalmanFilterParam()[1]
     ret2 = ret and kfp.Q_angle == kfp2.Q_angle and kfp.Q_rate == kfp2.Q_rate and kfp.R_angle == kfp2.R_angle
     if ret2:
-        print "  setKalmanFilterParam() => OK"
+        print >> sys.stderr, "  setKalmanFilterParam() => OK"
     assert(ret2)
 
 def demo():

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py
@@ -26,22 +26,22 @@ def init ():
     print("hrpsys_version = %s"%hrpsys_version)
 
 def demoGetForceMomentOffsetParam ():
-    print "1. GetForceMomentOffsetParam"
+    print >> sys.stderr, "1. GetForceMomentOffsetParam"
     for fs_name in ["rhsensor", "lhsensor"]:
         ret = hcf.rmfo_svc.getForceMomentOffsetParam(fs_name)
         if ret[0]:
-            print "    getForceMomentOffsetParam('", fs_name,"') => OK"
+            print >> sys.stderr, "    getForceMomentOffsetParam('", fs_name,"') => OK"
         assert(ret[0] is True)
 
 def demoSetForceMomentOffsetParam ():
-    print "2. SetForceMomentOffsetParam"
-    print "  Force and moment are large because of link offsets"
+    print >> sys.stderr, "2. SetForceMomentOffsetParam"
+    print >> sys.stderr, "  Force and moment are large because of link offsets"
     for fs_name in ["rhsensor", "lhsensor"]:
         fm = numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_"+fs_name)).data)
         vret = fm > 5e-2
-        print "    no-offset-removed force moment (",fs_name,") ", fm, "=> ", vret
+        print >> sys.stderr, "    no-offset-removed force moment (",fs_name,") ", fm, "=> ", vret
         assert(vret)
-    print "  Set link offsets (link_offset_centroid and link_offset_mass are identified value)."
+    print >> sys.stderr, "  Set link offsets (link_offset_centroid and link_offset_mass are identified value)."
     # Get param
     r_fmop = hcf.rmfo_svc.getForceMomentOffsetParam("rhsensor")[1]
     r_fmop.link_offset_centroid = [0,0.0368,-0.076271]
@@ -55,22 +55,22 @@ def demoSetForceMomentOffsetParam ():
     # Check values
     ret = hcf.rmfo_svc.getForceMomentOffsetParam("rhsensor")
     if ret[0] and ret[1].link_offset_mass == r_fmop.link_offset_mass and ret[1].link_offset_centroid == r_fmop.link_offset_centroid:
-        print "    getForceMomentOffsetParam('rhsensor') => OK"
+        print >> sys.stderr, "    getForceMomentOffsetParam('rhsensor') => OK"
     assert((ret[0] and ret[1].link_offset_mass == r_fmop.link_offset_mass and ret[1].link_offset_centroid == r_fmop.link_offset_centroid))
     ret = hcf.rmfo_svc.getForceMomentOffsetParam("lhsensor")
     if ret[0] and ret[1].link_offset_mass == l_fmop.link_offset_mass and ret[1].link_offset_centroid == l_fmop.link_offset_centroid:
-        print "    getForceMomentOffsetParam('lhsensor') => OK"
+        print >> sys.stderr, "    getForceMomentOffsetParam('lhsensor') => OK"
     assert((ret[0] and ret[1].link_offset_mass == l_fmop.link_offset_mass and ret[1].link_offset_centroid == l_fmop.link_offset_centroid))
-    print "  Force and moment are reduced"
+    print >> sys.stderr, "  Force and moment are reduced"
     for fs_name in ["rhsensor", "lhsensor"]:
         fm = numpy.linalg.norm(rtm.readDataPort(hcf.rmfo.port("off_"+fs_name)).data)
         vret = fm < 5e-2
-        print "    no-offset-removed force moment (",fs_name,") ", fm, "=> ", vret
+        print >> sys.stderr, "    no-offset-removed force moment (",fs_name,") ", fm, "=> ", vret
         assert(vret)
 
 def demoDumpLoadForceMomentOffsetParams():
-    print "3. Dump and load parameter file"
-    print "  Get and set param"
+    print >> sys.stderr, "3. Dump and load parameter file"
+    print >> sys.stderr, "  Get and set param"
     r_fmop = hcf.rmfo_svc.getForceMomentOffsetParam("rhsensor")[1]
     r_fmop.link_offset_centroid = [0,0.0368,-0.076271]
     r_fmop.link_offset_mass = 0.80011
@@ -79,18 +79,18 @@ def demoDumpLoadForceMomentOffsetParams():
     l_fmop.link_offset_mass = 0.80011
     hcf.rmfo_svc.setForceMomentOffsetParam("rhsensor", r_fmop)
     hcf.rmfo_svc.setForceMomentOffsetParam("lhsensor", l_fmop)
-    print "  Dump param as file"
+    print >> sys.stderr, "  Dump param as file"
     ret = hcf.rmfo_svc.dumpForceMomentOffsetParams("/tmp/test-rmfo-offsets.dat")
-    print "  Value check"
+    print >> sys.stderr, "  Value check"
     data_str=filter(lambda x : x.find("lhsensor") >= 0, open("/tmp/test-rmfo-offsets.dat", "r").read().split("\n"))[0]
     vcheck = map(float, data_str.split(" ")[7:10]) == l_fmop.link_offset_centroid and float(data_str.split(" ")[10]) == l_fmop.link_offset_mass
     data_str=filter(lambda x : x.find("rhsensor") >= 0, open("/tmp/test-rmfo-offsets.dat", "r").read().split("\n"))[0]
     vcheck = vcheck and map(float, data_str.split(" ")[7:10]) == r_fmop.link_offset_centroid and float(data_str.split(" ")[10]) == r_fmop.link_offset_mass
     import os
     if ret and os.path.exists("/tmp/test-rmfo-offsets.dat") and vcheck:
-        print "    dumpForceMomentOffsetParams => OK"
+        print >> sys.stderr, "    dumpForceMomentOffsetParams => OK"
     assert((ret and os.path.exists("/tmp/test-rmfo-offsets.dat") and vcheck))
-    print "  Resetting values"
+    print >> sys.stderr, "  Resetting values"
     r_fmop2 = hcf.rmfo_svc.getForceMomentOffsetParam("rhsensor")[1]
     r_fmop2.link_offset_centroid = [0,0,0]
     r_fmop2.link_offset_mass = 0
@@ -99,13 +99,13 @@ def demoDumpLoadForceMomentOffsetParams():
     l_fmop2.link_offset_mass = 0
     hcf.rmfo_svc.setForceMomentOffsetParam("rhsensor", r_fmop2)
     hcf.rmfo_svc.setForceMomentOffsetParam("lhsensor", l_fmop2)
-    print "  Load from file"
+    print >> sys.stderr, "  Load from file"
     ret = hcf.rmfo_svc.loadForceMomentOffsetParams("/tmp/test-rmfo-offsets.dat")
     r_fmop3 = hcf.rmfo_svc.getForceMomentOffsetParam("rhsensor")[1]
     l_fmop3 = hcf.rmfo_svc.getForceMomentOffsetParam("lhsensor")[1]
     vcheck = r_fmop3.link_offset_mass == r_fmop.link_offset_mass and r_fmop3.link_offset_centroid == r_fmop.link_offset_centroid and l_fmop3.link_offset_mass == l_fmop.link_offset_mass and l_fmop3.link_offset_centroid == l_fmop.link_offset_centroid
     if ret and vcheck:
-        print "    loadForceMomentOffsetParams => OK"
+        print >> sys.stderr, "    loadForceMomentOffsetParams => OK"
     assert((ret and vcheck))
 
 def demo():

--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -221,8 +221,8 @@ def demoSetWrenches ():
 def demoSetJointAnglesOfGroup():
     print >> sys.stderr, "8. setJointAnglesOfGroup"
     hcf.seq_svc.addJointGroup('larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R'])
-    larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0]
-    larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0]
+    larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0, 0.0]
+    larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0, 0.0]
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
     hcf.seq_svc.setJointAnglesOfGroup('larm', larm_pos0, 1.0);
     hcf.seq_svc.waitInterpolationOfGroup('larm');
@@ -256,8 +256,8 @@ def demoSetJointAnglesOfGroup():
 def demoSetJointAnglesSequenceOfGroup():
     print >> sys.stderr, "9. setJointAnglesOfGroup"
     hcf.seq_svc.addJointGroup('larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R'])
-    larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0]
-    larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0]
+    larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0, 0.0]
+    larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0, 0.0]
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
     hcf.seq_svc.setJointAnglesSequenceOfGroup('larm', [larm_pos0, larm_pos1, larm_pos0], [1.0, 1.0, 1.0]);
     hcf.seq_svc.waitInterpolationOfGroup('larm');

--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -103,7 +103,7 @@ def checkRobotState (var_doc):
 
 # demo functions
 def demoSetJointAngles():
-    print "1. setJointAngles"
+    print >> sys.stderr, "1. setJointAngles"
     hcf.seq_svc.setJointAngles(move_base_pose_doc['pos'], 1.0);
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(move_base_pose_doc)
@@ -111,7 +111,7 @@ def demoSetJointAngles():
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(reset_pose_doc)
     # check override
-    print "   check override"
+    print >> sys.stderr, "   check override"
     hcf.seq_svc.setJointAngles(move_base_pose_doc['pos'], 5.0);
     time.sleep(2.5)
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
@@ -120,14 +120,14 @@ def demoSetJointAngles():
     # check clear
     if hrpsys_version < '315.5.0':
         return
-    print "   check clear"
+    print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAngles(move_base_pose_doc['pos'], 5.0);
     time.sleep(2.5)
     hcf.seq_svc.clearJointAngles()
     checkJointAnglesBetween(reset_pose_doc,move_base_pose_doc)
 
 def demoSetJointAnglesSequence():
-    print "1. setJointAnglesSequence"
+    print >> sys.stderr, "2. setJointAnglesSequence"
     hcf.seq_svc.setJointAnglesSequence([move_base_pose_doc['pos'],reset_pose_doc['pos'],move_base_pose_doc['pos']], [1.0,1.0,1.0]);
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(move_base_pose_doc)
@@ -135,21 +135,21 @@ def demoSetJointAnglesSequence():
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(reset_pose_doc)
     # check override
-    print "   check override"
+    print >> sys.stderr, "   check override"
     hcf.seq_svc.setJointAnglesSequence([move_base_pose_doc['pos'],reset_pose_doc['pos'],move_base_pose_doc['pos']], [1.0,1.0,5.0])
     time.sleep(3.5)
     hcf.seq_svc.setJointAnglesSequence([reset_pose_doc['pos'],move_base_pose_doc['pos'],reset_pose_doc['pos']], [1.0,1.0,1.0]);
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(reset_pose_doc)
     # check clear
-    print "   check clear"
+    print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAnglesSequence([move_base_pose_doc['pos'],reset_pose_doc['pos'],move_base_pose_doc['pos']], [1.0,1.0,5.0])
     time.sleep(3.5)
     hcf.seq_svc.clearJointAngles()
     checkJointAnglesBetween(reset_pose_doc,move_base_pose_doc)
 
 def demoSetJointAngle():
-    print "2. setJointAngle"
+    print >> sys.stderr, "3. setJointAngle"
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
     hcf.seq_svc.waitInterpolation();
     hcf.seq_svc.setJointAngle("WAIST_R", 10*3.14159/180.0, 1.0);
@@ -177,7 +177,7 @@ def demoSetJointAngle():
     # checkJointAnglesBetween(reset_pose_doc,p)
 
 def demoLoadPattern():
-    print "3. loadPattern"
+    print >> sys.stderr, "4. loadPattern"
     # dump pattern doc as loadPattern file
     dumpLoadPatternTestFile("/tmp/test-samplerobot-move-base-pose", move_base_pose_doc, 2.0);
     dumpLoadPatternTestFile("/tmp/test-samplerobot-reset-pose", reset_pose_doc, 2.0);
@@ -190,7 +190,7 @@ def demoLoadPattern():
     checkRobotState(reset_pose_doc)
 
 def demoSetZmp ():
-    print "4. setZmp"
+    print >> sys.stderr, "5. setZmp"
     hcf.seq_svc.setZmp(move_base_pose_doc['zmp'], 1.0);
     hcf.seq_svc.waitInterpolation();
     checkZmp(move_base_pose_doc)
@@ -199,7 +199,7 @@ def demoSetZmp ():
     checkZmp(reset_pose_doc)
 
 def demoSetBasePosRpy ():
-    print "4. setBasePos and setBaseRpy"
+    print >> sys.stderr, "6. setBasePos and setBaseRpy"
     hcf.seq_svc.setBasePos(move_base_pose_doc['waist'][0:3], 1.0);
     hcf.seq_svc.setBaseRpy(move_base_pose_doc['waist'][3:6], 1.0);
     hcf.seq_svc.waitInterpolation();
@@ -210,7 +210,7 @@ def demoSetBasePosRpy ():
     checkWaist(reset_pose_doc)
 
 def demoSetWrenches ():
-    print "5. setWrenches"
+    print >> sys.stderr, "7. setWrenches"
     hcf.seq_svc.setWrenches(move_base_pose_doc['wrenches'], 1.0);
     hcf.seq_svc.waitInterpolation();
     checkWrenches(move_base_pose_doc)
@@ -219,7 +219,7 @@ def demoSetWrenches ():
     checkWrenches(reset_pose_doc)
 
 def demoSetJointAnglesOfGroup():
-    print "6. setJointAnglesOfGroup"
+    print >> sys.stderr, "8. setJointAnglesOfGroup"
     hcf.seq_svc.addJointGroup('larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R'])
     larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0]
     larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0]
@@ -237,7 +237,7 @@ def demoSetJointAnglesOfGroup():
         p1[i+19] = larm_pos1[i]
     checkJointAngles(p1)
     # check override
-    print "   check override"
+    print >> sys.stderr, "   check override"
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
     hcf.seq_svc.setJointAnglesOfGroup('larm', larm_pos0, 5.0);
     time.sleep(2.5)
@@ -247,14 +247,14 @@ def demoSetJointAnglesOfGroup():
     # check clear
     if hrpsys_version < '315.5.0':
         return
-    print "   check clear"
+    print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAnglesOfGroup('larm', larm_pos0, 5.0);
     time.sleep(2.5)
     hcf.seq_svc.clearJointAnglesOfGroup('larm')
     checkJointAnglesBetween(p1, p0)
 
 def demoSetJointAnglesSequenceOfGroup():
-    print "6. setJointAnglesOfGroup"
+    print >> sys.stderr, "9. setJointAnglesOfGroup"
     hcf.seq_svc.addJointGroup('larm', ['LARM_SHOULDER_P', 'LARM_SHOULDER_R', 'LARM_SHOULDER_Y', 'LARM_ELBOW', 'LARM_WRIST_Y', 'LARM_WRIST_P', 'LARM_WRIST_R'])
     larm_pos0 = [-0.000111, 0.31129, -0.159481, -1.57079, -0.636277, 0.0]
     larm_pos1 = [-0.000111, 0.31129, -0.159481, -0.115399, -0.636277, 0.0]
@@ -272,7 +272,7 @@ def demoSetJointAnglesSequenceOfGroup():
         p1[i+19] = larm_pos1[i]
     checkJointAngles(p1)
     # check override
-    print "   check override"
+    print >> sys.stderr, "   check override"
     hcf.seq_svc.setJointAngles(reset_pose_doc['pos'], 1.0);
     hcf.seq_svc.setJointAnglesSequenceOfGroup('larm', [larm_pos0, larm_pos1, larm_pos0], [1.0, 1.0, 5.0]);
     time.sleep(3.5)
@@ -280,7 +280,7 @@ def demoSetJointAnglesSequenceOfGroup():
     hcf.seq_svc.waitInterpolationOfGroup('larm');
     checkJointAngles(p1)
     # check clear
-    print "   check clear"
+    print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAnglesSequenceOfGroup('larm', [larm_pos0, larm_pos1, larm_pos0], [1.0, 1.0, 5.0]);
     time.sleep(3.5)
     hcf.seq_svc.clearJointAnglesOfGroup('larm')

--- a/sample/SampleRobot/samplerobot_stabilizer.py
+++ b/sample/SampleRobot/samplerobot_stabilizer.py
@@ -41,12 +41,12 @@ def calcCOP ():
             [(cop_info[1]+cop_info[1+3])/(cop_info[2]+cop_info[2+3]),(cop_info[0]+cop_info[0+3])/(cop_info[2]+cop_info[2+3])]] # total ZMP
 
 def demoGetParameter():
-    print "1. getParameter"
+    print >> sys.stderr, "1. getParameter"
     stp = hcf.st_svc.getParameter()
-    print "  getParameter() => OK"
+    print >> sys.stderr, "  getParameter() => OK"
 
 def demoSetParameter():
-    print "2. setParameter"
+    print >> sys.stderr, "2. setParameter"
     stp_org = hcf.st_svc.getParameter()
     # for tpcc
     stp_org.k_tpcc_p=[0.2, 0.2]
@@ -66,11 +66,11 @@ def demoSetParameter():
     stp = hcf.st_svc.getParameter()
     vcheck = stp.k_tpcc_p == stp_org.k_tpcc_p and stp.k_tpcc_x == stp_org.k_tpcc_x and stp.k_brot_p == stp_org.k_brot_p
     if vcheck:
-        print "  setParameter() => OK", vcheck
+        print >> sys.stderr, "  setParameter() => OK", vcheck
     assert(vcheck)
 
 def demoStartStopTPCCST ():
-    print "3. start and stop TPCC st"
+    print >> sys.stderr, "3. start and stop TPCC st"
     if hcf.pdc:
         stp = hcf.st_svc.getParameter()
         stp.st_algorithm=OpenHRP.StabilizerService.TPCC
@@ -79,13 +79,13 @@ def demoStartStopTPCCST ():
         hcf.abc_svc.goPos(0.5, 0.1, 10)
         hcf.abc_svc.waitFootSteps()
         hcf.stopStabilizer ()
-        print "  Start and Stop Stabilizer => OK"
+        print >> sys.stderr, "  Start and Stop Stabilizer => OK"
     else:
-        print "  This sample is neglected in High-gain mode simulation"
+        print >> sys.stderr, "  This sample is neglected in High-gain mode simulation"
 
 
 def demoStartStopEEFMQPST ():
-    print "4. start and stop EEFMQP st"
+    print >> sys.stderr, "4. start and stop EEFMQP st"
     if hcf.pdc:
         stp = hcf.st_svc.getParameter()
         stp.st_algorithm=OpenHRP.StabilizerService.EEFMQP
@@ -94,9 +94,9 @@ def demoStartStopEEFMQPST ():
         hcf.abc_svc.goPos(0.3, 0, 0)
         hcf.abc_svc.waitFootSteps()
         hcf.stopStabilizer ()
-        print "  Start and Stop Stabilizer => OK"
+        print >> sys.stderr, "  Start and Stop Stabilizer => OK"
     else:
-        print "  This sample is neglected in High-gain mode simulation"
+        print >> sys.stderr, "  This sample is neglected in High-gain mode simulation"
 
 def demo():
     init()


### PR DESCRIPTION
SeqのxxOfGroup系で関節長さが不適切なときに対応できてなかったので、修正しました。
https://github.com/fkanehiro/hrpsys-base/blob/master/sample/SampleRobot/samplerobot_sequence_player.py#L224
このへんのところで、左腕GROUPが７自由度なのに対し、６自由度分のベクトルを与えていて
https://github.com/fkanehiro/hrpsys-base/pull/723#issuecomment-123127848
の上段のようなエラーがでてました。
確かに最近のtravisのしっぱいろぐをよくみると、L_WRIST_Rでちょうど７自由度めのところがposition limit overで引っかかっていました。

元々playPatternOfGroupは長さチェックをしていて、setJointAnglesOfGroup, setJointAnglesSequenceOfGroupはのーちぇっくでした。
おそらくplayPatternOfGroupのほうは、seqplay.*にはCORBA系変数を持ち込まないように引き数が設計されてるようにみえたので、他の２つも同様に引き数で配列サイズをわたし、長さが違ってればfalseでかえりつつprint分がでるようにしました。

また、sample*.pyで今どこの何関数をpythonからよんでるがrostestの出力からわかるように、
sys.stderrにprint分を出力するようにしました。


これで、多分jointのdifferenceがあってエラる状況および配列が一見初期化されてないっぽいエラりかたが治るきがします。
これと別件で、https://github.com/fkanehiro/hrpsys-base/pull/723#issuecomment-123127848の下段のほうはまだ起こるのではという気もします。