### PR TITLE
Enable to check ik error.

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -186,6 +186,12 @@ module OpenHRP
       /// Transition time [s] for adjust foot step
       double adjust_footstep_transition_time;
       StrSequence leg_names;
+      /// Flag for inverse kinematics (IK). If true, IK has failed before.
+      boolean has_ik_failed;
+      /// IK position threshold [m]
+      double pos_ik_thre;
+      /// IK rotation threshold [rad]
+      double rot_ik_thre;
     };
 
     /**

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -776,11 +776,11 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param)
   // IK check
   vel_p = param.target_p0 - param.target_link->p;
   rats::difference_rotation(vel_r, param.current_r0, param.target_link->R);
-  if (vel_p.norm() > pos_ik_thre) {
+  if (vel_p.norm() > pos_ik_thre && transition_interpolator->isEmpty()) {
       std::cerr << "[" << m_profile.instance_name << "] Too large IK error (vel_p) = [" << vel_p(0) << " " << vel_p(1) << " " << vel_p(2) << "][m]" << std::endl;
       has_ik_failed = true;
   }
-  if (vel_r.norm() > rot_ik_thre) {
+  if (vel_r.norm() > rot_ik_thre && transition_interpolator->isEmpty()) {
       std::cerr << "[" << m_profile.instance_name << "] Too large IK error (vel_r) = [" << vel_r(0) << " " << vel_r(1) << " " << vel_r(2) << "][rad]" << std::endl;
       has_ik_failed = true;
   }

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -234,12 +234,13 @@ class AutoBalancer
   std::vector<hrp::Vector3> ref_forces;
 
   unsigned int m_debugLevel;
-  bool is_legged_robot, is_stop_mode;
+  bool is_legged_robot, is_stop_mode, has_ik_failed;
   int loop;
   bool graspless_manip_mode;
   std::string graspless_manip_arm;
   hrp::Vector3 graspless_manip_p_gain;
   rats::coordinates graspless_manip_reference_trans_coords;
+  double pos_ik_thre, rot_ik_thre;
 };
 
 


### PR DESCRIPTION
AutoBalancerのIK結果を取得できるようにしました。

@garaemon 
pos_ik_thre、rot_ik_threで誤差のしきい値をかえることができ、
has_ik_failedで一度でも誤差以上になったか取得できます（start-auto-baalncer, 歩行指令時にリセットされます）

よろしくお願いします。