### PR TITLE
Update 2

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -453,7 +453,7 @@ namespace rats
       prev_que_rzmp = rzmp;
       prev_que_sfzos = sfzos;
     }
-    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets.front(), rzmp, sfzos.front(), (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
+    bool solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
     /* update refzmp */
     if ( lcg.get_lcg_count() == static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1 ) { // Almost middle of step time
       if (velocity_mode_flg != VEL_IDLING && lcg.get_footstep_index() > 0) {
@@ -713,7 +713,7 @@ namespace rats
     bool not_solved = true;
     while (not_solved) {
       bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
-      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets[0], rzmp, sfzos[0], refzmp_exist_p);
+      not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, refzmp_exist_p);
       rg.update_refzmp(footstep_nodes_list);
     }
   };

--- a/rtc/AutoBalancer/PreviewController.cpp
+++ b/rtc/AutoBalancer/PreviewController.cpp
@@ -5,7 +5,7 @@ using namespace hrp;
 using namespace rats;
 
 template <std::size_t dim>
-void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr, const hrp::Vector3& _qdata)
+void preview_control_base<dim>::update_x_k(const hrp::Vector3& pr, const std::vector<hrp::Vector3>& _qdata)
 {
   zmp_z = pr(2);
   Eigen::Matrix<double, 2, 1> tmpv;

--- a/rtc/AutoBalancer/PreviewController.h
+++ b/rtc/AutoBalancer/PreviewController.h
@@ -60,7 +60,7 @@ namespace rats
     hrp::dvector f;
     std::deque<Eigen::Matrix<double, 2, 1> > p;
     std::deque<double> pz;
-    std::deque<hrp::Vector3> qdata;
+    std::deque< std::vector<hrp::Vector3> > qdata;
     double zmp_z, cog_z;
     size_t delay, ending_count;
     virtual void calc_f() = 0;
@@ -101,7 +101,7 @@ namespace rats
       pz.clear();
       qdata.clear();
     };
-    virtual void update_x_k(const hrp::Vector3& pr, const hrp::Vector3& qdata);
+    virtual void update_x_k(const hrp::Vector3& pr, const std::vector<hrp::Vector3>& qdata);
     virtual void update_x_k()
     {
       hrp::Vector3 pr;
@@ -132,7 +132,7 @@ namespace rats
       ret[1] = p.front()(1);
       ret[2] = pz.front();
     };
-    void get_current_qdata (hrp::Vector3& _qdata)
+    void get_current_qdata (std::vector<hrp::Vector3>& _qdata)
     {
         _qdata = qdata.front();
     };
@@ -218,7 +218,7 @@ namespace rats
     preview_dynamics_filter(const double dt, const double zc, const hrp::Vector3& init_xk, const double _gravitational_acceleration = DEFAULT_GRAVITATIONAL_ACCELERATION, const double q = 1.0, const double r = 1.0e-6, const double d = 1.6)
         : preview_controller(dt, zc, init_xk, _gravitational_acceleration, q, r, d), finishedp(false) {};
     ~preview_dynamics_filter() {};
-    bool update(hrp::Vector3& p_ret, hrp::Vector3& x_ret, hrp::Vector3& qdata_ret, const hrp::Vector3& pr, const hrp::Vector3& qdata, const bool updatep)
+    bool update(hrp::Vector3& p_ret, hrp::Vector3& x_ret, std::vector<hrp::Vector3>& qdata_ret, const hrp::Vector3& pr, const std::vector<hrp::Vector3>& qdata, const bool updatep)
     {
       bool flg;
       if (updatep) {

--- a/rtc/AutoBalancer/testPreviewController.cpp
+++ b/rtc/AutoBalancer/testPreviewController.cpp
@@ -51,7 +51,8 @@ int main(int argc, char* argv[])
   bool r = true;
   size_t index = 0;
   while (r) {
-    hrp::Vector3 p, x, qdata;
+    hrp::Vector3 p, x;
+    std::vector<hrp::Vector3> qdata;
     r = df.update(p, x, qdata, ref_zmp_list.front(), qdata, !ref_zmp_list.empty());
     if (r) {
       index++;

--- a/rtc/AutoBalancer/testPreviewController.cpp
+++ b/rtc/AutoBalancer/testPreviewController.cpp
@@ -77,9 +77,9 @@ int main(int argc, char* argv[])
   for (size_t ii = 0; ii < 2; ii++) {
     gp[ii] = popen("gnuplot", "w");
     fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
-    fprintf(gp[ii], "plot \"%s\" using 1:%d with lines title \"cart-table zmp\"\n", fname.c_str(), ( ii * 3 + 2));
-    fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"cog\"\n", fname.c_str(), ( ii * 3 + 3));
-    fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"refzmp\"\n", fname.c_str(), ( ii * 3 + 4));
+    fprintf(gp[ii], "plot \"%s\" using 1:%zu with lines title \"cart-table zmp\"\n", fname.c_str(), ( ii * 3 + 2));
+    fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"cog\"\n", fname.c_str(), ( ii * 3 + 3));
+    fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"refzmp\"\n", fname.c_str(), ( ii * 3 + 4));
     fflush(gp[ii]);
   }
   double tmp;


### PR DESCRIPTION
PreviewControllerに入力しているzmp_offsetの型を hrp::Vector3 から std::vector<hrp::Vector3> に変えることで，遊脚が複数のときにも使えるようにしました．
