### PR TITLE
[GaitGenerator.*] use std::count_if instead of boost::count_if since …

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -630,14 +630,14 @@ namespace rats
     /* inside step limitation */
     if (use_inside_step_limitation) {
         if (vel_param.velocity_y > 0) {
-            if (boost::count_if(sup_fns, (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dy *= 0.5;
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dy *= 0.5;
         } else {
-            if (boost::count_if(sup_fns, (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dy *= 0.5;
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dy *= 0.5;
         }
         if (vel_param.velocity_theta > 0) {
-            if (boost::count_if(sup_fns, (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dth *= 0.5;
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dth *= 0.5;
         } else {
-            if (boost::count_if(sup_fns, (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dth *= 0.5;
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dth *= 0.5;
         }
     }
     trans = hrp::Vector3(dx * default_step_time, dy * default_step_time, 0);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -807,8 +807,8 @@ namespace rats
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
         use_inside_step_limitation(true),
         preview_controller_ptr(NULL) {
-        swing_foot_zmp_offsets = boost::assign::list_of(hrp::Vector3::Zero());
-        prev_que_sfzos = boost::assign::list_of(hrp::Vector3::Zero());
+        swing_foot_zmp_offsets = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
+        prev_que_sfzos = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
     };
     ~gait_generator () {
       if ( preview_controller_ptr != NULL ) {

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -8,7 +8,6 @@
 #include <queue>
 #include <boost/assign.hpp>
 #include <boost/lambda/lambda.hpp>
-#include <boost/range/algorithm/count_if.hpp>
 
 namespace rats
 {


### PR DESCRIPTION
…HRP2 inside PC does not support boost::count_if

https://github.com/fkanehiro/hrpsys-base/issues/751 を受けて修正しました．

これ以外で使っているboostの関数は

- boost::assign::list_of
- boost::lambda

ですが，バージョン1.34.1のboostが上記の関数を持っていればOKそうなので，調べてみます．