### PR TITLE
[GaitGenerator.*] improve get_swing_legs of leg_coords_generator for …

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -2,7 +2,6 @@
 
 #include "GaitGenerator.h"
 #include <numeric>
-#include <boost/range/algorithm/count_if.hpp>
 
 namespace rats
 {


### PR DESCRIPTION
…multiple legs


https://github.com/fkanehiro/hrpsys-base/pull/742 の続きです．

- leg_coords_generator::get_swing_legsにて，脚候補を引数に取ることで，support legリストからswing legのリストを取得できるようにした