### PR TITLE
Enable thermolimiter and thermoestimator

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -662,8 +662,8 @@ class HrpsysConfigurator:
             ['st', "Stabilizer"],
             ['co', "CollisionDetector"],
             ['tc', "TorqueController"],
-            # ['te', "ThermoEstimator"],
-            # ['tl', "ThermoLimiter"],
+            ['te', "ThermoEstimator"],
+            ['tl', "ThermoLimiter"],
             ['hes', "EmergencyStopper"],
             ['el', "SoftErrorLimiter"],
             ['log', "DataLogger"]


### PR DESCRIPTION
Thermolimiter and thermoestimatorをdefaultのunstable rtcで有効にしました。
HRP２ではどちらも実機で使っています。
@orikumaさん確認お願いします。

よろしくお願いします。