### PR TITLE
Add methods to enable torque controller entirely

### DIFF
--- a/idl/TorqueControllerService.idl
+++ b/idl/TorqueControllerService.idl
@@ -19,7 +19,35 @@ module OpenHRP
       double alpha; // for TwoDofControllerDynamicModel
       double beta; // for TwoDofControllerDynamicModel
     };
+
+    /**
+     * @brief enable torque controller in specified joint
+     * @param jname: target joint name
+     * @return true if set successfully, false otherwise
+     */
+    boolean enableTorqueController(in string jname);
+
+    /**
+     * @brief enable torque controller in specified joints
+     * @param jnames: target joint names
+     * @return true if set successfully, false otherwise
+     */
+    boolean enableMultipleTorqueControllers(in StrSequence jnames);
     
+    /**
+     * @brief disable torque controller in specified joint
+     * @param jname: target joint name
+     * @return true if set successfully, false otherwise
+     */
+    boolean disableTorqueController(in string jname);
+
+    /**
+     * @brief disable torque controller in specified joints
+     * @param jnames: target joint names
+     * @return true if set successfully, false otherwise
+     */
+    boolean disableMultipleTorqueControllers(in StrSequence jnames);
+      
     /**
      * @brief start torque controller in specified joint
      * @param jname: target joint name

--- a/rtc/TorqueController/MotorTorqueController.cpp
+++ b/rtc/TorqueController/MotorTorqueController.cpp
@@ -128,7 +128,7 @@ bool MotorTorqueController::enable(void)
 bool MotorTorqueController::disable(void)
 {
   bool retval;
-  if (m_emergencyController.state != INACTIVE) {
+  if (m_normalController.state != INACTIVE) {
     std::cerr << "[" << m_error_prefix << "]" << "Normal torque control in " << m_joint_name << " is active" << std::endl;
     retval = false;
   } else if (m_emergencyController.state != INACTIVE) {

--- a/rtc/TorqueController/MotorTorqueController.h
+++ b/rtc/TorqueController/MotorTorqueController.h
@@ -48,17 +48,23 @@ public:
   void setupController(TwoDofControllerDynamicsModel::TwoDofControllerDynamicsModelParam &_param);
   bool updateControllerParam(TwoDofControllerDynamicsModel::TwoDofControllerDynamicsModelParam &_param);
 
+  // for normal/emergency torque contorller
+  bool enable(void); // enable torque controller (normal controller is not activated but emergency toruqe control may be activated)
+  bool disable(void); // disable torque controller (emergency controller is also ignored)
+
+  // for normal torque controller
   void setupMotorControllerMinMaxDq(double _min_dq, double _max_dq); // set min/max dq for transition
   bool activate(void); // set state of torque controller to ACTIVE
   bool deactivate(void); // set state of torque controller to STOP -> INACTIVE
   bool setReferenceTorque(double _tauRef); // set reference torque (does not activate controller)
-  double execute(double _tau, double _tauMax); // determine final state and tauRef, then throw tau, tauRef and state to executeControl
 
-  motor_model_t getMotorModelType(void);
+  double execute(double _tau, double _tauMax); // determine final state and tauRef, then throw tau, tauRef and state to executeControl
   
   // accessor
+  motor_model_t getMotorModelType(void);
   std::string getJointName(void);
   controller_state_t getMotorControllerState(void);
+  bool isEnabled(void);
 
   // for debug
   void setErrorPrefix(const std::string& _error_prefix);
@@ -108,6 +114,7 @@ private:
   MotorController m_normalController; // substance of two dof controller
   MotorController m_emergencyController; // overwrite normal controller when emergency
   std::string m_error_prefix; // assumed to be instance name of rtc
+  bool m_enable_flag;
 };
 
 

--- a/rtc/TorqueController/TorqueController.cpp
+++ b/rtc/TorqueController/TorqueController.cpp
@@ -396,6 +396,60 @@ void TorqueController::executeTorqueControl(hrp::dvector &dq)
   return;
 }
 
+bool TorqueController::enableTorqueController(std::string jname)
+{
+  bool succeed = false;
+  for (std::vector<MotorTorqueController>::iterator it = m_motorTorqueControllers.begin(); it != m_motorTorqueControllers.end(); ++it) {
+    if ((*it).getJointName() == jname){
+      if (m_debugLevel > 0) {
+        std::cerr << "[" <<  m_profile.instance_name << "]" << "Enable torque controller in " << jname << std::endl;
+      }
+      succeed = (*it).enable();
+    }
+  }
+  return succeed;
+}
+
+bool TorqueController::enableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames)
+{
+  bool succeed = true;
+  bool retval;
+  for (int i = 0; i < jnames.length(); i++) {
+    retval = enableTorqueController(std::string(jnames[i]));
+    if (!retval) { // return false when once failed
+      succeed = false;
+    }
+  }
+  return succeed;
+}
+
+bool TorqueController::disableTorqueController(std::string jname)
+{
+  bool succeed = false;
+  for (std::vector<MotorTorqueController>::iterator it = m_motorTorqueControllers.begin(); it != m_motorTorqueControllers.end(); ++it) {
+    if ((*it).getJointName() == jname){
+      if (m_debugLevel > 0) {
+        std::cerr << "[" <<  m_profile.instance_name << "]" << "Disable torque controller in " << jname << std::endl;
+      }
+      succeed = (*it).disable();
+    }
+  }
+  return succeed;
+}
+
+bool TorqueController::disableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames)
+{
+  bool succeed = true;
+  bool retval;
+  for (int i = 0; i < jnames.length(); i++) {
+    retval = disableTorqueController(std::string(jnames[i]));
+    if (!retval) { // return false when once failed
+      succeed = false;
+    }
+  }
+  return succeed;
+}
+
 bool TorqueController::startTorqueControl(std::string jname)
 {
   bool succeed = false;
@@ -420,6 +474,7 @@ bool TorqueController::startMultipleTorqueControls(const OpenHRP::TorqueControll
       succeed = false;
     }
   }
+  return succeed;
 }
 
 bool TorqueController::stopTorqueControl(std::string jname)
@@ -446,6 +501,7 @@ bool TorqueController::stopMultipleTorqueControls(const OpenHRP::TorqueControlle
       succeed = false;
     }
   }
+  return succeed;
 }
 
 bool TorqueController::setReferenceTorque(std::string jname, double tauRef)

--- a/rtc/TorqueController/TorqueController.h
+++ b/rtc/TorqueController/TorqueController.h
@@ -101,7 +101,10 @@ public:
 // The action that is invoked when execution context's rate is changed
 // no corresponding operation exists in OpenRTm-aist-0.2.0
 // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
-
+  bool enableTorqueController(std::string jname);
+  bool enableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames);
+  bool disableTorqueController(std::string jname);
+  bool disableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames);
   bool startTorqueControl(std::string jname);
   bool startMultipleTorqueControls(const OpenHRP::TorqueControllerService::StrSequence& jnames);
   bool stopTorqueControl(std::string jname);

--- a/rtc/TorqueController/TorqueControllerService_impl.cpp
+++ b/rtc/TorqueController/TorqueControllerService_impl.cpp
@@ -11,6 +11,26 @@ TorqueControllerService_impl::~TorqueControllerService_impl()
 {
 }
 
+CORBA::Boolean TorqueControllerService_impl::enableTorqueController(const char *jointName)
+{
+	return m_torque_controller->enableTorqueController(std::string(jointName));
+}
+
+CORBA::Boolean TorqueControllerService_impl::enableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames)
+{
+	return m_torque_controller->enableMultipleTorqueControllers(jnames);
+}
+
+CORBA::Boolean TorqueControllerService_impl::disableTorqueController(const char *jointName)
+{
+	return m_torque_controller->disableTorqueController(std::string(jointName));
+}
+
+CORBA::Boolean TorqueControllerService_impl::disableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames)
+{
+	return m_torque_controller->disableMultipleTorqueControllers(jnames);
+}
+
 CORBA::Boolean TorqueControllerService_impl::startTorqueControl(const char *jointName)
 {
 	return m_torque_controller->startTorqueControl(std::string(jointName));

--- a/rtc/TorqueController/TorqueControllerService_impl.h
+++ b/rtc/TorqueController/TorqueControllerService_impl.h
@@ -16,6 +16,11 @@ public:
 	TorqueControllerService_impl();
 	virtual ~TorqueControllerService_impl();
 
+	CORBA::Boolean enableTorqueController(const char *jointName);
+	CORBA::Boolean enableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames);
+	CORBA::Boolean disableTorqueController(const char *jointName);
+	CORBA::Boolean disableMultipleTorqueControllers(const OpenHRP::TorqueControllerService::StrSequence& jnames);
+	
 	CORBA::Boolean startTorqueControl(const char *jointName);
 	CORBA::Boolean startMultipleTorqueControls(const OpenHRP::TorqueControllerService::StrSequence& jnames);
 	CORBA::Boolean stopTorqueControl(const char *jointName);


### PR DESCRIPTION
Related to https://github.com/start-jsk/rtmros_tutorials/issues/356.
Prevent both normal and emergency torque control from modifying joint angles when torque controller is disabled.