### PR TITLE
try to extend the number of limbs for gait

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -169,7 +169,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     double stride_bwd_x_limit = 0.05;
     std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_y_limit << "[m], " << stride_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
     if (default_zmp_offsets.size() == 0) {
-      for (size_t i = 0; i < 2; i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
+      for (size_t i = 0; i < leg_pos.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
     }
     if (leg_offset_str.size() > 0) {
       gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, stride_fwd_x_limit/*[m]*/, stride_y_limit/*[m]*/, stride_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
@@ -540,15 +540,15 @@ void AutoBalancer::getTargetParameters()
   if (control_mode != MODE_IDLE) {
     coordinates tmp_fix_coords;
     if (!zmp_interpolator->isEmpty()) {
-      double default_zmp_offsets_output[6];
+      double default_zmp_offsets_output[leg_names.size() * 3];
       zmp_interpolator->get(default_zmp_offsets_output, true);
-      for (size_t i = 0; i < 2; i++)
+      for (size_t i = 0; i < leg_names.size(); i++)
         for (size_t j = 0; j < 3; j++)
           default_zmp_offsets[i](j) = default_zmp_offsets_output[i*3+j];
       if (DEBUGP) {
         std::cerr << "[" << m_profile.instance_name << "] default_zmp_offsets (interpolated)" << std::endl;
-        std::cerr << "[" << m_profile.instance_name << "]   rleg = " << default_zmp_offsets[0].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
-        std::cerr << "[" << m_profile.instance_name << "]   lleg = " << default_zmp_offsets[1].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
+        for (size_t i = 0; i < leg_names.size(); i++)
+            std::cerr << "[" << m_profile.instance_name << "]   " << leg_names[i] << " = " << default_zmp_offsets[i].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
       }
     }
     if ( gg_is_walking ) {

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -556,28 +556,28 @@ void AutoBalancer::getTargetParameters()
       gg_solved = gg->proc_one_tick();
       // for support leg
       coordinates sp_coords, sw_coords, tmpc;
-      for (size_t i = 0; i < gg->get_support_leg_coords_list().size(); i++) {
-        sp_coords = coordinates(gg->get_support_leg_coords_list()[i].pos,
-                                gg->get_support_leg_coords_list()[i].rot);
-        coordinates(ikp[gg->get_support_leg_list()[i]].localPos,
-                    ikp[gg->get_support_leg_list()[i]].localR).inverse_transformation(tmpc);
+      for (size_t i = 0; i < gg->get_support_legs_coords().size(); i++) {
+        sp_coords = coordinates(gg->get_support_legs_coords()[i].pos,
+                                gg->get_support_legs_coords()[i].rot);
+        coordinates(ikp[gg->get_support_legs()[i]].localPos,
+                    ikp[gg->get_support_legs()[i]].localR).inverse_transformation(tmpc);
         sp_coords.transform(tmpc);
-        ikp[gg->get_support_leg_list()[i]].target_p0 = sp_coords.pos;
-        ikp[gg->get_support_leg_list()[i]].target_r0 = sp_coords.rot;
+        ikp[gg->get_support_legs()[i]].target_p0 = sp_coords.pos;
+        ikp[gg->get_support_legs()[i]].target_r0 = sp_coords.rot;
       }
       // for swing leg
-      for (size_t i = 0; i < gg->get_swing_leg_coords_list().size(); i++) {
-        sw_coords = coordinates(gg->get_swing_leg_coords_list()[i].pos,
-                                gg->get_swing_leg_coords_list()[i].rot);
-        coordinates(ikp[gg->get_swing_leg_list()[i]].localPos,
-                    ikp[gg->get_swing_leg_list()[i]].localR).inverse_transformation(tmpc);
+      for (size_t i = 0; i < gg->get_swing_legs_coords().size(); i++) {
+        sw_coords = coordinates(gg->get_swing_legs_coords()[i].pos,
+                                gg->get_swing_legs_coords()[i].rot);
+        coordinates(ikp[gg->get_swing_legs()[i]].localPos,
+                    ikp[gg->get_swing_legs()[i]].localR).inverse_transformation(tmpc);
         sw_coords.transform(tmpc);
-        ikp[gg->get_swing_leg_list()[i]].target_p0 = sw_coords.pos;
-        ikp[gg->get_swing_leg_list()[i]].target_r0 = sw_coords.rot;
+        ikp[gg->get_swing_legs()[i]].target_p0 = sw_coords.pos;
+        ikp[gg->get_swing_legs()[i]].target_r0 = sw_coords.rot;
       }
       gg->get_swing_support_mid_coords(tmp_fix_coords);
       // TODO : assume biped
-      switch (gg->get_current_support_state_list().front()) {
+      switch (gg->get_current_support_states().front()) {
       case BOTH:
         m_contactStates.data[contact_states_index_map["rleg"]] = true;
         m_contactStates.data[contact_states_index_map["lleg"]] = true;
@@ -596,12 +596,12 @@ void AutoBalancer::getTargetParameters()
       }
       m_controlSwingSupportTime.data[contact_states_index_map["rleg"]] = gg->get_current_swing_time(0);
       m_controlSwingSupportTime.data[contact_states_index_map["lleg"]] = gg->get_current_swing_time(1);
-      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg_list().front()]].data.x = gg->get_swing_foot_zmp_offset_list().front()(0);
-      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg_list().front()]].data.y = gg->get_swing_foot_zmp_offset_list().front()(1);
-      m_limbCOPOffset[contact_states_index_map[gg->get_swing_leg_list().front()]].data.z = gg->get_swing_foot_zmp_offset_list().front()(2);
-      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg_list().front()]].data.x = gg->get_support_foot_zmp_offset_list().front()(0);
-      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg_list().front()]].data.y = gg->get_support_foot_zmp_offset_list().front()(1);
-      m_limbCOPOffset[contact_states_index_map[gg->get_support_leg_list().front()]].data.z = gg->get_support_foot_zmp_offset_list().front()(2);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_legs().front()]].data.x = gg->get_swing_foot_zmp_offsets().front()(0);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_legs().front()]].data.y = gg->get_swing_foot_zmp_offsets().front()(1);
+      m_limbCOPOffset[contact_states_index_map[gg->get_swing_legs().front()]].data.z = gg->get_swing_foot_zmp_offsets().front()(2);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_legs().front()]].data.x = gg->get_support_foot_zmp_offsets().front()(0);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_legs().front()]].data.y = gg->get_support_foot_zmp_offsets().front()(1);
+      m_limbCOPOffset[contact_states_index_map[gg->get_support_legs().front()]].data.z = gg->get_support_foot_zmp_offsets().front()(2);
     } else {
       tmp_fix_coords = fix_leg_coords;
       // double support by default
@@ -795,7 +795,7 @@ void AutoBalancer::solveLimbIK ()
   for ( std::map<std::string, ABCIKparam>::iterator it = ikp.begin(); it != ikp.end(); it++ ) {
       if (it->second.is_active && (it->first.find("leg") != std::string::npos) && it->second.manip->numJoints() == 7) {
           int i = it->second.target_link->jointId;
-          if (gg->get_swing_leg_list().front() == it->first) {
+          if (gg->get_swing_legs().front() == it->first) {
               m_robot->joint(i)->q = qrefv[i] + -1 * gg->get_foot_dif_rot_angle();
           } else {
               m_robot->joint(i)->q = qrefv[i];
@@ -892,8 +892,8 @@ void AutoBalancer::startWalking ()
   }
   {
     Guard guard(m_mutex);
-    std::string init_support_leg (gg->get_footstep_front_leg_list().front() == "rleg" ? "lleg" : "rleg");
-    std::string init_swing_leg (gg->get_footstep_front_leg_list().front());
+    std::string init_support_leg (gg->get_footstep_front_legs().front() == "rleg" ? "lleg" : "rleg");
+    std::string init_swing_leg (gg->get_footstep_front_legs().front());
     gg->set_default_zmp_offsets(default_zmp_offsets);
     gg->initialize_gait_parameter(ref_cog, boost::assign::list_of(ikp[init_support_leg].target_end_coords), boost::assign::list_of(ikp[init_swing_leg].target_end_coords));
   }
@@ -908,7 +908,7 @@ void AutoBalancer::stopWalking ()
 {
   mid_coords(fix_leg_coords, 0.5, ikp["rleg"].target_end_coords, ikp["lleg"].target_end_coords);
   fixLegToCoords(fix_leg_coords.pos, fix_leg_coords.rot);
-  gg->clear_footstep_node_list_list();
+  gg->clear_footstep_nodes_list();
   if (return_control_mode == MODE_IDLE) stopABCparam();
   gg_is_walking = false;
 }
@@ -944,7 +944,7 @@ void AutoBalancer::waitABCTransition()
 bool AutoBalancer::goPos(const double& x, const double& y, const double& th)
 {
   if ( !gg_is_walking && !is_stop_mode) {
-    gg->go_pos_param_2_footstep_list_list(x, y, th,
+    gg->go_pos_param_2_footstep_nodes_list(x, y, th,
                                      (y > 0 ? ikp["rleg"].target_end_coords : ikp["lleg"].target_end_coords),
                                      (y > 0 ? ikp["lleg"].target_end_coords : ikp["rleg"].target_end_coords),
                                      (y > 0 ? RLEG : LLEG));
@@ -1053,18 +1053,18 @@ bool AutoBalancer::setFootStepsWithParam(const OpenHRP::AutoBalancerService::Foo
         return false;
     }
     std::cerr << "[" << m_profile.instance_name << "] print footsteps " << std::endl;
-    std::vector< std::vector<step_node> > fnll;
+    std::vector< std::vector<step_node> > fnsl;
     for (size_t i = 0; i < fs_vec.size(); i++) {
         if (!(gg_is_walking && i == 0)) // If initial footstep, e.g., not walking, pass user-defined footstep list. If walking, pass cdr footsteps in order to neglect initial double support leg.
-            fnll.push_back(boost::assign::list_of(step_node(leg_name_vec[i], fs_vec[i], sps[i].step_height, sps[i].step_time, sps[i].toe_angle, sps[i].heel_angle)));
+            fnsl.push_back(boost::assign::list_of(step_node(leg_name_vec[i], fs_vec[i], sps[i].step_height, sps[i].step_time, sps[i].toe_angle, sps[i].heel_angle)));
     }
     if (gg_is_walking) {
         std::cerr << "[" << m_profile.instance_name << "]  Set overwrite footsteps" << std::endl;
-        gg->set_overwrite_foot_steps(fnll);
+        gg->set_overwrite_foot_steps_list(fnsl);
         gg->set_overwrite_foot_step_index(overwrite_fs_idx);
     } else {
         std::cerr << "[" << m_profile.instance_name << "]  Set normal footsteps" << std::endl;
-        gg->set_foot_steps_list(fnll);
+        gg->set_foot_steps_list(fnsl);
         startWalking();
     }
     return true;
@@ -1283,17 +1283,17 @@ bool AutoBalancer::getFootstepParam(OpenHRP::AutoBalancerService::FootstepParam&
   }
   copyRatscoords2Footstep(i_param.rleg_coords, leg_coords[0]);
   copyRatscoords2Footstep(i_param.lleg_coords, leg_coords[1]);
-  copyRatscoords2Footstep(i_param.support_leg_coords, gg->get_support_leg_coords_list().front());
-  copyRatscoords2Footstep(i_param.swing_leg_coords, gg->get_swing_leg_coords_list().front());
-  copyRatscoords2Footstep(i_param.swing_leg_src_coords, gg->get_swing_leg_src_coords_list().front());
-  copyRatscoords2Footstep(i_param.swing_leg_dst_coords, gg->get_swing_leg_dst_coords_list().front());
-  copyRatscoords2Footstep(i_param.dst_foot_midcoords, gg->get_dst_foot_midcoords_list().front());
-  if (gg->get_support_leg_list().front() == "rleg") {
+  copyRatscoords2Footstep(i_param.support_leg_coords, gg->get_support_legs_coords().front());
+  copyRatscoords2Footstep(i_param.swing_leg_coords, gg->get_swing_legs_coords().front());
+  copyRatscoords2Footstep(i_param.swing_leg_src_coords, gg->get_swing_legs_src_coords().front());
+  copyRatscoords2Footstep(i_param.swing_leg_dst_coords, gg->get_swing_legs_dst_coords().front());
+  copyRatscoords2Footstep(i_param.dst_foot_midcoords, gg->get_dst_feet_midcoords().front());
+  if (gg->get_support_legs().front() == "rleg") {
     i_param.support_leg = OpenHRP::AutoBalancerService::RLEG;
   } else {
     i_param.support_leg = OpenHRP::AutoBalancerService::LLEG;
   }
-  switch ( gg->get_current_support_state_list().front() ) {
+  switch ( gg->get_current_support_states().front() ) {
   case BOTH: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::BOTH; break;
   case RLEG: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::RLEG; break;
   case LLEG: i_param.support_leg_with_both = OpenHRP::AutoBalancerService::LLEG; break;
@@ -1370,12 +1370,12 @@ bool AutoBalancer::getRemainingFootstepSequence(OpenHRP::AutoBalancerService::Fo
     std::cerr << "[" << m_profile.instance_name << "] getRemainingFootstepSequence" << std::endl;
     o_footstep = new OpenHRP::AutoBalancerService::FootstepSequence;
     if (gg_is_walking) {
-      std::vector< std::vector<step_node> > fsll = gg->get_remaining_footstep_list_list();
+        std::vector< std::vector<step_node> > fsnl = gg->get_remaining_footstep_nodes_list();
         o_current_fs_idx = gg->get_footstep_index();
-        o_footstep->length(fsll.size());
-        for (size_t i = 0; i < fsll.size(); i++) {
-          o_footstep[i].leg = (fsll[i].front().l_r==RLEG?"rleg":"lleg");
-          copyRatscoords2Footstep(o_footstep[i], fsll[i].front().worldcoords);
+        o_footstep->length(fsnl.size());
+        for (size_t i = 0; i < fsnl.size(); i++) {
+            o_footstep[i].leg = (fsnl[i].front().l_r==RLEG?"rleg":"lleg");
+            copyRatscoords2Footstep(o_footstep[i], fsnl[i].front().worldcoords);
         }
     }
 };
@@ -1436,9 +1436,9 @@ hrp::Vector3 AutoBalancer::calc_vel_from_hand_error (const coordinates& tmp_fix_
 {
   if (graspless_manip_mode) {
     hrp::Vector3 dp,dr;
-    coordinates ref_hand_coords(gg->get_dst_foot_midcoords_list().front()), act_hand_coords;
+    coordinates ref_hand_coords(gg->get_dst_feet_midcoords().front()), act_hand_coords;
     ref_hand_coords.transform(graspless_manip_reference_trans_coords); // desired arm coords
-    hrp::Vector3 foot_pos(gg->get_dst_foot_midcoords_list().front().pos);
+    hrp::Vector3 foot_pos(gg->get_dst_feet_midcoords().front().pos);
     if ( graspless_manip_arm == "arms" ) {
       // act_hand_coords.pos = (target_coords["rarm"].pos + target_coords["larm"].pos) / 2.0;
       // vector3 cur_y(target_coords["larm"].pos - target_coords["rarm"].pos);
@@ -1458,7 +1458,7 @@ hrp::Vector3 AutoBalancer::calc_vel_from_hand_error (const coordinates& tmp_fix_
     dp = act_hand_coords.pos - ref_hand_coords.pos
         + dr.cross(hrp::Vector3(foot_pos - act_hand_coords.pos));
     dp(2) = 0;
-    hrp::Matrix33 foot_mt(gg->get_dst_foot_midcoords_list().front().rot.transpose());
+    hrp::Matrix33 foot_mt(gg->get_dst_feet_midcoords().front().rot.transpose());
     //alias(dp) = foot_mt * dp;
     hrp::Vector3 dp2 = foot_mt * dp;
     //alias(dr) = foot_mt * dr;

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -34,86 +34,86 @@ namespace rats
     ret = dvm * cycloid_point + start + uz;
   };
 
-    std::vector<leg_type> get_support_leg_type_list_from_footstep_node_list(const std::vector<step_node>& fnl) {
-        if (fnl.size() == 1) {
-            std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG);
-            boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == fnl.front().l_r));
-            return tmp_spll;
-        } else if (fnl.size() == 2) {
-            std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
-            boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == fnl.at(0).l_r || boost::lambda::_1 == fnl.at(1).l_r));
-            return tmp_spll;
+    std::vector<leg_type> get_support_leg_types_from_footstep_nodes(const std::vector<step_node>& fns) {
+        if (fns.size() == 1) {
+            std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG);
+            boost::remove_erase_if(tmp_spls, (boost::lambda::_1 == fns.front().l_r));
+            return tmp_spls;
+        } else if (fns.size() == 2) {
+            std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
+            boost::remove_erase_if(tmp_spls, (boost::lambda::_1 == fns.at(0).l_r || boost::lambda::_1 == fns.at(1).l_r));
+            return tmp_spls;
         } else {
             std::cerr << "not implemented yet " << std::endl;
         }
     };
 
   /* member function implementation for refzmp_generator */
-  void refzmp_generator::push_refzmp_from_footstep_list_for_dual (const std::vector<step_node>& fnl,
-                                                                  const std::vector<coordinates>& _support_leg_coords_list,
-                                                                  const std::vector<coordinates>& _swing_leg_coords_list)
+  void refzmp_generator::push_refzmp_from_footstep_nodes_for_dual (const std::vector<step_node>& fns,
+                                                                  const std::vector<coordinates>& _support_legs_coords,
+                                                                  const std::vector<coordinates>& _swing_legs_coords)
   {
     hrp::Vector3 rzmp;
     std::vector<hrp::Vector3> dzl;
     hrp::Vector3 ret_zmp;
     hrp::Vector3 tmp_zero = hrp::Vector3::Zero();
-    std::vector<leg_type> spll = get_support_leg_type_list_from_footstep_node_list(fnl);
-    for (size_t i = 0, len = _support_leg_coords_list.size(); i < len; i++) {
-      dzl.push_back(_support_leg_coords_list.at(i).rot * default_zmp_offsets[spll.at(i)] + _support_leg_coords_list.at(i).pos);
+    std::vector<leg_type> spls = get_support_leg_types_from_footstep_nodes(fns);
+    for (size_t i = 0, len = _support_legs_coords.size(); i < len; i++) {
+      dzl.push_back(_support_legs_coords.at(i).rot * default_zmp_offsets[spls.at(i)] + _support_legs_coords.at(i).pos);
     }
-    for (size_t i = 0, len = _swing_leg_coords_list.size(); i < len; i++) {
-      dzl.push_back(_swing_leg_coords_list.at(i).rot * default_zmp_offsets[fnl.at(i).l_r] + _swing_leg_coords_list.at(i).pos);
+    for (size_t i = 0, len = _swing_legs_coords.size(); i < len; i++) {
+      dzl.push_back(_swing_legs_coords.at(i).rot * default_zmp_offsets[fns.at(i).l_r] + _swing_legs_coords.at(i).pos);
     }
     rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
     refzmp_cur_list.push_back( rzmp );
-    std::vector<hrp::Vector3> foot_x_axis_list;
-    for (size_t i = 0; i < _swing_leg_coords_list.size(); i++) {
-        foot_x_axis_list.push_back( hrp::Vector3(_swing_leg_coords_list.at(i).rot * hrp::Vector3::UnitX()) );
+    std::vector<hrp::Vector3> foot_x_axises;
+    for (size_t i = 0; i < _swing_legs_coords.size(); i++) {
+        foot_x_axises.push_back( hrp::Vector3(_swing_legs_coords.at(i).rot * hrp::Vector3::UnitX()) );
     }
-    foot_x_axis_list_list.push_back(foot_x_axis_list);
-    std::vector<leg_type> swing_leg_list;
-    for (size_t i = 0; i < fnl.size(); i++) {
-        swing_leg_list.push_back(fnl.at(i).l_r);
+    foot_x_axises_list.push_back(foot_x_axises);
+    std::vector<leg_type> swing_legs;
+    for (size_t i = 0; i < fns.size(); i++) {
+        swing_legs.push_back(fns.at(i).l_r);
     }
-    swing_leg_list_list.push_back( swing_leg_list );
-    step_count_list.push_back(static_cast<size_t>(fnl.front().step_time/dt));
-    //std::cerr << "double " << (fnl[fs_index].l_r==RLEG?LLEG:RLEG) << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
+    swing_legs_list.push_back( swing_legs );
+    step_count_list.push_back(static_cast<size_t>(fns.front().step_time/dt));
+    //std::cerr << "double " << (fns[fs_index].l_r==RLEG?LLEG:RLEG) << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::push_refzmp_from_footstep_list_for_single (const std::vector<step_node>& fnl, const std::vector<coordinates>& _support_leg_coords_list)
+  void refzmp_generator::push_refzmp_from_footstep_nodes_for_single (const std::vector<step_node>& fns, const std::vector<coordinates>& _support_legs_coords)
   {
-    // support leg = prev fnl l_r
-    // swing leg = fnl l_r
+    // support leg = prev fns l_r
+    // swing leg = fns l_r
     hrp::Vector3 rzmp, tmp_zero=hrp::Vector3::Zero();
     std::vector<hrp::Vector3> dzl;
 
-    std::vector<leg_type> spll = get_support_leg_type_list_from_footstep_node_list(fnl);
-    for (size_t i = 0, len = _support_leg_coords_list.size(); i < len; i++) {
-      dzl.push_back(_support_leg_coords_list.at(i).rot * default_zmp_offsets[spll.at(i)] + _support_leg_coords_list.at(i).pos);
+    std::vector<leg_type> spls = get_support_leg_types_from_footstep_nodes(fns);
+    for (size_t i = 0, len = _support_legs_coords.size(); i < len; i++) {
+      dzl.push_back(_support_legs_coords.at(i).rot * default_zmp_offsets[spls.at(i)] + _support_legs_coords.at(i).pos);
     }
     rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
     refzmp_cur_list.push_back( rzmp );
-    std::vector<hrp::Vector3> foot_x_axis_list;
-    for (size_t i = 0; i < _support_leg_coords_list.size(); i++) {
-        foot_x_axis_list.push_back( hrp::Vector3(_support_leg_coords_list.at(i).rot * hrp::Vector3::UnitX()) );
+    std::vector<hrp::Vector3> foot_x_axises;
+    for (size_t i = 0; i < _support_legs_coords.size(); i++) {
+        foot_x_axises.push_back( hrp::Vector3(_support_legs_coords.at(i).rot * hrp::Vector3::UnitX()) );
     }
-    foot_x_axis_list_list.push_back(foot_x_axis_list);
-    std::vector<leg_type> swing_leg_list;
-    for (size_t i = 0; i< fnl.size(); i++) {
-        swing_leg_list.push_back(fnl.at(i).l_r);
+    foot_x_axises_list.push_back(foot_x_axises);
+    std::vector<leg_type> swing_legs;
+    for (size_t i = 0; i< fns.size(); i++) {
+        swing_legs.push_back(fns.at(i).l_r);
     }
-    swing_leg_list_list.push_back( swing_leg_list );
-    step_count_list.push_back(static_cast<size_t>(fnl.front().step_time/dt));
-    //std::cerr << "single " << fnl[fs_index-1].l_r << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
+    swing_legs_list.push_back( swing_legs );
+    step_count_list.push_back(static_cast<size_t>(fns.front().step_time/dt));
+    //std::cerr << "single " << fns[fs_index-1].l_r << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offset_list, const double default_double_support_ratio, const double default_double_support_static_ratio) const
+  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const
   {
     size_t cnt = one_step_count - refzmp_count; // current counter (0 -> one_step_count)
     size_t double_support_count_half = (0.5 * default_double_support_ratio) * one_step_count;
     size_t double_support_static_count_half = (0.5 * default_double_support_static_ratio) * one_step_count;
-    for (size_t i = 0; i < swing_leg_list_list[refzmp_index].size(); i++) {
-        swing_foot_zmp_offset_list.push_back(default_zmp_offsets[swing_leg_list_list[refzmp_index].at(i)]);
+    for (size_t i = 0; i < swing_legs_list[refzmp_index].size(); i++) {
+        swing_foot_zmp_offsets.push_back(default_zmp_offsets[swing_legs_list[refzmp_index].at(i)]);
     }
     double zmp_diff = 0.0; // difference between total swing_foot_zmp_offset and default_zmp_offset
     //if (cnt==0) std::cerr << "z " << refzmp_index << " " << refzmp_cur_list.size() << " " << fs_index << " " << (refzmp_index == refzmp_cur_list.size()-2) << " " << is_final_double_support_set << std::endl;
@@ -123,19 +123,19 @@ namespace rats
         !(is_start_double_support_phase() || is_end_double_support_phase())) { // Do not use toe heel zmp transition during start and end double support period because there is no swing foot
         if (thp_ptr->is_between_phases(cnt, SOLE0)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt+1, SOLE0);
-            swing_foot_zmp_offset_list.front()(0) = (1-ratio)*swing_foot_zmp_offset_list.front()(0) + ratio*toe_zmp_offset_x;
+            swing_foot_zmp_offsets.front()(0) = (1-ratio)*swing_foot_zmp_offsets.front()(0) + ratio*toe_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, HEEL2SOLE, SOLE2)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt, HEEL2SOLE, SOLE2);
-            swing_foot_zmp_offset_list.front()(0) = ratio*swing_foot_zmp_offset_list.front()(0) + (1-ratio)*heel_zmp_offset_x;
+            swing_foot_zmp_offsets.front()(0) = ratio*swing_foot_zmp_offsets.front()(0) + (1-ratio)*heel_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE0, SOLE2TOE)) {
-            swing_foot_zmp_offset_list.front()(0) = toe_zmp_offset_x;
+            swing_foot_zmp_offsets.front()(0) = toe_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE2HEEL, HEEL2SOLE)) {
-            swing_foot_zmp_offset_list.front()(0) = heel_zmp_offset_x;
+            swing_foot_zmp_offsets.front()(0) = heel_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE2TOE, SOLE2HEEL)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt, SOLE2TOE, SOLE2HEEL);
-            swing_foot_zmp_offset_list.front()(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
+            swing_foot_zmp_offsets.front()(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
         }
-        zmp_diff = swing_foot_zmp_offset_list.front()(0)-default_zmp_offsets[swing_leg_list_list[refzmp_index].front()](0);
+        zmp_diff = swing_foot_zmp_offsets.front()(0)-default_zmp_offsets[swing_legs_list[refzmp_index].front()](0);
         if ((is_second_phase() && ( cnt < double_support_count_half )) ||
             (is_second_last_phase() && ( cnt > one_step_count - double_support_count_half ))) {
             // "* 0.5" is for double supprot period
@@ -148,21 +148,21 @@ namespace rats
       ret = refzmp_cur_list[refzmp_index];
     } else if ( cnt < double_support_static_count_half ) { // Start double support static period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
-      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list_list[refzmp_index-1].front();
+      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axises_list[refzmp_index-1].front();
       double ratio = (is_second_phase()?1.0:0.5); 
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_count - double_support_static_count_half ) { // End double support static period
-      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list_list[refzmp_index+1].front();
+      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axises_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = (is_second_last_phase()?1.0:0.5);
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else if ( cnt < double_support_count_half ) { // Start double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
-      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list_list[refzmp_index-1].front();
+      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axises_list[refzmp_index-1].front();
       double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (double_support_count_half-cnt);
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_count - double_support_count_half ) { // End double support period
-        hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list_list[refzmp_index+1].front();
+      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axises_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (cnt - 1 - (one_step_count - double_support_count_half));
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
@@ -171,7 +171,7 @@ namespace rats
     }
   };
 
-  void refzmp_generator::update_refzmp (const std::vector< std::vector<step_node> >& fnll)
+  void refzmp_generator::update_refzmp (const std::vector< std::vector<step_node> >& fnsl)
   {
     if ( 1 <= refzmp_count ) {
       refzmp_count--;
@@ -183,10 +183,10 @@ namespace rats
   };
 
   /* member function implementation for leg_coords_generator */
-  void leg_coords_generator::calc_current_swing_leg_coords_list (std::vector<coordinates>& ret_list, const double step_height, const double _current_toe_angle, const double _current_heel_angle)
+  void leg_coords_generator::calc_current_swing_legs_coords (std::vector<coordinates>& rets, const double step_height, const double _current_toe_angle, const double _current_heel_angle)
   {
-    for (std::vector<coordinates>::iterator it1 = swing_leg_src_coords_list.begin(), it2 = swing_leg_dst_coords_list.begin();
-         it1 != swing_leg_src_coords_list.end() && it2 != swing_leg_dst_coords_list.end();
+    for (std::vector<coordinates>::iterator it1 = swing_legs_src_coords.begin(), it2 = swing_legs_dst_coords.begin();
+         it1 != swing_legs_src_coords.end() && it2 != swing_legs_dst_coords.end();
          it1++, it2++) {
       coordinates ret;
       switch (default_orbit_type) {
@@ -213,7 +213,7 @@ namespace rats
       if (std::fabs(step_height) > 1e-3*10) {
         modif_foot_coords_for_toe_heel_phase(ret, _current_toe_angle, _current_heel_angle);
       }
-      ret_list.push_back(ret);
+      rets.push_back(ret);
     }
   };
 
@@ -251,8 +251,8 @@ namespace rats
       swing_ratio = static_cast<double>(current_swing_count-support_len/2)/swing_len;
       //std::cerr << "gp " << swing_ratio << " " << swing_rot_ratio << std::endl;
     }
-    current_swing_time[support_leg_list.front()] = (lcg_count + 0.5 * default_double_support_ratio * next_one_step_count) * dt;
-    current_swing_time[support_leg_list.front()==RLEG ? LLEG : RLEG] = tmp_current_swing_time;
+    current_swing_time[support_legs.front()] = (lcg_count + 0.5 * default_double_support_ratio * next_one_step_count) * dt;
+    current_swing_time[support_legs.front()==RLEG ? LLEG : RLEG] = tmp_current_swing_time;
     //std::cerr << "sl " << support_leg << " " << current_swing_time[support_leg==RLEG?0:1] << " " << current_swing_time[support_leg==RLEG?1:0] << " " << tmp_current_swing_time << " " << lcg_count << std::endl;
   };
 
@@ -349,52 +349,52 @@ namespace rats
     cdktg.get_trajectory_point(ret.pos, hrp::Vector3(start.pos), hrp::Vector3(goal.pos), height);
   };
 
-  void leg_coords_generator::update_leg_coords (const std::vector< std::vector<step_node> >& fnll, const double default_double_support_ratio)
+  void leg_coords_generator::update_legs_coords (const std::vector< std::vector<step_node> >& fnsl, const double default_double_support_ratio)
   {
     if (!foot_ratio_interpolator->isEmpty()) {
         foot_ratio_interpolator->get(&foot_midcoords_ratio, true);
     }
 
     // Get current swing coords, support coords, and support leg parameters
-    size_t current_footstep_index = (footstep_index < fnll.size() - 1 ? footstep_index : fnll.size()-1);
-    swing_leg_dst_coords_list.clear();
-    for (size_t i = 0; i < fnll[current_footstep_index].size(); i++) {
-        swing_leg_dst_coords_list.push_back(fnll[current_footstep_index].at(i).worldcoords);
+    size_t current_footstep_index = (footstep_index < fnsl.size() - 1 ? footstep_index : fnsl.size()-1);
+    swing_legs_dst_coords.clear();
+    for (size_t i = 0; i < fnsl[current_footstep_index].size(); i++) {
+        swing_legs_dst_coords.push_back(fnsl[current_footstep_index].at(i).worldcoords);
     }
-    support_leg_list = get_support_leg_type_list_from_footstep_node_list(fnll[current_footstep_index]);
+    support_legs = get_support_leg_types_from_footstep_nodes(fnsl[current_footstep_index]);
     if (footstep_index != 0) { // If not initial step, support_leg_coords is previous swing_leg_dst_coords
-        support_leg_coords_list = support_leg_coords_list_list[current_footstep_index];
+        support_legs_coords = support_legs_coords_list[current_footstep_index];
     }
     if (current_footstep_index > 0) {
-      if (fnll[current_footstep_index].front().l_r == fnll[current_footstep_index-1].front().l_r) {
-            swing_leg_src_coords_list = swing_leg_dst_coords_list_list[current_footstep_index-1];
+      if (fnsl[current_footstep_index].front().l_r == fnsl[current_footstep_index-1].front().l_r) {
+            swing_legs_src_coords = swing_legs_dst_coords_list[current_footstep_index-1];
         } else {
-            swing_leg_src_coords_list = support_leg_coords_list_list[current_footstep_index-1];
+            swing_legs_src_coords = support_legs_coords_list[current_footstep_index-1];
         }
     }
 
     calc_ratio_from_double_support_ratio(default_double_support_ratio);
-    swing_leg_coords_list.clear();
-    calc_current_swing_leg_coords_list(swing_leg_coords_list, current_step_height, current_toe_angle, current_heel_angle);
+    swing_legs_coords.clear();
+    calc_current_swing_legs_coords(swing_legs_coords, current_step_height, current_toe_angle, current_heel_angle);
     if ( 1 <= lcg_count ) {
       lcg_count--;
     } else {
       //std::cerr << "gp " << footstep_index << std::endl;
-      if (footstep_index < fnll.size() - 1) {
+      if (footstep_index < fnsl.size() - 1) {
         footstep_index++;
       }
-      if (footstep_index < fnll.size() - 1) {
-        current_step_height = fnll[footstep_index].front().step_height;
-        current_toe_angle = fnll[footstep_index].front().toe_angle;
-        current_heel_angle = fnll[footstep_index].front().heel_angle;
+      if (footstep_index < fnsl.size() - 1) {
+        current_step_height = fnsl[footstep_index].front().step_height;
+        current_toe_angle = fnsl[footstep_index].front().toe_angle;
+        current_heel_angle = fnsl[footstep_index].front().heel_angle;
       } else {
         current_step_height = current_toe_angle = current_heel_angle = 0.0;
       }
-      if (footstep_index < fnll.size()) {
-        one_step_count = static_cast<size_t>(fnll[footstep_index].front().step_time/dt);
+      if (footstep_index < fnsl.size()) {
+        one_step_count = static_cast<size_t>(fnsl[footstep_index].front().step_time/dt);
       }
-      if (footstep_index + 1 < fnll.size()) {
-        next_one_step_count = static_cast<size_t>(fnll[footstep_index+1].front().step_time/dt);
+      if (footstep_index + 1 < fnsl.size()) {
+        next_one_step_count = static_cast<size_t>(fnsl[footstep_index+1].front().step_time/dt);
       }
       lcg_count = one_step_count;
       rdtg.reset(one_step_count, default_double_support_ratio);
@@ -407,81 +407,81 @@ namespace rats
 
   /* member function implementation for gait_generator */
   void gait_generator::initialize_gait_parameter (const hrp::Vector3& cog,
-                                                  const std::vector<coordinates>& initial_support_leg_coords_list,
-                                                  const std::vector<coordinates>& initial_swing_leg_dst_coords_list,
+                                                  const std::vector<coordinates>& initial_support_legs_coords,
+                                                  const std::vector<coordinates>& initial_swing_legs_dst_coords,
                                                   const double delay)
   {
     /* clear all gait_parameter */
-    size_t one_step_len = footstep_node_list_list[0][0].step_time / dt;
+    size_t one_step_len = footstep_nodes_list[0][0].step_time / dt;
     finalize_count = 0;
-    for (size_t i = 0; i < footstep_node_list_list[0].size(); i++) {
-      footstep_node_list_list[0][i].worldcoords = initial_swing_leg_dst_coords_list[i];
+    for (size_t i = 0; i < footstep_nodes_list[0].size(); i++) {
+      footstep_nodes_list[0][i].worldcoords = initial_swing_legs_dst_coords[i];
     }
     rg.reset(one_step_len);
-    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list.front(), initial_support_leg_coords_list, initial_swing_leg_dst_coords_list);
+    rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list.front(), initial_support_legs_coords, initial_swing_legs_dst_coords);
     if ( preview_controller_ptr != NULL ) {
       delete preview_controller_ptr;
       preview_controller_ptr = NULL;
     }
     //preview_controller_ptr = new preview_dynamics_filter<preview_control>(dt, cog(2) - refzmp_cur_list[0](2), refzmp_cur_list[0]);
     preview_controller_ptr = new preview_dynamics_filter<extended_preview_control>(dt, cog(2) - rg.get_refzmp_cur()(2), rg.get_refzmp_cur(), gravitational_acceleration);
-    lcg.reset(one_step_len, footstep_node_list_list[1][0].step_time/dt, initial_swing_leg_dst_coords_list, initial_swing_leg_dst_coords_list, initial_support_leg_coords_list, default_double_support_ratio);
+    lcg.reset(one_step_len, footstep_nodes_list[1].front().step_time/dt, initial_swing_legs_dst_coords, initial_swing_legs_dst_coords, initial_support_legs_coords, default_double_support_ratio);
     /* make another */
-    lcg.set_swing_support_list_list(footstep_node_list_list);
-    for (size_t i = 1; i < footstep_node_list_list.size()-1; i++) {
-        rg.push_refzmp_from_footstep_list_for_single(footstep_node_list_list[i], lcg.get_support_leg_coords_list_idx(i));
+    lcg.set_swings_supports_list(footstep_nodes_list);
+    for (size_t i = 1; i < footstep_nodes_list.size()-1; i++) {
+        rg.push_refzmp_from_footstep_nodes_for_single(footstep_nodes_list[i], lcg.get_support_legs_coords_idx(i));
     }
-    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[footstep_node_list_list.size()-1],
-                                               lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
-                                               lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
+    rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list[footstep_nodes_list.size()-1],
+                                               lcg.get_swing_legs_dst_coords_idx(footstep_nodes_list.size()-1),
+                                               lcg.get_support_legs_coords_idx(footstep_nodes_list.size()-1));
     emergency_flg = IDLING;
   };
 
   bool gait_generator::proc_one_tick ()
   {
     hrp::Vector3 rzmp;
-    std::vector<hrp::Vector3> sfzo_list;
-    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo_list, default_double_support_ratio, default_double_support_static_ratio);
+    std::vector<hrp::Vector3> sfzos;
+    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
     if (!refzmp_exist_p) {
       finalize_count++;
       rzmp = prev_que_rzmp;
-      sfzo_list = prev_que_sfzo_list;
+      sfzos = prev_que_sfzos;
     } else {
       prev_que_rzmp = rzmp;
-      prev_que_sfzo_list = sfzo_list;
+      prev_que_sfzos = sfzos;
     }
-    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset_list.front(), rzmp, sfzo_list.front(), (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
+    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets.front(), rzmp, sfzos.front(), (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
     /* update refzmp */
-    if ( lcg.get_lcg_count() == static_cast<size_t>(footstep_node_list_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1 ) { // Almost middle of step time
+    if ( lcg.get_lcg_count() == static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1 ) { // Almost middle of step time
       if (velocity_mode_flg != VEL_IDLING && lcg.get_footstep_index() > 0) {
         std::vector< std::vector<coordinates> > cv;
         calc_next_coords_velocity_mode(cv, lcg.get_footstep_index() + 1);
         if (velocity_mode_flg == VEL_ENDING) velocity_mode_flg = VEL_IDLING;
         std::vector<leg_type> cur_leg;
-        for (size_t i = 0; i < footstep_node_list_list[lcg.get_footstep_index()].size(); i++) {
-            cur_leg.push_back(footstep_node_list_list[lcg.get_footstep_index()].at(i).l_r);
+        for (size_t i = 0; i < footstep_nodes_list[lcg.get_footstep_index()].size(); i++) {
+            cur_leg.push_back(footstep_nodes_list[lcg.get_footstep_index()].at(i).l_r);
         }
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[0][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front(), cv[1][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[2][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
-        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
-        overwrite_footstep_node_list_list.clear();
-      } else if ( !overwrite_footstep_node_list_list.empty() && // If overwrite_footstep_node_list exists
-                  (lcg.get_footstep_index() < footstep_node_list_list.size()-1) &&  // If overwrite_footstep_node_list is specified and current footstep is not last footstep.
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[0][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg.front(), cv[1][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[2][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_refzmp_queue(overwrite_footstep_nodes_list);
+        overwrite_footstep_nodes_list.clear();
+      } else if ( !overwrite_footstep_nodes_list.empty() && // If overwrite_footstep_node_list exists
+                  (lcg.get_footstep_index() < footstep_nodes_list.size()-1) &&  // If overwrite_footstep_node_list is specified and current footstep is not last footstep.
                   get_overwritable_index() == overwrite_footstep_index ) {
-        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
-        overwrite_footstep_node_list_list.clear();
+        overwrite_refzmp_queue(overwrite_footstep_nodes_list);
+        overwrite_footstep_nodes_list.clear();
       } else if (emergency_flg == EMERGENCY_STOP && lcg.get_footstep_index() > 0) {
-        leg_type cur_leg = footstep_node_list_list[lcg.get_footstep_index()].front().l_r;
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg, footstep_node_list_list[lcg.get_footstep_index()].front().worldcoords, 0, default_step_time, 0, 0)));
-        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
-        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
-        overwrite_footstep_node_list_list.clear();
+        leg_type cur_leg = footstep_nodes_list[lcg.get_footstep_index()].front().l_r;
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_nodes_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg, footstep_nodes_list[lcg.get_footstep_index()].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_footstep_nodes_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_nodes_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_refzmp_queue(overwrite_footstep_nodes_list);
+        overwrite_footstep_nodes_list.clear();
         emergency_flg = STOPPING;
       }
     }
-    rg.update_refzmp(footstep_node_list_list);
+    rg.update_refzmp(footstep_nodes_list);
     // { // debug
     //   double cart_zmp[3];
     //   preview_controller_ptr->get_cart_zmp(cart_zmp);
@@ -494,7 +494,7 @@ namespace rats
 
     /* update swing_leg_coords, support_leg_coords */
     if ( solved ) {
-      lcg.update_leg_coords(footstep_node_list_list, default_double_support_ratio);
+      lcg.update_legs_coords(footstep_nodes_list, default_double_support_ratio);
     } else if (finalize_count>0) {
       lcg.clear_interpolators();
     }
@@ -505,9 +505,9 @@ namespace rats
    *  x, y and theta are simply divided by using stride params
    *  unit system -> x [mm], y [mm], theta [deg]
    */
-  void gait_generator::go_pos_param_2_footstep_list_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
-                                       const coordinates& initial_support_coords, const coordinates& initial_swing_src_coords,
-                                       const leg_type initial_support_leg)
+  void gait_generator::go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
+                                                           const coordinates& initial_support_coords, const coordinates& initial_swing_src_coords,
+                                                           const leg_type initial_support_leg)
   {
     coordinates foot_midcoords; /* foot_midcoords is modified during loop */
     mid_coords(foot_midcoords, 0.5, initial_support_coords, initial_swing_src_coords);
@@ -526,9 +526,9 @@ namespace rats
     std::cerr << goal_foot_midcoords.rot.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
 
     /* initialize */
-    clear_footstep_node_list_list();
+    clear_footstep_nodes_list();
     // For initial double support period
-    footstep_node_list_list.push_back(boost::assign::list_of(step_node(initial_support_leg, initial_support_coords, 0, default_step_time, 0, 0)));
+    footstep_nodes_list.push_back(boost::assign::list_of(step_node(initial_support_leg, initial_support_coords, 0, default_step_time, 0, 0)));
 
     /* footstep generation loop */
     hrp::Vector3 dp, dr;
@@ -538,45 +538,45 @@ namespace rats
     while ( !(eps_eq(dp.norm(), 0.0, 1e-3*0.1) && eps_eq(dr.norm(), 0.0, deg2rad(0.5))) ) {
       set_velocity_param(dp(0)/default_step_time, dp(1)/default_step_time, rad2deg(dr(2))/default_step_time);
       append_footstep_list_velocity_mode();
-      foot_midcoords = footstep_node_list_list.back().front().worldcoords;
-      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list_list.back().front().l_r] * -1.0);
+      foot_midcoords = footstep_nodes_list.back().front().worldcoords;
+      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_nodes_list.back().front().l_r] * -1.0);
       foot_midcoords.difference(dp, dr, goal_foot_midcoords);
       dp = foot_midcoords.rot.transpose() * dp;
       dr = foot_midcoords.rot.transpose() * dr;
     }
     for (size_t i = 0; i < optional_go_pos_finalize_footstep_num; i++) {
-        append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
+        append_go_pos_step_node(foot_midcoords, (footstep_nodes_list.back().front().l_r == RLEG ? LLEG : RLEG));
     }
 
     /* finalize */
     //   Align last foot
-    append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
+    append_go_pos_step_node(foot_midcoords, (footstep_nodes_list.back().front().l_r == RLEG ? LLEG : RLEG));
     //   Check align
-    coordinates final_step_coords1 = footstep_node_list_list[footstep_node_list_list.size()-2].front().worldcoords; // Final coords in footstep_node_list
+    coordinates final_step_coords1 = footstep_nodes_list[footstep_nodes_list.size()-2].front().worldcoords; // Final coords in footstep_node_list
     coordinates final_step_coords2 = foot_midcoords; // Final coords calculated from foot_midcoords + translate pos
-    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list_list[footstep_node_list_list.size()-2].front().l_r]);
+    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_nodes_list[footstep_nodes_list.size()-2].front().l_r]);
     final_step_coords1.difference(dp, dr, final_step_coords2);
     if ( !(eps_eq(dp.norm(), 0.0, 1e-3*0.1) && eps_eq(dr.norm(), 0.0, deg2rad(0.5))) ) { // If final_step_coords1 != final_step_coords2, add steps to match final_step_coords1 and final_step_coords2
-        append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
+        append_go_pos_step_node(foot_midcoords, (footstep_nodes_list.back().front().l_r == RLEG ? LLEG : RLEG));
     }
     //   For Last double support period
     append_finalize_footstep();
-    print_footstep_list_list();
+    print_footstep_nodes_list();
   };
 
-  void gait_generator::go_single_step_param_2_footstep_list_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,
+  void gait_generator::go_single_step_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,
                                                              const std::string& tmp_swing_leg,
                                                              const coordinates& _support_leg_coords)
   {
     leg_type _swing_leg = (tmp_swing_leg == "rleg") ? RLEG : LLEG;
     step_node sn0((_swing_leg == RLEG) ? LLEG : RLEG, _support_leg_coords, lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle());
-    footstep_node_list_list.push_back(boost::assign::list_of(sn0));
+    footstep_nodes_list.push_back(boost::assign::list_of(sn0));
     step_node sn1(_swing_leg, _support_leg_coords, lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle());
     hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[_swing_leg] + hrp::Vector3(goal_x, goal_y, goal_z));
     sn1.worldcoords.pos += sn1.worldcoords.rot * trs;
     sn1.worldcoords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
-    footstep_node_list_list.push_back(boost::assign::list_of(sn1));
-    footstep_node_list_list.push_back(boost::assign::list_of(sn0));
+    footstep_nodes_list.push_back(boost::assign::list_of(sn1));
+    footstep_nodes_list.push_back(boost::assign::list_of(sn0));
   };
 
   void gait_generator::initialize_velocity_mode (const coordinates& _foot_midcoords,
@@ -585,7 +585,7 @@ namespace rats
     velocity_mode_flg = VEL_DOING;
     /* initialize */
     leg_type current_leg = (vel_y > 0.0) ? RLEG : LLEG;
-    clear_footstep_node_list_list();
+    clear_footstep_nodes_list();
     set_velocity_param (vel_x, vel_y, vel_theta);
     append_go_pos_step_node(_foot_midcoords, current_leg);
     append_footstep_list_velocity_mode();
@@ -598,14 +598,14 @@ namespace rats
     if (velocity_mode_flg == VEL_DOING) velocity_mode_flg = VEL_ENDING;
   };
 
-  void gait_generator::calc_foot_midcoords_trans_vector_velocity_mode (std::vector<coordinates>& foot_midcoords_list, std::vector<hrp::Vector3>& trans_list, std::vector<double>& dth_list, const std::vector<step_node>& snl)
+  void gait_generator::calc_feet_midcoords_trans_vectors_velocity_mode (std::vector<coordinates>& feet_midcoords, std::vector<hrp::Vector3>& transes, std::vector<double>& dthes, const std::vector<step_node>& sns)
   {
-    for (size_t i = 0; i < snl.size(); i++) {
-      step_node sn = snl.at(i);
+    for (size_t i = 0; i < sns.size(); i++) {
+      step_node sn = sns.at(i);
       coordinates foot_midcoords = sn.worldcoords;
       hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[sn.l_r] * -1.0);
       foot_midcoords.pos += foot_midcoords.rot * tmpv;
-      foot_midcoords_list.push_back(foot_midcoords);
+      feet_midcoords.push_back(foot_midcoords);
       double dx = vel_param.velocity_x + offset_vel_param.velocity_x, dy = vel_param.velocity_y + offset_vel_param.velocity_y;
       double dth = vel_param.velocity_theta + offset_vel_param.velocity_theta;
       /* velocity limitation by stride parameters <- this should be based on footstep candidates */
@@ -630,88 +630,88 @@ namespace rats
           if (sn.l_r == RLEG || sn.l_r == RARM) dth *= 0.5;
         }
       }
-      trans_list.push_back(hrp::Vector3(dx * default_step_time, dy * default_step_time, 0));
-      dth_list.push_back(deg2rad(dth * default_step_time));
+      transes.push_back(hrp::Vector3(dx * default_step_time, dy * default_step_time, 0));
+      dthes.push_back(deg2rad(dth * default_step_time));
     }
   };
 
   void gait_generator::append_footstep_list_velocity_mode ()
   {
-    std::vector<coordinates> foot_midcoords_list;
-    std::vector<hrp::Vector3> trans_list;
-    std::vector<double> dth_list;
-    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords_list, trans_list, dth_list, footstep_node_list_list.back());
+    std::vector<coordinates> feet_midcoords;
+    std::vector<hrp::Vector3> transes;
+    std::vector<double> dthes;
+    calc_feet_midcoords_trans_vectors_velocity_mode(feet_midcoords, transes, dthes, footstep_nodes_list.back());
 
-    for (size_t i = 0; i < foot_midcoords_list.size(); i++) {
-      foot_midcoords_list[i].pos += foot_midcoords_list[i].rot * trans_list[i];
-      foot_midcoords_list[i].rotate(dth_list[i], hrp::Vector3(0,0,1));
+    for (size_t i = 0; i < feet_midcoords.size(); i++) {
+      feet_midcoords[i].pos += feet_midcoords[i].rot * transes[i];
+      feet_midcoords[i].rotate(dthes[i], hrp::Vector3(0,0,1));
     }
-    append_go_pos_step_node(foot_midcoords_list.front(), get_support_leg_type_list_from_footstep_node_list(footstep_node_list_list.back()).front());
+    append_go_pos_step_node(feet_midcoords.front(), get_support_leg_types_from_footstep_nodes(footstep_nodes_list.back()).front());
   };
 
-  void gait_generator::calc_next_coords_velocity_mode (std::vector< std::vector<coordinates> >& ret_list, const size_t idx)
+  void gait_generator::calc_next_coords_velocity_mode (std::vector< std::vector<coordinates> >& rets, const size_t idx)
   {
-    std::vector<coordinates> foot_midcoords_list;
-    std::vector<hrp::Vector3> trans_list;
-    std::vector<double> dth_list;
-    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords_list, trans_list, dth_list, footstep_node_list_list[idx-1]);
+    std::vector<coordinates> feet_midcoords;
+    std::vector<hrp::Vector3> transes;
+    std::vector<double> dthes;
+    calc_feet_midcoords_trans_vectors_velocity_mode(feet_midcoords, transes, dthes, footstep_nodes_list[idx-1]);
 
     for (size_t i = 0; i < 3; i++) {
       std::vector<coordinates> ret;
-      for (size_t j = 0; j < foot_midcoords_list.size(); j++) {
-        ret.push_back(foot_midcoords_list[j]);
+      for (size_t j = 0; j < feet_midcoords.size(); j++) {
+        ret.push_back(feet_midcoords[j]);
         if ( velocity_mode_flg != VEL_ENDING ) {
-          ret[j].pos += ret[j].rot * trans_list[j];
-          ret[j].rotate(dth_list[j], hrp::Vector3(0,0,1));
+          ret[j].pos += ret[j].rot * transes[j];
+          ret[j].rotate(dthes[j], hrp::Vector3(0,0,1));
         }
-        ret[j].pos += ret[j].rot * footstep_param.leg_default_translate_pos[(footstep_node_list_list[idx-1][0].l_r == RLEG) ? (1 + i)%2 : i%2];
+        ret[j].pos += ret[j].rot * footstep_param.leg_default_translate_pos[(footstep_nodes_list[idx-1][0].l_r == RLEG) ? (1 + i)%2 : i%2];
       }
-      ret_list.push_back(ret);
+      rets.push_back(ret);
     }
   };
 
-  void gait_generator::overwrite_refzmp_queue(const std::vector< std::vector<step_node> >& fnll)
+  void gait_generator::overwrite_refzmp_queue(const std::vector< std::vector<step_node> >& fnsl)
   {
     /* clear footstep and refzmp after footstep_index + 1, it means we do not modify current step */
     size_t idx = get_overwritable_index();
-    footstep_node_list_list.erase(footstep_node_list_list.begin()+idx, footstep_node_list_list.end());
+    footstep_nodes_list.erase(footstep_nodes_list.begin()+idx, footstep_nodes_list.end());
 
-    /* add new next steps ;; the number of next steps is fnl.size() */
-    footstep_node_list_list.insert(footstep_node_list_list.end(), fnll.begin(), fnll.end());
+    /* add new next steps ;; the number of next steps is fnsl.size() */
+    footstep_nodes_list.insert(footstep_nodes_list.end(), fnsl.begin(), fnsl.end());
 
-    /* remove refzmp after idx for allocation of new refzmp by push_refzmp_from_footstep_list */
+    /* remove refzmp after idx for allocation of new refzmp by push_refzmp_from_footstep_nodes */
     rg.remove_refzmp_cur_list_over_length(idx);
     /* remove refzmp in preview contoroller queue */
     preview_controller_ptr->remove_preview_queue(lcg.get_lcg_count());
 
     /* reset index and counter */
     rg.set_indices(idx);
-    rg.set_refzmp_count(static_cast<size_t>(fnll[0][0].step_time/dt));
-    lcg.set_swing_support_list_list(footstep_node_list_list);
+    rg.set_refzmp_count(static_cast<size_t>(fnsl[0][0].step_time/dt));
+    lcg.set_swings_supports_list(footstep_nodes_list);
     /* reset refzmp */
-    for (size_t i = 0; i < fnll.size(); i++) {
+    for (size_t i = 0; i < fnsl.size(); i++) {
         if (emergency_flg == EMERGENCY_STOP)
-            rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[idx+i],
-                                                       lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
-                                                       lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
+            rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list[idx+i],
+                                                       lcg.get_swing_legs_dst_coords_idx(footstep_nodes_list.size()-1),
+                                                       lcg.get_support_legs_coords_idx(footstep_nodes_list.size()-1));
         else {
-            if (i==fnll.size()-1) {
-                rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[fnll.size()-1],
-                                                           lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
-                                                           lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
+            if (i==fnsl.size()-1) {
+                rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list[fnsl.size()-1],
+                                                           lcg.get_swing_legs_dst_coords_idx(footstep_nodes_list.size()-1),
+                                                           lcg.get_support_legs_coords_idx(footstep_nodes_list.size()-1));
             } else {
-                rg.push_refzmp_from_footstep_list_for_single(footstep_node_list_list[idx+i], lcg.get_support_leg_coords_list_idx(idx+i));
+                rg.push_refzmp_from_footstep_nodes_for_single(footstep_nodes_list[idx+i], lcg.get_support_legs_coords_idx(idx+i));
             }
         }
     }
     /* fill preview controller queue by new refzmp */
     hrp::Vector3 rzmp;
-    std::vector<hrp::Vector3> sfzo_list;
+    std::vector<hrp::Vector3> sfzos;
     bool not_solved = true;
     while (not_solved) {
-      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo_list, default_double_support_ratio, default_double_support_static_ratio);
-      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset_list[0], rzmp, sfzo_list[0], refzmp_exist_p);
-      rg.update_refzmp(footstep_node_list_list);
+      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
+      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets[0], rzmp, sfzos[0], refzmp_exist_p);
+      rg.update_refzmp(footstep_nodes_list);
     }
   };
 }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -1,6 +1,7 @@
 /* -*- coding:utf-8-unix; mode:c++; -*- */
 
 #include "GaitGenerator.h"
+#include <numeric>
 namespace rats
 {
 #ifndef rad2deg
@@ -33,46 +34,87 @@ namespace rats
     ret = dvm * cycloid_point + start + uz;
   };
 
+    std::vector<leg_type> get_support_leg_type_list_from_footstep_node_list(const std::vector<step_node>& fnl) {
+        if (fnl.size() == 1) {
+            std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG);
+            boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == fnl.front().l_r));
+            return tmp_spll;
+        } else if (fnl.size() == 2) {
+            std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
+            boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == fnl.at(0).l_r || boost::lambda::_1 == fnl.at(1).l_r));
+            return tmp_spll;
+        } else {
+            std::cerr << "not implemented yet " << std::endl;
+        }
+    };
+
   /* member function implementation for refzmp_generator */
-  void refzmp_generator::push_refzmp_from_footstep_list_for_dual (const step_node& fn,
-                                                                                  const coordinates& _support_leg_coords,
-                                                                                  const coordinates& _swing_leg_coords)
+  void refzmp_generator::push_refzmp_from_footstep_list_for_dual (const std::vector<step_node>& fnl,
+                                                                  const std::vector<coordinates>& _support_leg_coords_list,
+                                                                  const std::vector<coordinates>& _swing_leg_coords_list)
   {
     hrp::Vector3 rzmp;
-    hrp::Vector3 dz0, dz1, ret_zmp;
-    leg_type spl = (fn.l_r == RLEG) ? LLEG :RLEG;
-    dz0 = _support_leg_coords.rot * default_zmp_offsets[spl];
-    dz1 = _swing_leg_coords.rot * default_zmp_offsets[spl == RLEG ? LLEG : RLEG];
-    dz0 += _support_leg_coords.pos;
-    dz1 += _swing_leg_coords.pos;
-    rzmp = (dz0 + dz1) / 2.0;
+    std::vector<hrp::Vector3> dzl;
+    hrp::Vector3 ret_zmp;
+    hrp::Vector3 tmp_zero = hrp::Vector3::Zero();
+    std::vector<leg_type> spll = get_support_leg_type_list_from_footstep_node_list(fnl);
+    for (size_t i = 0, len = _support_leg_coords_list.size(); i < len; i++) {
+      dzl.push_back(_support_leg_coords_list.at(i).rot * default_zmp_offsets[spll.at(i)] + _support_leg_coords_list.at(i).pos);
+    }
+    for (size_t i = 0, len = _swing_leg_coords_list.size(); i < len; i++) {
+      dzl.push_back(_swing_leg_coords_list.at(i).rot * default_zmp_offsets[fnl.at(i).l_r] + _swing_leg_coords_list.at(i).pos);
+    }
+    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
     refzmp_cur_list.push_back( rzmp );
-    foot_x_axis_list.push_back( hrp::Vector3(_swing_leg_coords.rot * hrp::Vector3::UnitX()) );
-    swing_leg_list.push_back( fn.l_r );
-    step_count_list.push_back(static_cast<size_t>(fn.step_time/dt));
+    std::vector<hrp::Vector3> foot_x_axis_list;
+    for (size_t i = 0; i < _swing_leg_coords_list.size(); i++) {
+        foot_x_axis_list.push_back( hrp::Vector3(_swing_leg_coords_list.at(i).rot * hrp::Vector3::UnitX()) );
+    }
+    foot_x_axis_list_list.push_back(foot_x_axis_list);
+    std::vector<leg_type> swing_leg_list;
+    for (size_t i = 0; i < fnl.size(); i++) {
+        swing_leg_list.push_back(fnl.at(i).l_r);
+    }
+    swing_leg_list_list.push_back( swing_leg_list );
+    step_count_list.push_back(static_cast<size_t>(fnl.front().step_time/dt));
     //std::cerr << "double " << (fnl[fs_index].l_r==RLEG?LLEG:RLEG) << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::push_refzmp_from_footstep_list_for_single (const step_node& fn, const coordinates& _support_leg_coords)
+  void refzmp_generator::push_refzmp_from_footstep_list_for_single (const std::vector<step_node>& fnl, const std::vector<coordinates>& _support_leg_coords_list)
   {
     // support leg = prev fnl l_r
     // swing leg = fnl l_r
-    hrp::Vector3 rzmp;
-    coordinates tmp(_support_leg_coords);
-    rzmp = tmp.rot * default_zmp_offsets[fn.l_r==RLEG?LLEG:RLEG] + tmp.pos;
+    hrp::Vector3 rzmp, tmp_zero=hrp::Vector3::Zero();
+    std::vector<hrp::Vector3> dzl;
+
+    std::vector<leg_type> spll = get_support_leg_type_list_from_footstep_node_list(fnl);
+    for (size_t i = 0, len = _support_leg_coords_list.size(); i < len; i++) {
+      dzl.push_back(_support_leg_coords_list.at(i).rot * default_zmp_offsets[spll.at(i)] + _support_leg_coords_list.at(i).pos);
+    }
+    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
     refzmp_cur_list.push_back( rzmp );
-    foot_x_axis_list.push_back( hrp::Vector3(tmp.rot * hrp::Vector3::UnitX()) );
-    swing_leg_list.push_back(fn.l_r);
-    step_count_list.push_back(static_cast<size_t>(fn.step_time/dt));
+    std::vector<hrp::Vector3> foot_x_axis_list;
+    for (size_t i = 0; i < _support_leg_coords_list.size(); i++) {
+        foot_x_axis_list.push_back( hrp::Vector3(_support_leg_coords_list.at(i).rot * hrp::Vector3::UnitX()) );
+    }
+    foot_x_axis_list_list.push_back(foot_x_axis_list);
+    std::vector<leg_type> swing_leg_list;
+    for (size_t i = 0; i< fnl.size(); i++) {
+        swing_leg_list.push_back(fnl.at(i).l_r);
+    }
+    swing_leg_list_list.push_back( swing_leg_list );
+    step_count_list.push_back(static_cast<size_t>(fnl.front().step_time/dt));
     //std::cerr << "single " << fnl[fs_index-1].l_r << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, hrp::Vector3& swing_foot_zmp_offset, const double default_double_support_ratio, const double default_double_support_static_ratio) const
+  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offset_list, const double default_double_support_ratio, const double default_double_support_static_ratio) const
   {
     size_t cnt = one_step_count - refzmp_count; // current counter (0 -> one_step_count)
     size_t double_support_count_half = (0.5 * default_double_support_ratio) * one_step_count;
     size_t double_support_static_count_half = (0.5 * default_double_support_static_ratio) * one_step_count;
-    swing_foot_zmp_offset = default_zmp_offsets[swing_leg_list[refzmp_index]];
+    for (size_t i = 0; i < swing_leg_list_list[refzmp_index].size(); i++) {
+        swing_foot_zmp_offset_list.push_back(default_zmp_offsets[swing_leg_list_list[refzmp_index].at(i)]);
+    }
     double zmp_diff = 0.0; // difference between total swing_foot_zmp_offset and default_zmp_offset
     //if (cnt==0) std::cerr << "z " << refzmp_index << " " << refzmp_cur_list.size() << " " << fs_index << " " << (refzmp_index == refzmp_cur_list.size()-2) << " " << is_final_double_support_set << std::endl;
 
@@ -81,19 +123,19 @@ namespace rats
         !(is_start_double_support_phase() || is_end_double_support_phase())) { // Do not use toe heel zmp transition during start and end double support period because there is no swing foot
         if (thp_ptr->is_between_phases(cnt, SOLE0)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt+1, SOLE0);
-            swing_foot_zmp_offset(0) = (1-ratio)*swing_foot_zmp_offset(0) + ratio*toe_zmp_offset_x;
+            swing_foot_zmp_offset_list.front()(0) = (1-ratio)*swing_foot_zmp_offset_list.front()(0) + ratio*toe_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, HEEL2SOLE, SOLE2)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt, HEEL2SOLE, SOLE2);
-            swing_foot_zmp_offset(0) = ratio*swing_foot_zmp_offset(0) + (1-ratio)*heel_zmp_offset_x;
+            swing_foot_zmp_offset_list.front()(0) = ratio*swing_foot_zmp_offset_list.front()(0) + (1-ratio)*heel_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE0, SOLE2TOE)) {
-            swing_foot_zmp_offset(0) = toe_zmp_offset_x;
+            swing_foot_zmp_offset_list.front()(0) = toe_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE2HEEL, HEEL2SOLE)) {
-            swing_foot_zmp_offset(0) = heel_zmp_offset_x;
+            swing_foot_zmp_offset_list.front()(0) = heel_zmp_offset_x;
         } else if (thp_ptr->is_between_phases(cnt, SOLE2TOE, SOLE2HEEL)) {
             double ratio = thp_ptr->calc_phase_ratio(cnt, SOLE2TOE, SOLE2HEEL);
-            swing_foot_zmp_offset(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
+            swing_foot_zmp_offset_list.front()(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
         }
-        zmp_diff = swing_foot_zmp_offset(0)-default_zmp_offsets[swing_leg_list[refzmp_index]](0);
+        zmp_diff = swing_foot_zmp_offset_list.front()(0)-default_zmp_offsets[swing_leg_list_list[refzmp_index].front()](0);
         if ((is_second_phase() && ( cnt < double_support_count_half )) ||
             (is_second_last_phase() && ( cnt > one_step_count - double_support_count_half ))) {
             // "* 0.5" is for double supprot period
@@ -106,21 +148,21 @@ namespace rats
       ret = refzmp_cur_list[refzmp_index];
     } else if ( cnt < double_support_static_count_half ) { // Start double support static period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
-      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list[refzmp_index-1];
+      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list_list[refzmp_index-1].front();
       double ratio = (is_second_phase()?1.0:0.5); 
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_count - double_support_static_count_half ) { // End double support static period
-      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list[refzmp_index+1];
+      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = (is_second_last_phase()?1.0:0.5);
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else if ( cnt < double_support_count_half ) { // Start double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
-      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list[refzmp_index-1];
+      hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axis_list_list[refzmp_index-1].front();
       double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (double_support_count_half-cnt);
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_count - double_support_count_half ) { // End double support period
-      hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list[refzmp_index+1];
+        hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axis_list_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (cnt - 1 - (one_step_count - double_support_count_half));
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
@@ -129,7 +171,7 @@ namespace rats
     }
   };
 
-  void refzmp_generator::update_refzmp (const std::vector<step_node>& fnl)
+  void refzmp_generator::update_refzmp (const std::vector< std::vector<step_node> >& fnll)
   {
     if ( 1 <= refzmp_count ) {
       refzmp_count--;
@@ -141,31 +183,37 @@ namespace rats
   };
 
   /* member function implementation for leg_coords_generator */
-  void leg_coords_generator::calc_current_swing_leg_coords (coordinates& ret, const double step_height, const double _current_toe_angle, const double _current_heel_angle)
+  void leg_coords_generator::calc_current_swing_leg_coords_list (std::vector<coordinates>& ret_list, const double step_height, const double _current_toe_angle, const double _current_heel_angle)
   {
-    switch (default_orbit_type) {
-    case SHUFFLING:
-      mid_coords(ret, swing_rot_ratio, swing_leg_src_coords, swing_leg_dst_coords);
-      break;
-    case CYCLOID:
-      cycloid_midcoords(ret, swing_leg_src_coords, swing_leg_dst_coords, step_height);
-      break;
-    case RECTANGLE:
-      rectangle_midcoords(ret, swing_leg_src_coords, swing_leg_dst_coords, step_height);
-      break;
-    case STAIR:
-      stair_midcoords(ret, swing_leg_src_coords, swing_leg_dst_coords, step_height);
-      break;
-    case CYCLOIDDELAY:
-      cycloid_delay_midcoords(ret, swing_leg_src_coords, swing_leg_dst_coords, step_height);
-      break;
-    case CYCLOIDDELAYKICK:
-      cycloid_delay_kick_midcoords(ret, swing_leg_src_coords, swing_leg_dst_coords, step_height);
-      break;
-    default: break;
-    }
-    if (std::fabs(step_height) > 1e-3*10) {
+    for (std::vector<coordinates>::iterator it1 = swing_leg_src_coords_list.begin(), it2 = swing_leg_dst_coords_list.begin();
+         it1 != swing_leg_src_coords_list.end() && it2 != swing_leg_dst_coords_list.end();
+         it1++, it2++) {
+      coordinates ret;
+      switch (default_orbit_type) {
+      case SHUFFLING:
+        mid_coords(ret, swing_rot_ratio, *it1, *it2);
+        break;
+      case CYCLOID:
+        cycloid_midcoords(ret, *it1, *it2, step_height);
+        break;
+      case RECTANGLE:
+        rectangle_midcoords(ret, *it1, *it2, step_height);
+        break;
+      case STAIR:
+        stair_midcoords(ret, *it1, *it2, step_height);
+        break;
+      case CYCLOIDDELAY:
+        cycloid_delay_midcoords(ret, *it1, *it2, step_height);
+        break;
+      case CYCLOIDDELAYKICK:
+        cycloid_delay_kick_midcoords(ret, *it1, *it2, step_height);
+        break;
+      default: break;
+      }
+      if (std::fabs(step_height) > 1e-3*10) {
         modif_foot_coords_for_toe_heel_phase(ret, _current_toe_angle, _current_heel_angle);
+      }
+      ret_list.push_back(ret);
     }
   };
 
@@ -203,8 +251,8 @@ namespace rats
       swing_ratio = static_cast<double>(current_swing_count-support_len/2)/swing_len;
       //std::cerr << "gp " << swing_ratio << " " << swing_rot_ratio << std::endl;
     }
-    current_swing_time[support_leg] = (lcg_count + 0.5 * default_double_support_ratio * next_one_step_count) * dt;
-    current_swing_time[support_leg==RLEG ? LLEG : RLEG] = tmp_current_swing_time;
+    current_swing_time[support_leg_list.front()] = (lcg_count + 0.5 * default_double_support_ratio * next_one_step_count) * dt;
+    current_swing_time[support_leg_list.front()==RLEG ? LLEG : RLEG] = tmp_current_swing_time;
     //std::cerr << "sl " << support_leg << " " << current_swing_time[support_leg==RLEG?0:1] << " " << current_swing_time[support_leg==RLEG?1:0] << " " << tmp_current_swing_time << " " << lcg_count << std::endl;
   };
 
@@ -301,48 +349,52 @@ namespace rats
     cdktg.get_trajectory_point(ret.pos, hrp::Vector3(start.pos), hrp::Vector3(goal.pos), height);
   };
 
-  void leg_coords_generator::update_leg_coords (const std::vector<step_node>& fnl, const double default_double_support_ratio)
+  void leg_coords_generator::update_leg_coords (const std::vector< std::vector<step_node> >& fnll, const double default_double_support_ratio)
   {
     if (!foot_ratio_interpolator->isEmpty()) {
         foot_ratio_interpolator->get(&foot_midcoords_ratio, true);
     }
 
     // Get current swing coords, support coords, and support leg parameters
-    size_t current_footstep_index = (footstep_index < fnl.size() - 1 ? footstep_index : fnl.size()-1);
-    swing_leg_dst_coords = fnl[current_footstep_index].worldcoords;
-    support_leg = (fnl[current_footstep_index].l_r==RLEG ? LLEG : RLEG);
+    size_t current_footstep_index = (footstep_index < fnll.size() - 1 ? footstep_index : fnll.size()-1);
+    swing_leg_dst_coords_list.clear();
+    for (size_t i = 0; i < fnll[current_footstep_index].size(); i++) {
+        swing_leg_dst_coords_list.push_back(fnll[current_footstep_index].at(i).worldcoords);
+    }
+    support_leg_list = get_support_leg_type_list_from_footstep_node_list(fnll[current_footstep_index]);
     if (footstep_index != 0) { // If not initial step, support_leg_coords is previous swing_leg_dst_coords
-        support_leg_coords = support_leg_coords_list[current_footstep_index];
+        support_leg_coords_list = support_leg_coords_list_list[current_footstep_index];
     }
     if (current_footstep_index > 0) {
-        if (fnl[current_footstep_index].l_r == fnl[current_footstep_index-1].l_r) {
-            swing_leg_src_coords = swing_leg_dst_coords_list[current_footstep_index-1];
+      if (fnll[current_footstep_index].front().l_r == fnll[current_footstep_index-1].front().l_r) {
+            swing_leg_src_coords_list = swing_leg_dst_coords_list_list[current_footstep_index-1];
         } else {
-            swing_leg_src_coords = support_leg_coords_list[current_footstep_index-1];
+            swing_leg_src_coords_list = support_leg_coords_list_list[current_footstep_index-1];
         }
     }
 
     calc_ratio_from_double_support_ratio(default_double_support_ratio);
-    calc_current_swing_leg_coords(swing_leg_coords, current_step_height, current_toe_angle, current_heel_angle);
+    swing_leg_coords_list.clear();
+    calc_current_swing_leg_coords_list(swing_leg_coords_list, current_step_height, current_toe_angle, current_heel_angle);
     if ( 1 <= lcg_count ) {
       lcg_count--;
     } else {
       //std::cerr << "gp " << footstep_index << std::endl;
-      if (footstep_index < fnl.size() - 1) {
+      if (footstep_index < fnll.size() - 1) {
         footstep_index++;
       }
-      if (footstep_index < fnl.size() - 1) {
-        current_step_height = fnl[footstep_index].step_height;
-        current_toe_angle = fnl[footstep_index].toe_angle;
-        current_heel_angle = fnl[footstep_index].heel_angle;
+      if (footstep_index < fnll.size() - 1) {
+        current_step_height = fnll[footstep_index].front().step_height;
+        current_toe_angle = fnll[footstep_index].front().toe_angle;
+        current_heel_angle = fnll[footstep_index].front().heel_angle;
       } else {
         current_step_height = current_toe_angle = current_heel_angle = 0.0;
       }
-      if (footstep_index < fnl.size()) {
-        one_step_count = static_cast<size_t>(fnl[footstep_index].step_time/dt);
+      if (footstep_index < fnll.size()) {
+        one_step_count = static_cast<size_t>(fnll[footstep_index].front().step_time/dt);
       }
-      if (footstep_index + 1 < fnl.size()) {
-        next_one_step_count = static_cast<size_t>(fnl[footstep_index+1].step_time/dt);
+      if (footstep_index + 1 < fnll.size()) {
+        next_one_step_count = static_cast<size_t>(fnll[footstep_index+1].front().step_time/dt);
       }
       lcg_count = one_step_count;
       rdtg.reset(one_step_count, default_double_support_ratio);
@@ -355,75 +407,81 @@ namespace rats
 
   /* member function implementation for gait_generator */
   void gait_generator::initialize_gait_parameter (const hrp::Vector3& cog,
-                                                  const coordinates& initial_support_leg_coords,
-                                                  const coordinates& initial_swing_leg_dst_coords,
+                                                  const std::vector<coordinates>& initial_support_leg_coords_list,
+                                                  const std::vector<coordinates>& initial_swing_leg_dst_coords_list,
                                                   const double delay)
   {
     /* clear all gait_parameter */
-    size_t one_step_len = footstep_node_list[0].step_time / dt;
+    size_t one_step_len = footstep_node_list_list[0][0].step_time / dt;
     finalize_count = 0;
-    footstep_node_list[0].worldcoords = initial_swing_leg_dst_coords;
+    for (size_t i = 0; i < footstep_node_list_list[0].size(); i++) {
+      footstep_node_list_list[0][i].worldcoords = initial_swing_leg_dst_coords_list[i];
+    }
     rg.reset(one_step_len);
-    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list.front(), initial_support_leg_coords, initial_swing_leg_dst_coords);
+    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list.front(), initial_support_leg_coords_list, initial_swing_leg_dst_coords_list);
     if ( preview_controller_ptr != NULL ) {
       delete preview_controller_ptr;
       preview_controller_ptr = NULL;
     }
     //preview_controller_ptr = new preview_dynamics_filter<preview_control>(dt, cog(2) - refzmp_cur_list[0](2), refzmp_cur_list[0]);
     preview_controller_ptr = new preview_dynamics_filter<extended_preview_control>(dt, cog(2) - rg.get_refzmp_cur()(2), rg.get_refzmp_cur(), gravitational_acceleration);
-    lcg.reset(one_step_len, footstep_node_list[1].step_time/dt, initial_swing_leg_dst_coords, initial_swing_leg_dst_coords, initial_support_leg_coords, default_double_support_ratio);
+    lcg.reset(one_step_len, footstep_node_list_list[1][0].step_time/dt, initial_swing_leg_dst_coords_list, initial_swing_leg_dst_coords_list, initial_support_leg_coords_list, default_double_support_ratio);
     /* make another */
-    lcg.set_swing_support_list(footstep_node_list);
-    for (size_t i = 1; i < footstep_node_list.size()-1; i++) {
-        rg.push_refzmp_from_footstep_list_for_single(footstep_node_list[i], lcg.get_support_leg_coords_idx(i));
+    lcg.set_swing_support_list_list(footstep_node_list_list);
+    for (size_t i = 1; i < footstep_node_list_list.size()-1; i++) {
+        rg.push_refzmp_from_footstep_list_for_single(footstep_node_list_list[i], lcg.get_support_leg_coords_list_idx(i));
     }
-    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list[footstep_node_list.size()-1],
-                                               lcg.get_swing_leg_dst_coords_idx(footstep_node_list.size()-1),
-                                               lcg.get_support_leg_coords_idx(footstep_node_list.size()-1));
+    rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[footstep_node_list_list.size()-1],
+                                               lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
+                                               lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
     emergency_flg = IDLING;
   };
 
   bool gait_generator::proc_one_tick ()
   {
-    hrp::Vector3 rzmp, sfzo;
-    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo, default_double_support_ratio, default_double_support_static_ratio);
+    hrp::Vector3 rzmp;
+    std::vector<hrp::Vector3> sfzo_list;
+    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo_list, default_double_support_ratio, default_double_support_static_ratio);
     if (!refzmp_exist_p) {
       finalize_count++;
       rzmp = prev_que_rzmp;
-      sfzo = prev_que_sfzo;
+      sfzo_list = prev_que_sfzo_list;
     } else {
       prev_que_rzmp = rzmp;
-      prev_que_sfzo = sfzo;
+      prev_que_sfzo_list = sfzo_list;
     }
-    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset, rzmp, sfzo, (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
+    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset_list.front(), rzmp, sfzo_list.front(), (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
     /* update refzmp */
-    if ( lcg.get_lcg_count() == static_cast<size_t>(footstep_node_list[lcg.get_footstep_index()].step_time/dt * 0.5) - 1 ) { // Almost middle of step time
+    if ( lcg.get_lcg_count() == static_cast<size_t>(footstep_node_list_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1 ) { // Almost middle of step time
       if (velocity_mode_flg != VEL_IDLING && lcg.get_footstep_index() > 0) {
-        std::vector<coordinates> cv;
+        std::vector< std::vector<coordinates> > cv;
         calc_next_coords_velocity_mode(cv, lcg.get_footstep_index() + 1);
         if (velocity_mode_flg == VEL_ENDING) velocity_mode_flg = VEL_IDLING;
-        leg_type cur_leg = footstep_node_list[lcg.get_footstep_index()].l_r;
-        overwrite_footstep_node_list.push_back(step_node(cur_leg==RLEG?LLEG:RLEG, cv[0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle()));
-        overwrite_footstep_node_list.push_back(step_node(cur_leg, cv[1], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle()));
-        overwrite_footstep_node_list.push_back(step_node(cur_leg==RLEG?LLEG:RLEG, cv[2], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle()));
-        overwrite_refzmp_queue(overwrite_footstep_node_list);
-        overwrite_footstep_node_list.clear();
-      } else if ( !overwrite_footstep_node_list.empty() && // If overwrite_footstep_node_list exists
-                  (lcg.get_footstep_index() < footstep_node_list.size()-1) &&  // If overwrite_footstep_node_list is specified and current footstep is not last footstep.
+        std::vector<leg_type> cur_leg;
+        for (size_t i = 0; i < footstep_node_list_list[lcg.get_footstep_index()].size(); i++) {
+            cur_leg.push_back(footstep_node_list_list[lcg.get_footstep_index()].at(i).l_r);
+        }
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[0][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front(), cv[1][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg.front()==RLEG?LLEG:RLEG, cv[2][0], lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle())));
+        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
+        overwrite_footstep_node_list_list.clear();
+      } else if ( !overwrite_footstep_node_list_list.empty() && // If overwrite_footstep_node_list exists
+                  (lcg.get_footstep_index() < footstep_node_list_list.size()-1) &&  // If overwrite_footstep_node_list is specified and current footstep is not last footstep.
                   get_overwritable_index() == overwrite_footstep_index ) {
-        overwrite_refzmp_queue(overwrite_footstep_node_list);
-        overwrite_footstep_node_list.clear();
+        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
+        overwrite_footstep_node_list_list.clear();
       } else if (emergency_flg == EMERGENCY_STOP && lcg.get_footstep_index() > 0) {
-        leg_type cur_leg = footstep_node_list[lcg.get_footstep_index()].l_r;
-        overwrite_footstep_node_list.push_back(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list[lcg.get_footstep_index()-1].worldcoords, 0, default_step_time, 0, 0));
-        overwrite_footstep_node_list.push_back(step_node(cur_leg, footstep_node_list[lcg.get_footstep_index()].worldcoords, 0, default_step_time, 0, 0));
-        overwrite_footstep_node_list.push_back(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list[lcg.get_footstep_index()-1].worldcoords, 0, default_step_time, 0, 0));
-        overwrite_refzmp_queue(overwrite_footstep_node_list);
-        overwrite_footstep_node_list.clear();
+        leg_type cur_leg = footstep_node_list_list[lcg.get_footstep_index()].front().l_r;
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg, footstep_node_list_list[lcg.get_footstep_index()].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_footstep_node_list_list.push_back(boost::assign::list_of(step_node(cur_leg==RLEG?LLEG:RLEG, footstep_node_list_list[lcg.get_footstep_index()-1].front().worldcoords, 0, default_step_time, 0, 0)));
+        overwrite_refzmp_queue(overwrite_footstep_node_list_list);
+        overwrite_footstep_node_list_list.clear();
         emergency_flg = STOPPING;
       }
     }
-    rg.update_refzmp(footstep_node_list);
+    rg.update_refzmp(footstep_node_list_list);
     // { // debug
     //   double cart_zmp[3];
     //   preview_controller_ptr->get_cart_zmp(cart_zmp);
@@ -436,7 +494,7 @@ namespace rats
 
     /* update swing_leg_coords, support_leg_coords */
     if ( solved ) {
-      lcg.update_leg_coords(footstep_node_list, default_double_support_ratio);
+      lcg.update_leg_coords(footstep_node_list_list, default_double_support_ratio);
     } else if (finalize_count>0) {
       lcg.clear_interpolators();
     }
@@ -447,9 +505,9 @@ namespace rats
    *  x, y and theta are simply divided by using stride params
    *  unit system -> x [mm], y [mm], theta [deg]
    */
-  void gait_generator::go_pos_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_theta,
-                                                     const coordinates& initial_support_coords, const coordinates& initial_swing_src_coords,
-                                                     const leg_type initial_support_leg)
+  void gait_generator::go_pos_param_2_footstep_list_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
+                                       const coordinates& initial_support_coords, const coordinates& initial_swing_src_coords,
+                                       const leg_type initial_support_leg)
   {
     coordinates foot_midcoords; /* foot_midcoords is modified during loop */
     mid_coords(foot_midcoords, 0.5, initial_support_coords, initial_swing_src_coords);
@@ -468,9 +526,9 @@ namespace rats
     std::cerr << goal_foot_midcoords.rot.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
 
     /* initialize */
-    clear_footstep_node_list();
+    clear_footstep_node_list_list();
     // For initial double support period
-    footstep_node_list.push_back(step_node(initial_support_leg, initial_support_coords, 0, default_step_time, 0, 0));
+    footstep_node_list_list.push_back(boost::assign::list_of(step_node(initial_support_leg, initial_support_coords, 0, default_step_time, 0, 0)));
 
     /* footstep generation loop */
     hrp::Vector3 dp, dr;
@@ -480,45 +538,45 @@ namespace rats
     while ( !(eps_eq(dp.norm(), 0.0, 1e-3*0.1) && eps_eq(dr.norm(), 0.0, deg2rad(0.5))) ) {
       set_velocity_param(dp(0)/default_step_time, dp(1)/default_step_time, rad2deg(dr(2))/default_step_time);
       append_footstep_list_velocity_mode();
-      foot_midcoords = footstep_node_list.back().worldcoords;
-      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list.back().l_r] * -1.0);
+      foot_midcoords = footstep_node_list_list.back().front().worldcoords;
+      foot_midcoords.pos += foot_midcoords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list_list.back().front().l_r] * -1.0);
       foot_midcoords.difference(dp, dr, goal_foot_midcoords);
       dp = foot_midcoords.rot.transpose() * dp;
       dr = foot_midcoords.rot.transpose() * dr;
     }
     for (size_t i = 0; i < optional_go_pos_finalize_footstep_num; i++) {
-        append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == RLEG ? LLEG : RLEG));
+        append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
     }
 
     /* finalize */
     //   Align last foot
-    append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == RLEG ? LLEG : RLEG));
+    append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
     //   Check align
-    coordinates final_step_coords1 = footstep_node_list[footstep_node_list.size()-2].worldcoords; // Final coords in footstep_node_list
+    coordinates final_step_coords1 = footstep_node_list_list[footstep_node_list_list.size()-2].front().worldcoords; // Final coords in footstep_node_list
     coordinates final_step_coords2 = foot_midcoords; // Final coords calculated from foot_midcoords + translate pos
-    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list[footstep_node_list.size()-2].l_r]);
+    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_node_list_list[footstep_node_list_list.size()-2].front().l_r]);
     final_step_coords1.difference(dp, dr, final_step_coords2);
     if ( !(eps_eq(dp.norm(), 0.0, 1e-3*0.1) && eps_eq(dr.norm(), 0.0, deg2rad(0.5))) ) { // If final_step_coords1 != final_step_coords2, add steps to match final_step_coords1 and final_step_coords2
-        append_go_pos_step_node(foot_midcoords, (footstep_node_list.back().l_r == RLEG ? LLEG : RLEG));
+        append_go_pos_step_node(foot_midcoords, (footstep_node_list_list.back().front().l_r == RLEG ? LLEG : RLEG));
     }
     //   For Last double support period
     append_finalize_footstep();
-    print_footstep_list();
+    print_footstep_list_list();
   };
 
-  void gait_generator::go_single_step_param_2_footstep_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,
+  void gait_generator::go_single_step_param_2_footstep_list_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,
                                                              const std::string& tmp_swing_leg,
                                                              const coordinates& _support_leg_coords)
   {
     leg_type _swing_leg = (tmp_swing_leg == "rleg") ? RLEG : LLEG;
     step_node sn0((_swing_leg == RLEG) ? LLEG : RLEG, _support_leg_coords, lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle());
-    footstep_node_list.push_back(sn0);
+    footstep_node_list_list.push_back(boost::assign::list_of(sn0));
     step_node sn1(_swing_leg, _support_leg_coords, lcg.get_default_step_height(), default_step_time, lcg.get_toe_angle(), lcg.get_heel_angle());
     hrp::Vector3 trs(2.0 * footstep_param.leg_default_translate_pos[_swing_leg] + hrp::Vector3(goal_x, goal_y, goal_z));
     sn1.worldcoords.pos += sn1.worldcoords.rot * trs;
     sn1.worldcoords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
-    footstep_node_list.push_back(sn1);
-    footstep_node_list.push_back(sn0);
+    footstep_node_list_list.push_back(boost::assign::list_of(sn1));
+    footstep_node_list_list.push_back(boost::assign::list_of(sn0));
   };
 
   void gait_generator::initialize_velocity_mode (const coordinates& _foot_midcoords,
@@ -527,7 +585,7 @@ namespace rats
     velocity_mode_flg = VEL_DOING;
     /* initialize */
     leg_type current_leg = (vel_y > 0.0) ? RLEG : LLEG;
-    clear_footstep_node_list();
+    clear_footstep_node_list_list();
     set_velocity_param (vel_x, vel_y, vel_theta);
     append_go_pos_step_node(_foot_midcoords, current_leg);
     append_footstep_list_velocity_mode();
@@ -540,78 +598,86 @@ namespace rats
     if (velocity_mode_flg == VEL_DOING) velocity_mode_flg = VEL_ENDING;
   };
 
-  void gait_generator::calc_foot_midcoords_trans_vector_velocity_mode (coordinates& foot_midcoords, hrp::Vector3& trans, double& dth, const step_node& sn)
+  void gait_generator::calc_foot_midcoords_trans_vector_velocity_mode (std::vector<coordinates>& foot_midcoords_list, std::vector<hrp::Vector3>& trans_list, std::vector<double>& dth_list, const std::vector<step_node>& snl)
   {
-    foot_midcoords = sn.worldcoords;
-    hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[sn.l_r] * -1.0);
-    foot_midcoords.pos += foot_midcoords.rot * tmpv;
-    double dx = vel_param.velocity_x + offset_vel_param.velocity_x, dy = vel_param.velocity_y + offset_vel_param.velocity_y;
-    dth = vel_param.velocity_theta + offset_vel_param.velocity_theta;
-    /* velocity limitation by stride parameters <- this should be based on footstep candidates */
-    if (footstep_param.stride_fwd_x / default_step_time < dx)
-      dx = footstep_param.stride_fwd_x / default_step_time;
-    if (-1*footstep_param.stride_bwd_x / default_step_time > dx)
-      dx = -1*footstep_param.stride_bwd_x / default_step_time;
-    if (footstep_param.stride_y / default_step_time < fabs(dy))
-      dy = footstep_param.stride_y * ((dy > 0.0) ? 1.0 : -1.0) / default_step_time;
-    if (footstep_param.stride_theta / default_step_time < fabs(dth))
-      dth = footstep_param.stride_theta * ((dth > 0.0) ? 1.0 : -1.0) / default_step_time;
-    /* inside step limitation */
-    if (use_inside_step_limitation) {
-      if (vel_param.velocity_y > 0) {
-        if (sn.l_r == LLEG) dy *= 0.5;
-      } else {
-        if (sn.l_r == RLEG) dy *= 0.5;
+    for (size_t i = 0; i < snl.size(); i++) {
+      step_node sn = snl.at(i);
+      coordinates foot_midcoords = sn.worldcoords;
+      hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[sn.l_r] * -1.0);
+      foot_midcoords.pos += foot_midcoords.rot * tmpv;
+      foot_midcoords_list.push_back(foot_midcoords);
+      double dx = vel_param.velocity_x + offset_vel_param.velocity_x, dy = vel_param.velocity_y + offset_vel_param.velocity_y;
+      double dth = vel_param.velocity_theta + offset_vel_param.velocity_theta;
+      /* velocity limitation by stride parameters <- this should be based on footstep candidates */
+      if (footstep_param.stride_fwd_x / default_step_time < dx)
+        dx = footstep_param.stride_fwd_x / default_step_time;
+      if (-1*footstep_param.stride_bwd_x / default_step_time > dx)
+        dx = -1*footstep_param.stride_bwd_x / default_step_time;
+      if (footstep_param.stride_y / default_step_time < fabs(dy))
+        dy = footstep_param.stride_y * ((dy > 0.0) ? 1.0 : -1.0) / default_step_time;
+      if (footstep_param.stride_theta / default_step_time < fabs(dth))
+        dth = footstep_param.stride_theta * ((dth > 0.0) ? 1.0 : -1.0) / default_step_time;
+      /* inside step limitation */
+      if (use_inside_step_limitation) {
+        if (vel_param.velocity_y > 0) {
+          if (sn.l_r == LLEG || sn.l_r == LARM) dy *= 0.5;
+        } else {
+          if (sn.l_r == RLEG || sn.l_r == RARM) dy *= 0.5;
+        }
+        if (vel_param.velocity_theta > 0) {
+          if (sn.l_r == LLEG || sn.l_r == LARM) dth *= 0.5;
+        } else {
+          if (sn.l_r == RLEG || sn.l_r == RARM) dth *= 0.5;
+        }
       }
-      if (vel_param.velocity_theta > 0) {
-        if (sn.l_r == LLEG) dth *= 0.5;
-      } else {
-        if (sn.l_r == RLEG) dth *= 0.5;
-      }
+      trans_list.push_back(hrp::Vector3(dx * default_step_time, dy * default_step_time, 0));
+      dth_list.push_back(deg2rad(dth * default_step_time));
     }
-    trans = hrp::Vector3(dx * default_step_time, dy * default_step_time, 0);
-    dth = deg2rad(dth * default_step_time);
   };
 
   void gait_generator::append_footstep_list_velocity_mode ()
   {
-    coordinates foot_midcoords;
-    hrp::Vector3 trans;
-    double dth;
-    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords, trans, dth, footstep_node_list.back());
+    std::vector<coordinates> foot_midcoords_list;
+    std::vector<hrp::Vector3> trans_list;
+    std::vector<double> dth_list;
+    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords_list, trans_list, dth_list, footstep_node_list_list.back());
 
-    foot_midcoords.pos += foot_midcoords.rot * trans;
-    foot_midcoords.rotate(dth, hrp::Vector3(0,0,1));
-    append_go_pos_step_node(foot_midcoords, (( footstep_node_list.back().l_r == RLEG ) ? LLEG : RLEG));
+    for (size_t i = 0; i < foot_midcoords_list.size(); i++) {
+      foot_midcoords_list[i].pos += foot_midcoords_list[i].rot * trans_list[i];
+      foot_midcoords_list[i].rotate(dth_list[i], hrp::Vector3(0,0,1));
+    }
+    append_go_pos_step_node(foot_midcoords_list.front(), get_support_leg_type_list_from_footstep_node_list(footstep_node_list_list.back()).front());
   };
 
-  void gait_generator::calc_next_coords_velocity_mode (std::vector<coordinates>& ret, const size_t idx)
+  void gait_generator::calc_next_coords_velocity_mode (std::vector< std::vector<coordinates> >& ret_list, const size_t idx)
   {
-    coordinates foot_midcoords;
-    hrp::Vector3 trans;
-    double dth;
-    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords, trans, dth, footstep_node_list[idx-1]);
+    std::vector<coordinates> foot_midcoords_list;
+    std::vector<hrp::Vector3> trans_list;
+    std::vector<double> dth_list;
+    calc_foot_midcoords_trans_vector_velocity_mode(foot_midcoords_list, trans_list, dth_list, footstep_node_list_list[idx-1]);
 
     for (size_t i = 0; i < 3; i++) {
-      ret.push_back(foot_midcoords);
-      if ( velocity_mode_flg != VEL_ENDING ) {
-        ret[i].pos += ret[i].rot * trans;
-        ret[i].rotate(dth, hrp::Vector3(0,0,1));
+      std::vector<coordinates> ret;
+      for (size_t j = 0; j < foot_midcoords_list.size(); j++) {
+        ret.push_back(foot_midcoords_list[j]);
+        if ( velocity_mode_flg != VEL_ENDING ) {
+          ret[j].pos += ret[j].rot * trans_list[j];
+          ret[j].rotate(dth_list[j], hrp::Vector3(0,0,1));
+        }
+        ret[j].pos += ret[j].rot * footstep_param.leg_default_translate_pos[(footstep_node_list_list[idx-1][0].l_r == RLEG) ? (1 + i)%2 : i%2];
       }
-      ret[i].pos += ret[i].rot * footstep_param.leg_default_translate_pos[(footstep_node_list[idx-1].l_r == RLEG) ? (1 + i)%2 : i%2];
+      ret_list.push_back(ret);
     }
   };
 
-  void gait_generator::overwrite_refzmp_queue(const std::vector<step_node>& fnl)
+  void gait_generator::overwrite_refzmp_queue(const std::vector< std::vector<step_node> >& fnll)
   {
     /* clear footstep and refzmp after footstep_index + 1, it means we do not modify current step */
     size_t idx = get_overwritable_index();
-    footstep_node_list.erase(footstep_node_list.begin()+idx, footstep_node_list.end());
+    footstep_node_list_list.erase(footstep_node_list_list.begin()+idx, footstep_node_list_list.end());
 
     /* add new next steps ;; the number of next steps is fnl.size() */
-    for (size_t i = 0; i < fnl.size(); i++ ) {
-        footstep_node_list.push_back(fnl[i]);
-    }
+    footstep_node_list_list.insert(footstep_node_list_list.end(), fnll.begin(), fnll.end());
 
     /* remove refzmp after idx for allocation of new refzmp by push_refzmp_from_footstep_list */
     rg.remove_refzmp_cur_list_over_length(idx);
@@ -620,31 +686,32 @@ namespace rats
 
     /* reset index and counter */
     rg.set_indices(idx);
-    rg.set_refzmp_count(static_cast<size_t>(fnl[0].step_time/dt));
-    lcg.set_swing_support_list(footstep_node_list);
+    rg.set_refzmp_count(static_cast<size_t>(fnll[0][0].step_time/dt));
+    lcg.set_swing_support_list_list(footstep_node_list_list);
     /* reset refzmp */
-    for (size_t i = 0; i < fnl.size(); i++) {
+    for (size_t i = 0; i < fnll.size(); i++) {
         if (emergency_flg == EMERGENCY_STOP)
-            rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list[idx+i],
-                                                       lcg.get_swing_leg_dst_coords_idx(footstep_node_list.size()-1),
-                                                       lcg.get_support_leg_coords_idx(footstep_node_list.size()-1));
+            rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[idx+i],
+                                                       lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
+                                                       lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
         else {
-            if (i==fnl.size()-1) {
-                rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list[fnl.size()-1],
-                                                           lcg.get_swing_leg_dst_coords_idx(footstep_node_list.size()-1),
-                                                           lcg.get_support_leg_coords_idx(footstep_node_list.size()-1));
+            if (i==fnll.size()-1) {
+                rg.push_refzmp_from_footstep_list_for_dual(footstep_node_list_list[fnll.size()-1],
+                                                           lcg.get_swing_leg_dst_coords_list_idx(footstep_node_list_list.size()-1),
+                                                           lcg.get_support_leg_coords_list_idx(footstep_node_list_list.size()-1));
             } else {
-                rg.push_refzmp_from_footstep_list_for_single(footstep_node_list[idx+i], lcg.get_support_leg_coords_idx(idx+i));
+                rg.push_refzmp_from_footstep_list_for_single(footstep_node_list_list[idx+i], lcg.get_support_leg_coords_list_idx(idx+i));
             }
         }
     }
     /* fill preview controller queue by new refzmp */
-    hrp::Vector3 rzmp, sfzo;
+    hrp::Vector3 rzmp;
+    std::vector<hrp::Vector3> sfzo_list;
     bool not_solved = true;
     while (not_solved) {
-      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo, default_double_support_ratio, default_double_support_static_ratio);
-      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset, rzmp, sfzo, refzmp_exist_p);
-      rg.update_refzmp(footstep_node_list);
+      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzo_list, default_double_support_ratio, default_double_support_static_ratio);
+      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offset_list[0], rzmp, sfzo_list[0], refzmp_exist_p);
+      rg.update_refzmp(footstep_node_list_list);
     }
   };
 }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -35,13 +35,16 @@ namespace rats
   };
 
     std::vector<leg_type> get_support_leg_types_from_footstep_nodes(const std::vector<step_node>& fns) {
+        /* cannot use boost::remove_erase_if() */
         if (fns.size() == 1) {
             std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG);
-            boost::remove_erase_if(tmp_spls, (boost::lambda::_1 == fns.front().l_r));
+            std::vector<leg_type>::iterator it = std::remove_if(tmp_spls.begin(), tmp_spls.end(), (boost::lambda::_1 == fns.front().l_r));
+            tmp_spls.erase(it, tmp_spls.end());
             return tmp_spls;
         } else if (fns.size() == 2) {
             std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
-            boost::remove_erase_if(tmp_spls, (boost::lambda::_1 == fns.at(0).l_r || boost::lambda::_1 == fns.at(1).l_r));
+            std::vector<leg_type>::iterator it = std::remove_if(tmp_spls.begin(), tmp_spls.end(), (boost::lambda::_1 == fns.at(0).l_r || boost::lambda::_1 == fns.at(1).l_r));
+            tmp_spls.erase(it, tmp_spls.end());
             return tmp_spls;
         } else {
             std::cerr << "not implemented yet " << std::endl;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -6,7 +6,6 @@
 #include "interpolator.h"
 #include <vector>
 #include <queue>
-#include <boost/range/algorithm_ext/erase.hpp>
 #include <boost/assign.hpp>
 #include <boost/lambda/lambda.hpp>
 
@@ -675,14 +674,17 @@ namespace rats
       const std::vector<coordinates>& get_support_legs_coords_idx(const size_t idx) const { return support_legs_coords_list[idx]; };
       std::vector<leg_type> get_support_legs() const { return support_legs;};
       std::vector<leg_type> get_swing_legs() const {
+        /* cannot use boost::remove_erase_if() */
         if (support_legs.size() == 1) {
-          std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG);
-          boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == support_legs.front()));
-          return tmp_spll;
+          std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG);
+          std::vector<leg_type>::iterator it = std::remove_if(tmp_spls.begin(), tmp_spls.end(), (boost::lambda::_1 == support_legs.front()));
+          tmp_spls.erase(it, tmp_spls.end());
+          return tmp_spls;
         } else if (support_legs.size() == 2) {
-          std::vector<leg_type> tmp_spll = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
-          boost::remove_erase_if(tmp_spll, (boost::lambda::_1 == support_legs.at(0) || boost::lambda::_1 == support_legs.at(1)));
-          return tmp_spll;
+          std::vector<leg_type> tmp_spls = boost::assign::list_of(RLEG)(LLEG)(RARM)(LARM);
+          std::vector<leg_type>::iterator it = std::remove_if(tmp_spls.begin(), tmp_spls.end(), (boost::lambda::_1 == support_legs.at(0) || boost::lambda::_1 == support_legs.at(1)));
+          tmp_spls.erase(it, tmp_spls.end());
+          return tmp_spls;
         }
       };
       double get_default_step_height () const { return default_step_height;};

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -94,7 +94,7 @@ namespace rats
     {
         double toe_heel_phase_ratio[NUM_TH_PHASES];
         size_t toe_heel_phase_count[NUM_TH_PHASES], one_step_count;
-        bool calc_toe_heel_phase_count_from_raio ()
+        void calc_toe_heel_phase_count_from_raio ()
         {
             double ratio_sum = 0.0;
             for (size_t i = 0; i < NUM_TH_PHASES; i++) {
@@ -939,7 +939,7 @@ namespace rats
     size_t get_footstep_index() const { return lcg.get_footstep_index(); };
     size_t get_lcg_count() const { return lcg.get_lcg_count(); };
     double get_current_swing_time(const size_t idx) const { return lcg.get_current_swing_time(idx); };
-    size_t get_current_support_state() const { return lcg.get_current_support_state();};
+    leg_type get_current_support_state() const { return lcg.get_current_support_state();};
     double get_default_step_time () const { return default_step_time; };
     double get_default_step_height () const { return lcg.get_default_step_height(); };
     double get_default_double_support_ratio () const { return default_double_support_ratio; };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -765,8 +765,6 @@ namespace rats
     //preview_dynamics_filter<preview_control>* preview_controller_ptr;
     preview_dynamics_filter<extended_preview_control>* preview_controller_ptr;
 
-    void solve_angle_vector (const leg_type support_leg, const coordinates& support_leg_coords,
-                             const coordinates& swing_leg_coords, const hrp::Vector3& cog);
     void append_go_pos_step_node (const coordinates& _foot_midcoords,
                                   const leg_type _l_r)
     {

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -68,13 +68,13 @@ private:
                 fprintf(fp, "%f ", cogpos);
             }
             // Foot pos
-            hrp::Vector3 rfoot_pos = (gg->get_support_leg() == "rleg") ? gg->get_support_leg_coords().pos : gg->get_swing_leg_coords().pos;
+            hrp::Vector3 rfoot_pos = (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_leg_coords_list().front().pos : gg->get_swing_leg_coords_list().front().pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", rfoot_pos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), rfoot_pos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), rfoot_pos(ii));
             }
-            hrp::Vector3 lfoot_pos = (gg->get_support_leg() == "lleg") ? gg->get_support_leg_coords().pos : gg->get_swing_leg_coords().pos;
+            hrp::Vector3 lfoot_pos = (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_leg_coords_list().front().pos : gg->get_swing_leg_coords_list().front().pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", lfoot_pos(ii));
                 min_lfoot_pos(ii) = std::min(min_lfoot_pos(ii), lfoot_pos(ii));
@@ -82,22 +82,22 @@ private:
             }
             // Foot rot
             hrp::Vector3 rpy;
-            hrp::Matrix33 rfoot_rot = (gg->get_support_leg() == "rleg") ? gg->get_support_leg_coords().rot : gg->get_swing_leg_coords().rot;
+            hrp::Matrix33 rfoot_rot = (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_leg_coords_list().front().rot : gg->get_swing_leg_coords_list().front().rot;
             rpy = hrp::rpyFromRot(rfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
-            hrp::Matrix33 lfoot_rot = (gg->get_support_leg() == "lleg") ? gg->get_support_leg_coords().rot : gg->get_swing_leg_coords().rot;
+            hrp::Matrix33 lfoot_rot = (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_leg_coords_list().front().rot : gg->get_swing_leg_coords_list().front().rot;
             rpy = hrp::rpyFromRot(lfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
             // ZMP offsets
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg() == "rleg") ? gg->get_support_foot_zmp_offset()(ii) : gg->get_swing_foot_zmp_offset()(ii));
+                fprintf(fp, "%f ", (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_foot_zmp_offset_list().front()(ii) : gg->get_swing_foot_zmp_offset_list().front()(ii));
             }
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg() == "lleg") ? gg->get_support_foot_zmp_offset()(ii) : gg->get_swing_foot_zmp_offset()(ii));
+                fprintf(fp, "%f ", (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_foot_zmp_offset_list().front()(ii) : gg->get_swing_foot_zmp_offset_list().front()(ii));
             }
             // Swing time
             fprintf(fp, "%f %f ",
@@ -317,7 +317,7 @@ private:
     {
         parse_params();
         gg->print_param();
-        gg->initialize_gait_parameter(cog, initial_support_leg_coords, initial_swing_leg_dst_coords);
+        gg->initialize_gait_parameter(cog, boost::assign::list_of(initial_support_leg_coords), boost::assign::list_of(initial_swing_leg_dst_coords));
         while ( !gg->proc_one_tick() );
         //gg->print_footstep_list();
         plot_walk_pattern();
@@ -325,8 +325,8 @@ private:
 
     void gen_and_plot_walk_pattern()
     {
-        coordinates initial_support_leg_coords(gg->get_footstep_front_leg()=="rleg"?leg_pos[1]:leg_pos[0]);
-        coordinates initial_swing_leg_dst_coords(gg->get_footstep_front_leg()!="rleg"?leg_pos[1]:leg_pos[0]);
+        coordinates initial_support_leg_coords(gg->get_footstep_front_leg_list()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
+        coordinates initial_swing_leg_dst_coords(gg->get_footstep_front_leg_list()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
         gen_and_plot_walk_pattern(initial_support_leg_coords, initial_swing_leg_dst_coords);
     }
 
@@ -346,13 +346,13 @@ public:
         std::cerr << "test0 : Set foot steps" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        gg->set_foot_steps(fnl);
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -361,8 +361,8 @@ public:
         std::cerr << "test1 : Go pos x,y,th combination" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
-        gg->go_pos_param_2_footstep_list(200*1e-3, 100*1e-3, 20, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
+        gg->clear_footstep_node_list_list();
+        gg->go_pos_param_2_footstep_list_list(200*1e-3, 100*1e-3, 20, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -371,8 +371,8 @@ public:
         std::cerr << "test2 : Go pos x" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
-        gg->go_pos_param_2_footstep_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_node_list_list();
+        gg->go_pos_param_2_footstep_list_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -381,8 +381,8 @@ public:
         std::cerr << "test3 : Go pos y" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
-        gg->go_pos_param_2_footstep_list(0, 150*1e-3, 0, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
+        gg->clear_footstep_node_list_list();
+        gg->go_pos_param_2_footstep_list_list(0, 150*1e-3, 0, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -391,8 +391,8 @@ public:
         std::cerr << "test4 : Go pos th" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
-        gg->go_pos_param_2_footstep_list(0, 0, 30, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_node_list_list();
+        gg->go_pos_param_2_footstep_list_list(0, 0, 30, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -401,14 +401,14 @@ public:
         std::cerr << "test5 : Set foot steps with Z change" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 100*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        gg->set_foot_steps(fnl);
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 100*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -416,8 +416,8 @@ public:
     {
         std::cerr << "test6 : Go single step" << std::endl;
         parse_params();
-        gg->clear_footstep_node_list();
-        gg->go_single_step_param_2_footstep_list(100*1e-3, 0, 0, 0, "rleg", coordinates(leg_pos[0]));
+        gg->clear_footstep_node_list_list();
+        gg->go_single_step_param_2_footstep_list_list(100*1e-3, 0, 0, 0, "rleg", coordinates(leg_pos[0]));
         gen_and_plot_walk_pattern();
     };
 
@@ -438,8 +438,8 @@ public:
         gg->set_heel_angle(10);
         // gg->set_use_toe_heel_transition(false);
         gg->set_use_toe_heel_transition(true);
-        gg->clear_footstep_node_list();
-        gg->go_pos_param_2_footstep_list(100*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_node_list_list();
+        gg->go_pos_param_2_footstep_list_list(100*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -460,12 +460,12 @@ public:
         gg->set_heel_angle(10);
         // gg->set_use_toe_heel_transition(false);
         gg->set_use_toe_heel_transition(true);
-        gg->clear_footstep_node_list();
+        gg->clear_footstep_node_list_list();
         hrp::Matrix33 initial_foot_mid_rot = Eigen::AngleAxis<double>(M_PI/2, hrp::Vector3::UnitZ()).toRotationMatrix();
         //hrp::Matrix33 initial_foot_mid_rot = Eigen::AngleAxis<double>(M_PI, hrp::Vector3::UnitZ()).toRotationMatrix();
-        gg->go_pos_param_2_footstep_list(100*1e-3, 0, 0, coordinates(initial_foot_mid_rot*leg_pos[1], initial_foot_mid_rot), coordinates(initial_foot_mid_rot*leg_pos[0], initial_foot_mid_rot), LLEG);
-        coordinates initial_support_leg_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg()=="rleg"?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
-        coordinates initial_swing_leg_dst_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg()!="rleg"?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
+        gg->go_pos_param_2_footstep_list_list(100*1e-3, 0, 0, coordinates(initial_foot_mid_rot*leg_pos[1], initial_foot_mid_rot), coordinates(initial_foot_mid_rot*leg_pos[0], initial_foot_mid_rot), LLEG);
+        coordinates initial_support_leg_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg_list()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
+        coordinates initial_swing_leg_dst_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg_list()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
         gen_and_plot_walk_pattern(initial_support_leg_coords, initial_swing_leg_dst_coords);
 
     };
@@ -475,19 +475,19 @@ public:
         std::cerr << "test9 : Stair walk" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
+        gg->clear_footstep_node_list_list();
         gg->set_default_orbit_type(STAIR);
         gg->set_swing_trajectory_delay_time_offset (0.2);
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        gg->set_foot_steps(fnl);
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -496,7 +496,7 @@ public:
         std::cerr << "test10 : Stair walk + toe heel contact" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
+        gg->clear_footstep_node_list_list();
         gg->set_default_orbit_type(STAIR);
         gg->set_swing_trajectory_delay_time_offset (0.2);
         gg->set_toe_zmp_offset_x(137*1e-3);
@@ -510,16 +510,16 @@ public:
         double ratio[7] = {0.02, 0.28, 0.2, 0.0, 0.2, 0.25, 0.05};
         std::vector<double> ratio2(ratio, ratio+gg->get_NUM_TH_PHASES());
         gg->set_toe_heel_phase_ratio(ratio2);
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        gg->set_foot_steps(fnl);
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -529,13 +529,13 @@ public:
         /* initialize sample footstep_list */
         parse_params();
         hrp::Matrix33 tmpr;
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
         tmpr = hrp::rotFromRpy(5*M_PI/180.0, 15*M_PI/180.0, 0);
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[0]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[0]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
         tmpr = hrp::rotFromRpy(-5*M_PI/180.0, -15*M_PI/180.0, 0);
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[1]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle()));
-        gg->set_foot_steps(fnl);
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[1]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -544,15 +544,15 @@ public:
         std::cerr << "test12 : Change step param in set foot steps" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector<step_node> fnl;
+        std::vector< std::vector<step_node> > fnll;
         gg->set_default_step_time(4.0); // dummy
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 0, 0));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height()*2, 1.5, 0, 0));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.5, 0, 0));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 20, 5));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0));
-        gg->set_foot_steps(fnl);
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height()*2, 1.5, 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.5, 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 20, 5)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -561,14 +561,14 @@ public:
         std::cerr << "test13 : Arbitrary leg switching" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector<step_node> fnl;
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        fnl.push_back(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        fnl.push_back(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0));
-        gg->set_foot_steps(fnl);
+        std::vector< std::vector<step_node> > fnll;
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        gg->set_foot_steps_list(fnll);
         gen_and_plot_walk_pattern();
     };
 
@@ -577,9 +577,9 @@ public:
         std::cerr << "test14 : kick walk" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list();
+        gg->clear_footstep_node_list_list();
         gg->set_default_orbit_type(CYCLOIDDELAYKICK);
-        gg->go_pos_param_2_footstep_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->go_pos_param_2_footstep_list_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -68,13 +68,13 @@ private:
                 fprintf(fp, "%f ", cogpos);
             }
             // Foot pos
-            hrp::Vector3 rfoot_pos = (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_leg_coords_list().front().pos : gg->get_swing_leg_coords_list().front().pos;
+            hrp::Vector3 rfoot_pos = (gg->get_support_legs() == boost::assign::list_of("rleg")) ? gg->get_support_legs_coords().front().pos : gg->get_swing_legs_coords().front().pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", rfoot_pos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), rfoot_pos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), rfoot_pos(ii));
             }
-            hrp::Vector3 lfoot_pos = (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_leg_coords_list().front().pos : gg->get_swing_leg_coords_list().front().pos;
+            hrp::Vector3 lfoot_pos = (gg->get_support_legs() == boost::assign::list_of("lleg")) ? gg->get_support_legs_coords().front().pos : gg->get_swing_legs_coords().front().pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", lfoot_pos(ii));
                 min_lfoot_pos(ii) = std::min(min_lfoot_pos(ii), lfoot_pos(ii));
@@ -82,22 +82,22 @@ private:
             }
             // Foot rot
             hrp::Vector3 rpy;
-            hrp::Matrix33 rfoot_rot = (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_leg_coords_list().front().rot : gg->get_swing_leg_coords_list().front().rot;
+            hrp::Matrix33 rfoot_rot = (gg->get_support_legs() == boost::assign::list_of("rleg")) ? gg->get_support_legs_coords().front().rot : gg->get_swing_legs_coords().front().rot;
             rpy = hrp::rpyFromRot(rfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
-            hrp::Matrix33 lfoot_rot = (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_leg_coords_list().front().rot : gg->get_swing_leg_coords_list().front().rot;
+            hrp::Matrix33 lfoot_rot = (gg->get_support_legs() == boost::assign::list_of("lleg")) ? gg->get_support_legs_coords().front().rot : gg->get_swing_legs_coords().front().rot;
             rpy = hrp::rpyFromRot(lfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
             // ZMP offsets
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg_list() == boost::assign::list_of("rleg")) ? gg->get_support_foot_zmp_offset_list().front()(ii) : gg->get_swing_foot_zmp_offset_list().front()(ii));
+                fprintf(fp, "%f ", (gg->get_support_legs() == boost::assign::list_of("rleg")) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg_list() == boost::assign::list_of("lleg")) ? gg->get_support_foot_zmp_offset_list().front()(ii) : gg->get_swing_foot_zmp_offset_list().front()(ii));
+                fprintf(fp, "%f ", (gg->get_support_legs() == boost::assign::list_of("lleg")) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
             // Swing time
             fprintf(fp, "%f %f ",
@@ -325,8 +325,8 @@ private:
 
     void gen_and_plot_walk_pattern()
     {
-        coordinates initial_support_leg_coords(gg->get_footstep_front_leg_list()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
-        coordinates initial_swing_leg_dst_coords(gg->get_footstep_front_leg_list()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
+        coordinates initial_support_leg_coords(gg->get_footstep_front_legs()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
+        coordinates initial_swing_leg_dst_coords(gg->get_footstep_front_legs()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0]);
         gen_and_plot_walk_pattern(initial_support_leg_coords, initial_swing_leg_dst_coords);
     }
 
@@ -346,13 +346,13 @@ public:
         std::cerr << "test0 : Set foot steps" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        gg->set_foot_steps_list(fnll);
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -361,8 +361,8 @@ public:
         std::cerr << "test1 : Go pos x,y,th combination" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
-        gg->go_pos_param_2_footstep_list_list(200*1e-3, 100*1e-3, 20, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
+        gg->clear_footstep_nodes_list();
+        gg->go_pos_param_2_footstep_nodes_list(200*1e-3, 100*1e-3, 20, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -371,8 +371,8 @@ public:
         std::cerr << "test2 : Go pos x" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
-        gg->go_pos_param_2_footstep_list_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_nodes_list();
+        gg->go_pos_param_2_footstep_nodes_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -381,8 +381,8 @@ public:
         std::cerr << "test3 : Go pos y" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
-        gg->go_pos_param_2_footstep_list_list(0, 150*1e-3, 0, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
+        gg->clear_footstep_nodes_list();
+        gg->go_pos_param_2_footstep_nodes_list(0, 150*1e-3, 0, coordinates(leg_pos[0]), coordinates(leg_pos[1]), RLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -391,8 +391,8 @@ public:
         std::cerr << "test4 : Go pos th" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
-        gg->go_pos_param_2_footstep_list_list(0, 0, 30, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_nodes_list();
+        gg->go_pos_param_2_footstep_nodes_list(0, 0, 30, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -401,14 +401,14 @@ public:
         std::cerr << "test5 : Set foot steps with Z change" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 100*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        gg->set_foot_steps_list(fnll);
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 100*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 300*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -416,8 +416,8 @@ public:
     {
         std::cerr << "test6 : Go single step" << std::endl;
         parse_params();
-        gg->clear_footstep_node_list_list();
-        gg->go_single_step_param_2_footstep_list_list(100*1e-3, 0, 0, 0, "rleg", coordinates(leg_pos[0]));
+        gg->clear_footstep_nodes_list();
+        gg->go_single_step_param_2_footstep_nodes_list(100*1e-3, 0, 0, 0, "rleg", coordinates(leg_pos[0]));
         gen_and_plot_walk_pattern();
     };
 
@@ -438,8 +438,8 @@ public:
         gg->set_heel_angle(10);
         // gg->set_use_toe_heel_transition(false);
         gg->set_use_toe_heel_transition(true);
-        gg->clear_footstep_node_list_list();
-        gg->go_pos_param_2_footstep_list_list(100*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->clear_footstep_nodes_list();
+        gg->go_pos_param_2_footstep_nodes_list(100*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 
@@ -460,12 +460,12 @@ public:
         gg->set_heel_angle(10);
         // gg->set_use_toe_heel_transition(false);
         gg->set_use_toe_heel_transition(true);
-        gg->clear_footstep_node_list_list();
+        gg->clear_footstep_nodes_list();
         hrp::Matrix33 initial_foot_mid_rot = Eigen::AngleAxis<double>(M_PI/2, hrp::Vector3::UnitZ()).toRotationMatrix();
         //hrp::Matrix33 initial_foot_mid_rot = Eigen::AngleAxis<double>(M_PI, hrp::Vector3::UnitZ()).toRotationMatrix();
-        gg->go_pos_param_2_footstep_list_list(100*1e-3, 0, 0, coordinates(initial_foot_mid_rot*leg_pos[1], initial_foot_mid_rot), coordinates(initial_foot_mid_rot*leg_pos[0], initial_foot_mid_rot), LLEG);
-        coordinates initial_support_leg_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg_list()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
-        coordinates initial_swing_leg_dst_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_leg_list()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
+        gg->go_pos_param_2_footstep_nodes_list(100*1e-3, 0, 0, coordinates(initial_foot_mid_rot*leg_pos[1], initial_foot_mid_rot), coordinates(initial_foot_mid_rot*leg_pos[0], initial_foot_mid_rot), LLEG);
+        coordinates initial_support_leg_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_legs()==boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
+        coordinates initial_swing_leg_dst_coords(hrp::Vector3(initial_foot_mid_rot * (gg->get_footstep_front_legs()!=boost::assign::list_of("rleg")?leg_pos[1]:leg_pos[0])), initial_foot_mid_rot);
         gen_and_plot_walk_pattern(initial_support_leg_coords, initial_swing_leg_dst_coords);
 
     };
@@ -475,19 +475,19 @@ public:
         std::cerr << "test9 : Stair walk" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
+        gg->clear_footstep_nodes_list();
         gg->set_default_orbit_type(STAIR);
         gg->set_swing_trajectory_delay_time_offset (0.2);
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        gg->set_foot_steps_list(fnll);
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -496,7 +496,7 @@ public:
         std::cerr << "test10 : Stair walk + toe heel contact" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
+        gg->clear_footstep_nodes_list();
         gg->set_default_orbit_type(STAIR);
         gg->set_swing_trajectory_delay_time_offset (0.2);
         gg->set_toe_zmp_offset_x(137*1e-3);
@@ -510,16 +510,16 @@ public:
         double ratio[7] = {0.02, 0.28, 0.2, 0.0, 0.2, 0.25, 0.05};
         std::vector<double> ratio2(ratio, ratio+gg->get_NUM_TH_PHASES());
         gg->set_toe_heel_phase_ratio(ratio2);
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        gg->set_foot_steps_list(fnll);
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 200*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(500*1e-3, 0, 400*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(750*1e-3, 0, 600*1e-3)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -529,13 +529,13 @@ public:
         /* initialize sample footstep_list */
         parse_params();
         hrp::Matrix33 tmpr;
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
         tmpr = hrp::rotFromRpy(5*M_PI/180.0, 15*M_PI/180.0, 0);
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[0]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[0]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
         tmpr = hrp::rotFromRpy(-5*M_PI/180.0, -15*M_PI/180.0, 0);
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[1]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        gg->set_foot_steps_list(fnll);
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(250*1e-3, 0, 0*1e-3)+leg_pos[1]), tmpr), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -544,15 +544,15 @@ public:
         std::cerr << "test12 : Change step param in set foot steps" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector< std::vector<step_node> > fnll;
+        std::vector< std::vector<step_node> > fnsl;
         gg->set_default_step_time(4.0); // dummy
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height()*2, 1.5, 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.5, 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 20, 5)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
-        gg->set_foot_steps_list(fnll);
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height()*2, 1.5, 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.5, 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), 1.0, 20, 5)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(300*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), 2.0, 0, 0)));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -561,14 +561,14 @@ public:
         std::cerr << "test13 : Arbitrary leg switching" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        std::vector< std::vector<step_node> > fnll;
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        fnll.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
-        gg->set_foot_steps_list(fnll);
+        std::vector< std::vector<step_node> > fnsl;
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), 0, 0)));
+        gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };
 
@@ -577,9 +577,9 @@ public:
         std::cerr << "test14 : kick walk" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
-        gg->clear_footstep_node_list_list();
+        gg->clear_footstep_nodes_list();
         gg->set_default_orbit_type(CYCLOIDDELAYKICK);
-        gg->go_pos_param_2_footstep_list_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
+        gg->go_pos_param_2_footstep_nodes_list(300*1e-3, 0, 0, coordinates(leg_pos[1]), coordinates(leg_pos[0]), LLEG);
         gen_and_plot_walk_pattern();
     };
 


### PR DESCRIPTION
AutoBalancerに与えるfootstepに腕も与えられるように追加しようとしています．

例えば

RLEG -> LLEG -> RLEG -> ...

を

{RLEG, LARM} -> {LLEG, RARM} -> {RLEG, LARM} -> ...

などに拡張できるようにしようとしていて，その第一歩として，時系列のフットステップのリストをフットステップのリストのリストにしたので一旦コミットさせていただきます．

※ APIは変えておらず，現状の二足歩行のテストプログラム(testGaitGenerator.cpp / test-samplerobot-abc.py)が動くことを確認しました．
