### PR TITLE
add a "name" type to coordinate

### DIFF
--- a/rtc/ImpedanceController/RatsMatrix.h
+++ b/rtc/ImpedanceController/RatsMatrix.h
@@ -18,17 +18,20 @@ namespace rats
   struct coordinates {
     hrp::Vector3 pos;
     hrp::Matrix33 rot;
-    coordinates() : pos(hrp::Vector3::Zero()), rot(hrp::Matrix33::Identity()) {};
-    coordinates(const hrp::Vector3& p, const hrp::Matrix33& r) : pos(p), rot(r) {};
-    coordinates(const hrp::Vector3& p) : pos(p), rot(hrp::Matrix33::Identity()) {};
-    coordinates(const hrp::Matrix33& r) : pos(hrp::Vector3::Zero()), rot(r) {};
-    coordinates(const coordinates& c) : pos(c.pos), rot(c.rot) {};
+    std::string name;
+    coordinates() : pos(hrp::Vector3::Zero()), rot(hrp::Matrix33::Identity()), name("") {};
+    coordinates(const hrp::Vector3& p, const hrp::Matrix33& r) : pos(p), rot(r), name("") {};
+    coordinates(const hrp::Vector3& p, const hrp::Matrix33& r, const std::string& nm) : pos(p), rot(r), name(nm) {};
+    coordinates(const hrp::Vector3& p) : pos(p), rot(hrp::Matrix33::Identity()), name("") {};
+    coordinates(const hrp::Matrix33& r) : pos(hrp::Vector3::Zero()), rot(r), name("") {};
+    coordinates(const coordinates& c) : pos(c.pos), rot(c.rot), name(c.name) {};
     virtual ~coordinates() {
     }
     coordinates& operator=(const coordinates& c) {
       if (this != &c) {
         pos = c.pos;
         rot = c.rot;
+        name = c.name;
       }
       return *this;
     }


### PR DESCRIPTION
@snozawa さん，coordinates構造体に名前のメンバ変数（？）を追加したいのですが，どうでしょうか？

ある瞬間の支持脚の座標系のリスト（{右足の座標, 左手の座標} ）と支持脚の名前のリスト（{左手, 右足}）の順番を一致させる必要があって，そこの整合性をどのように取ろうか考えてみた（以下の※）結果，座標系自体が名前を持っているとシンプルかと思いましてPRを作って見ました．
（eus の footstep-list のようにしたい https://github.com/euslisp/jskeus/blob/master/irteus/demo/walk-motion.l#L15 ）


※他の候補

- 引数が座標系のすべての関数に名前の引数を追加する作戦
   - 最初はこれをやろうとしたけどもなかなか難しかった
- abc の中だけで coodinates-with-name 的な構造体を作って，abcの中ではそれを使う