### PR TITLE
Add zmp weight for target zmp calculation

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -198,7 +198,7 @@ module OpenHRP
     struct AutoBalancerParam
     {
       /// ZMP offset vectors[m] for rleg and lleg (<-please set by this order)
-      sequence<DblSequence3, 2> default_zmp_offsets;
+      sequence<DblSequence3> default_zmp_offsets;
       double move_base_gain;
       ControllerMode controller_mode;
       boolean graspless_manip_mode;

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -183,6 +183,8 @@ module OpenHRP
       boolean use_toe_joint;
       /// Use toe heel zmp transition. If true, zmp moves among default position, toe position (described by toe_zmp_offset_x), and heel position (described by heel_zmp_offset_x).
       boolean use_toe_heel_transition;
+      /// ZMP weight of RLEG, LLEG, RARM and LARM
+      sequence<double, 4> zmp_weight_map;
       /// Foot position offset[m] (rleg and lleg)
       sequence<DblSequence3> leg_default_translate_pos;
       /// Number of optional finalize footsteps in goPos

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -142,14 +142,6 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     control_mode = MODE_IDLE;
     loop = 0;
 
-    zmp_interpolator = new interpolator(6, m_dt);
-    zmp_transition_time = 1.0;
-    transition_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
-    transition_interpolator_ratio = 1.0;
-    adjust_footstep_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
-    transition_time = 2.0;
-    adjust_footstep_transition_time = 2.0;
-
     // setting from conf file
     // GaitGenerator requires abc_leg_offset and abc_stride_parameter in robot conf file
     // setting leg_pos from conf file
@@ -164,21 +156,6 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     }
     leg_names.push_back("rleg");
     leg_names.push_back("lleg");
-    // setting stride limitations from conf file
-    double stride_fwd_x_limit = 0.15;
-    double stride_y_limit = 0.05;
-    double stride_th_limit = 10;
-    double stride_bwd_x_limit = 0.05;
-    std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_y_limit << "[m], " << stride_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
-    if (default_zmp_offsets.size() == 0) {
-      for (size_t i = 0; i < leg_pos.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
-    }
-    if (leg_offset_str.size() > 0) {
-      gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, leg_names, stride_fwd_x_limit/*[m]*/, stride_y_limit/*[m]*/, stride_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
-      gg->set_default_zmp_offsets(default_zmp_offsets);
-    }
-    gg_is_walking = gg_solved = false;
-    fix_leg_coords = coordinates();
 
     // setting from conf file
     // rleg,TARGET_LINK,BASE_LINK
@@ -229,6 +206,30 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
       m_controlSwingSupportTime.data.length(num);
       for (size_t i = 0; i < num; i++) m_controlSwingSupportTime.data[i] = 0.0;
     }
+
+    zmp_interpolator = new interpolator(6, m_dt);
+    zmp_transition_time = 1.0;
+    transition_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
+    transition_interpolator_ratio = 1.0;
+    adjust_footstep_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
+    transition_time = 2.0;
+    adjust_footstep_transition_time = 2.0;
+
+    // setting stride limitations from conf file
+    double stride_fwd_x_limit = 0.15;
+    double stride_y_limit = 0.05;
+    double stride_th_limit = 10;
+    double stride_bwd_x_limit = 0.05;
+    std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_y_limit << "[m], " << stride_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
+    if (default_zmp_offsets.size() == 0) {
+      for (size_t i = 0; i < leg_pos.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
+    }
+    if (leg_offset_str.size() > 0) {
+      gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, leg_names, stride_fwd_x_limit/*[m]*/, stride_y_limit/*[m]*/, stride_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
+      gg->set_default_zmp_offsets(default_zmp_offsets);
+    }
+    gg_is_walking = gg_solved = false;
+    fix_leg_coords = coordinates();
 
     // load virtual force sensors
     readVirtualForceSensorParamFromProperties(m_vfs, m_robot, prop["virtual_force_sensor"], std::string(m_profile.instance_name));

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -207,7 +207,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
       for (size_t i = 0; i < num; i++) m_controlSwingSupportTime.data[i] = 0.0;
     }
 
-    zmp_interpolator = new interpolator(6, m_dt);
+    zmp_interpolator = new interpolator(ikp.size()*3, m_dt);
     zmp_transition_time = 1.0;
     transition_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
     transition_interpolator_ratio = 1.0;
@@ -222,7 +222,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     double stride_bwd_x_limit = 0.05;
     std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_y_limit << "[m], " << stride_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
     if (default_zmp_offsets.size() == 0) {
-      for (size_t i = 0; i < leg_pos.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
+      for (size_t i = 0; i < ikp.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
     }
     if (leg_offset_str.size() > 0) {
       gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, leg_names, stride_fwd_x_limit/*[m]*/, stride_y_limit/*[m]*/, stride_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
@@ -540,15 +540,19 @@ void AutoBalancer::getTargetParameters()
   if (control_mode != MODE_IDLE) {
     coordinates tmp_fix_coords;
     if (!zmp_interpolator->isEmpty()) {
-      double default_zmp_offsets_output[leg_names.size() * 3];
+      double *default_zmp_offsets_output = new double[ikp.size()*3];
       zmp_interpolator->get(default_zmp_offsets_output, true);
-      for (size_t i = 0; i < leg_names.size(); i++)
+      for (size_t i = 0; i < ikp.size(); i++)
         for (size_t j = 0; j < 3; j++)
           default_zmp_offsets[i](j) = default_zmp_offsets_output[i*3+j];
+      delete[] default_zmp_offsets_output;
       if (DEBUGP) {
         std::cerr << "[" << m_profile.instance_name << "] default_zmp_offsets (interpolated)" << std::endl;
-        for (size_t i = 0; i < leg_names.size(); i++)
-            std::cerr << "[" << m_profile.instance_name << "]   " << leg_names[i] << " = " << default_zmp_offsets[i].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
+        std::map<leg_type, std::string> leg_type_map = gg->get_leg_type_map();
+        for (size_t i = 0; i < leg_names.size(); i++) {
+            std::map<leg_type, std::string>::const_iterator dst = std::find_if(leg_type_map.begin(), leg_type_map.end(), (&boost::lambda::_1->* &std::map<leg_type, std::string>::value_type::second == leg_names[i]));
+            std::cerr << "[" << m_profile.instance_name << "]   " << leg_names[i] << " = " << default_zmp_offsets[dst->first].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
+        }
       }
     }
     if ( gg_is_walking ) {
@@ -1259,9 +1263,9 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
 bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::AutoBalancerParam& i_param)
 {
   std::cerr << "[" << m_profile.instance_name << "] setAutoBalancerParam" << std::endl;
-  double default_zmp_offsets_array[6];
+  double *default_zmp_offsets_array = new double[ikp.size()*3];
   move_base_gain = i_param.move_base_gain;
-  for (size_t i = 0; i < 2; i++)
+  for (size_t i = 0; i < ikp.size(); i++)
     for (size_t j = 0; j < 3; j++)
       default_zmp_offsets_array[i*3+j] = i_param.default_zmp_offsets[i][j];
   zmp_transition_time = i_param.zmp_transition_time;
@@ -1288,9 +1292,12 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
       leg_names.push_back(std::string(i_param.leg_names[i]));
   }
   std::cerr << "[" << m_profile.instance_name << "]   move_base_gain = " << move_base_gain << std::endl;
-  std::cerr << "[" << m_profile.instance_name << "]   default_zmp_offsets = "
-            << default_zmp_offsets_array[0] << " " << default_zmp_offsets_array[1] << " " << default_zmp_offsets_array[2] << " "
-            << default_zmp_offsets_array[3] << " " << default_zmp_offsets_array[4] << " " << default_zmp_offsets_array[5] << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   default_zmp_offsets = ";
+  for (size_t i = 0; i < ikp.size() * 3; i++) {
+      std::cerr << default_zmp_offsets_array[i] << " ";
+  }
+  std::cerr << std::endl;
+  delete[] default_zmp_offsets_array;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_mode = " << graspless_manip_mode << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_arm = " << graspless_manip_arm << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_p_gain = " << graspless_manip_p_gain.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
@@ -1304,9 +1311,13 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
 bool AutoBalancer::getAutoBalancerParam(OpenHRP::AutoBalancerService::AutoBalancerParam& i_param)
 {
   i_param.move_base_gain = move_base_gain;
-  for (size_t i = 0; i < 2; i++)
-    for (size_t j = 0; j < 3; j++)
-      i_param.default_zmp_offsets[i][j] = default_zmp_offsets[i](j);
+  i_param.default_zmp_offsets.length(ikp.size());
+  for (size_t i = 0; i < ikp.size(); i++) {
+      i_param.default_zmp_offsets[i].length(3);
+      for (size_t j = 0; j < 3; j++) {
+          i_param.default_zmp_offsets[i][j] = default_zmp_offsets[i](j);
+      }
+  }
   switch(control_mode) {
   case MODE_IDLE: i_param.controller_mode = OpenHRP::AutoBalancerService::MODE_IDLE; break;
   case MODE_ABC: i_param.controller_mode = OpenHRP::AutoBalancerService::MODE_ABC; break;

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -207,7 +207,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
       for (size_t i = 0; i < num; i++) m_controlSwingSupportTime.data[i] = 0.0;
     }
 
-    zmp_interpolator = new interpolator(ikp.size()*3, m_dt);
+    zmp_offset_interpolator = new interpolator(ikp.size()*3, m_dt);
     zmp_transition_time = 1.0;
     transition_interpolator = new interpolator(1, m_dt, interpolator::HOFFARBIB, 1);
     transition_interpolator_ratio = 1.0;
@@ -294,7 +294,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
 
 RTC::ReturnCode_t AutoBalancer::onFinalize()
 {
-  delete zmp_interpolator;
+  delete zmp_offset_interpolator;
   delete transition_interpolator;
   delete adjust_footstep_interpolator;
   return RTC::RTC_OK;
@@ -539,9 +539,9 @@ void AutoBalancer::getTargetParameters()
   //
   if (control_mode != MODE_IDLE) {
     coordinates tmp_fix_coords;
-    if (!zmp_interpolator->isEmpty()) {
+    if (!zmp_offset_interpolator->isEmpty()) {
       double *default_zmp_offsets_output = new double[ikp.size()*3];
-      zmp_interpolator->get(default_zmp_offsets_output, true);
+      zmp_offset_interpolator->get(default_zmp_offsets_output, true);
       for (size_t i = 0; i < ikp.size(); i++)
         for (size_t j = 0; j < 3; j++)
           default_zmp_offsets[i](j) = default_zmp_offsets_output[i*3+j];
@@ -1270,9 +1270,9 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
       default_zmp_offsets_array[i*3+j] = i_param.default_zmp_offsets[i][j];
   zmp_transition_time = i_param.zmp_transition_time;
   adjust_footstep_transition_time = i_param.adjust_footstep_transition_time;
-  if (zmp_interpolator->isEmpty()) {
-      zmp_interpolator->clear();
-      zmp_interpolator->go(default_zmp_offsets_array, zmp_transition_time, true);
+  if (zmp_offset_interpolator->isEmpty()) {
+      zmp_offset_interpolator->clear();
+      zmp_offset_interpolator->go(default_zmp_offsets_array, zmp_transition_time, true);
   } else {
       std::cerr << "[" << m_profile.instance_name << "]   default_zmp_offsets cannot be set because interpolating." << std::endl;
   }

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -692,7 +692,7 @@ void AutoBalancer::getTargetParameters()
             tmpikp.target_end_coords.rot = tmpikp.target_r0 * tmpikp.localR;
             // for foot_mid_pos
             std::map<leg_type, std::string>::const_iterator dst = std::find_if(leg_type_map.begin(), leg_type_map.end(), (&boost::lambda::_1->* &std::map<leg_type, std::string>::value_type::second == leg_names[i]));
-            tmp_foot_mid_pos += (tmpikp.target_link->p + tmpikp.target_link->R * tmpikp.localPos + tmpikp.target_link->R * tmpikp.localR * default_zmp_offsets[i]) * zmp_weight_map[dst->first];
+            tmp_foot_mid_pos += (tmpikp.target_p0 + tmpikp.target_r0 * tmpikp.localPos + tmpikp.target_r0 * tmpikp.localR * default_zmp_offsets[i]) * zmp_weight_map[dst->first];
             sum_of_weight += zmp_weight_map[dst->first];
         }
         tmp_foot_mid_pos *= (1.0 / sum_of_weight);

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -394,6 +394,7 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
     hrp::Matrix33 ref_baseRot;
     hrp::Vector3 rel_ref_zmp; // ref zmp in base frame
     if ( is_legged_robot ) {
+      gg->proc_zmp_weight_map_interpolation();
       getCurrentParameters();
       getTargetParameters();
       bool is_transition_interpolator_empty = transition_interpolator->isEmpty();

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1190,6 +1190,7 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_toe_heel_phase_ratio(tmp_ratio);
   gg->set_use_toe_joint(i_param.use_toe_joint);
   gg->set_use_toe_heel_transition(i_param.use_toe_heel_transition);
+  gg->set_zmp_weight_map(boost::assign::map_list_of<leg_type, double>(RLEG, i_param.zmp_weight_map[0])(LLEG, i_param.zmp_weight_map[1])(RARM, i_param.zmp_weight_map[2])(LARM, i_param.zmp_weight_map[3]));
   gg->set_optional_go_pos_finalize_footstep_num(i_param.optional_go_pos_finalize_footstep_num);
 
   // print
@@ -1245,6 +1246,11 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   for (int i = 0; i < gg->get_NUM_TH_PHASES(); i++) i_param.toe_heel_phase_ratio[i] = ratio[i];
   i_param.use_toe_joint = gg->get_use_toe_joint();
   i_param.use_toe_heel_transition = gg->get_use_toe_heel_transition();
+  std::map<leg_type, double> tmp_zmp_weight_map = gg->get_zmp_weight_map();
+  i_param.zmp_weight_map[0] = tmp_zmp_weight_map[RLEG];
+  i_param.zmp_weight_map[1] = tmp_zmp_weight_map[LLEG];
+  i_param.zmp_weight_map[2] = tmp_zmp_weight_map[RARM];
+  i_param.zmp_weight_map[3] = tmp_zmp_weight_map[LARM];
   i_param.optional_go_pos_finalize_footstep_num = gg->get_optional_go_pos_finalize_footstep_num();
   return true;
 };

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -224,7 +224,7 @@ class AutoBalancer
   coil::Mutex m_mutex;
 
   double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time;
-  interpolator *zmp_interpolator;
+  interpolator *zmp_offset_interpolator;
   interpolator *transition_interpolator;
   interpolator *adjust_footstep_interpolator;
   hrp::Vector3 input_zmp, input_basePos;

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -69,6 +69,7 @@ CORBA::Boolean AutoBalancerService_impl::getGaitGeneratorParam(OpenHRP::AutoBala
   i_param = new OpenHRP::AutoBalancerService::GaitGeneratorParam();
   i_param->stride_parameter.length(4);
   i_param->toe_heel_phase_ratio.length(7);
+  i_param->zmp_weight_map.length(4);
   return m_autobalancer->getGaitGeneratorParam(*i_param);
 };
 

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -81,9 +81,6 @@ CORBA::Boolean AutoBalancerService_impl::setAutoBalancerParam(const OpenHRP::Aut
 CORBA::Boolean AutoBalancerService_impl::getAutoBalancerParam(OpenHRP::AutoBalancerService::AutoBalancerParam_out i_param)
 {
   i_param = new OpenHRP::AutoBalancerService::AutoBalancerParam();
-  i_param->default_zmp_offsets.length(2);
-  for (size_t i = 0; i < 2; i++)
-    i_param->default_zmp_offsets[i].length(3);
   return m_autobalancer->getAutoBalancerParam(*i_param);
 };
 

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -475,8 +475,8 @@ namespace rats
         rg.push_refzmp_from_footstep_nodes_for_single(footstep_nodes_list.at(i), lcg.get_support_leg_steps_idx(i));
     }
     rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list.back(),
-                                                lcg.get_swing_leg_dst_steps_idx(footstep_nodes_list.size()-1),
-                                                lcg.get_support_leg_steps_idx(footstep_nodes_list.size()-1));
+                                                lcg.get_support_leg_steps_idx(footstep_nodes_list.size()-1),
+                                                lcg.get_swing_leg_dst_steps_idx(footstep_nodes_list.size()-1));
     emergency_flg = IDLING;
   };
 

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -61,14 +61,18 @@ namespace rats
     hrp::Vector3 ret_zmp;
     hrp::Vector3 tmp_zero = hrp::Vector3::Zero();
     std::vector<hrp::Vector3> foot_x_axises;
-    for (std::vector<step_node>::const_iterator it = _support_leg_steps.begin(); it != _support_leg_steps.end(); it++)
-        dzl.push_back(it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos);
+    double sum_of_weight = 0.0;
+    for (std::vector<step_node>::const_iterator it = _support_leg_steps.begin(); it != _support_leg_steps.end(); it++) {
+        dzl.push_back((it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos) * zmp_weight_map[it->l_r]);
+        sum_of_weight += zmp_weight_map[it->l_r];
+    }
     for (std::vector<step_node>::const_iterator it = _swing_leg_steps.begin(); it != _swing_leg_steps.end(); it++) {
-        dzl.push_back(it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos);
+        dzl.push_back((it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos) * zmp_weight_map[it->l_r]);
+        sum_of_weight += zmp_weight_map[it->l_r];
         foot_x_axises.push_back( hrp::Vector3(it->worldcoords.rot * hrp::Vector3::UnitX()) );
     }
     foot_x_axises_list.push_back(foot_x_axises);
-    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
+    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / sum_of_weight;
     refzmp_cur_list.push_back( rzmp );
     std::vector<leg_type> swing_leg_types;
     for (size_t i = 0; i < fns.size(); i++) {
@@ -86,12 +90,14 @@ namespace rats
     hrp::Vector3 rzmp, tmp_zero=hrp::Vector3::Zero();
     std::vector<hrp::Vector3> dzl;
     std::vector<hrp::Vector3> foot_x_axises;
+    double sum_of_weight = 0.0;
 
     for (std::vector<step_node>::const_iterator it = _support_leg_steps.begin(); it != _support_leg_steps.end(); it++) {
-      dzl.push_back(it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos);
-      foot_x_axises.push_back( hrp::Vector3(it->worldcoords.rot * hrp::Vector3::UnitX()) );
+        dzl.push_back((it->worldcoords.rot * default_zmp_offsets[it->l_r] + it->worldcoords.pos) * zmp_weight_map[it->l_r]);
+        sum_of_weight += zmp_weight_map[it->l_r];
+        foot_x_axises.push_back( hrp::Vector3(it->worldcoords.rot * hrp::Vector3::UnitX()) );
     }
-    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / dzl.size();
+    rzmp = std::accumulate(dzl.begin(), dzl.end(), tmp_zero) / sum_of_weight;
     refzmp_cur_list.push_back( rzmp );
     foot_x_axises_list.push_back(foot_x_axises);
     std::vector<leg_type> swing_leg_types;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -8,6 +8,7 @@
 #include <queue>
 #include <boost/assign.hpp>
 #include <boost/lambda/lambda.hpp>
+#include <boost/shared_ptr.hpp>
 
 namespace rats
 {
@@ -214,6 +215,7 @@ namespace rats
       double dt;
       toe_heel_phase_counter* thp_ptr;
       bool use_toe_heel_transition;
+      boost::shared_ptr<interpolator> zmp_weight_interpolator;
       void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const;
       const bool is_start_double_support_phase () const { return refzmp_index == 0; };
       const bool is_second_phase () const { return refzmp_index == 1; };
@@ -232,7 +234,10 @@ namespace rats
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
-          zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, 1.0)(LLEG, 1.0)(RARM, 0.01)(LARM, 0.01);
+          double zmp_weight_initial_value[4] = {1.0, 1.0, 0.1, 0.1};
+          zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, zmp_weight_initial_value[0])(LLEG, zmp_weight_initial_value[1])(RARM, zmp_weight_initial_value[2])(LARM, zmp_weight_initial_value[3]);
+          zmp_weight_interpolator = boost::shared_ptr<interpolator>(new interpolator(4, dt));
+          zmp_weight_interpolator->set(zmp_weight_initial_value); /* set initial value */
       };
       ~refzmp_generator()
       {
@@ -267,7 +272,17 @@ namespace rats
       void set_toe_zmp_offset_x (const double _off) { toe_zmp_offset_x = _off; };
       void set_heel_zmp_offset_x (const double _off) { heel_zmp_offset_x = _off; };
       void set_use_toe_heel_transition (const double _u) { use_toe_heel_transition = _u; };
-      void set_zmp_weight_map (const std::map<leg_type, double> _map) { zmp_weight_map = _map; };
+      void set_zmp_weight_map (const std::map<leg_type, double> _map) {
+          double zmp_weight_array[4] = {_map.find(RLEG)->second, _map.find(LLEG)->second, _map.find(RARM)->second, _map.find(LARM)->second};
+          if (zmp_weight_interpolator->isEmpty()) {
+              zmp_weight_interpolator->clear();
+              double zmp_weight_initial_value[4] = {zmp_weight_map[RLEG], zmp_weight_map[LLEG], zmp_weight_map[RARM], zmp_weight_map[LARM]};
+              zmp_weight_interpolator->set(zmp_weight_initial_value);
+              zmp_weight_interpolator->go(zmp_weight_array, 2.0, true);
+          } else {
+              std::cerr << "zmp_weight_map cannot be set because interpolating." << std::endl;
+          }
+      };
       // getter
       bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const
       {
@@ -280,6 +295,13 @@ namespace rats
       double get_heel_zmp_offset_x () const { return heel_zmp_offset_x; };
       bool get_use_toe_heel_transition () const { return use_toe_heel_transition; };
       const std::map<leg_type, double> get_zmp_weight_map () const { return zmp_weight_map; };
+      void proc_zmp_weight_map_interpolation () {
+          if (!zmp_weight_interpolator->isEmpty()) {
+              double zmp_weight_output[4];
+              zmp_weight_interpolator->get(zmp_weight_output, true);
+              zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, zmp_weight_output[0])(LLEG, zmp_weight_output[1])(RARM, zmp_weight_output[2])(LARM, zmp_weight_output[3]);
+          }
+      };
     };
 
     class delay_hoffarbib_trajectory_generator
@@ -1002,6 +1024,7 @@ namespace rats
     double get_heel_zmp_offset_x () const { return rg.get_heel_zmp_offset_x(); };
     bool get_use_toe_heel_transition () const { return rg.get_use_toe_heel_transition(); };
     const std::map<leg_type, double> get_zmp_weight_map () const { return rg.get_zmp_weight_map(); };
+    void proc_zmp_weight_map_interpolation () { return rg.proc_zmp_weight_map_interpolation(); };
     std::vector<std::string> get_footstep_front_leg_names () const {
       std::vector<leg_type> lts;
       for (size_t i = 0; i < footstep_nodes_list[0].size(); i++) {

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -204,6 +204,7 @@ namespace rats
     public:
 #endif
       std::vector<hrp::Vector3> refzmp_cur_list;
+      std::map<leg_type, double> zmp_weight_map;
       std::vector< std::vector<hrp::Vector3> > foot_x_axises_list; // Swing foot x axis list according to refzmp_cur_list
       std::vector< std::vector<leg_type> > swing_leg_types_list; // Swing leg list according to refzmp_cur_list
       std::vector<size_t> step_count_list; // Swing leg list according to refzmp_cur_list
@@ -231,6 +232,7 @@ namespace rats
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
+          zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, 1.0)(LLEG, 1.0)(RARM, 0.01)(LARM, 0.01);
       };
       ~refzmp_generator()
       {
@@ -265,6 +267,7 @@ namespace rats
       void set_toe_zmp_offset_x (const double _off) { toe_zmp_offset_x = _off; };
       void set_heel_zmp_offset_x (const double _off) { heel_zmp_offset_x = _off; };
       void set_use_toe_heel_transition (const double _u) { use_toe_heel_transition = _u; };
+      void set_zmp_weight_map (const std::map<leg_type, double> _map) { zmp_weight_map = _map; };
       // getter
       bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const
       {
@@ -276,6 +279,7 @@ namespace rats
       double get_toe_zmp_offset_x () const { return toe_zmp_offset_x; };
       double get_heel_zmp_offset_x () const { return heel_zmp_offset_x; };
       bool get_use_toe_heel_transition () const { return use_toe_heel_transition; };
+      const std::map<leg_type, double> get_zmp_weight_map () const { return zmp_weight_map; };
     };
 
     class delay_hoffarbib_trajectory_generator
@@ -887,6 +891,7 @@ namespace rats
     void set_toe_zmp_offset_x (const double _off) { rg.set_toe_zmp_offset_x(_off); };
     void set_heel_zmp_offset_x (const double _off) { rg.set_heel_zmp_offset_x(_off); };
     void set_use_toe_heel_transition (const double _u) { rg.set_use_toe_heel_transition(_u); };
+    void set_zmp_weight_map (const std::map<leg_type, double> _map) { rg.set_zmp_weight_map(_map); };
     void set_default_step_height(const double _tmp) { lcg.set_default_step_height(_tmp); };
     void set_default_top_ratio(const double _tmp) { lcg.set_default_top_ratio(_tmp); };
     void set_velocity_param (const double vel_x, const double vel_y, const double vel_theta) /* [mm/s] [mm/s] [deg/s] */
@@ -996,6 +1001,7 @@ namespace rats
     double get_toe_zmp_offset_x () const { return rg.get_toe_zmp_offset_x(); };
     double get_heel_zmp_offset_x () const { return rg.get_heel_zmp_offset_x(); };
     bool get_use_toe_heel_transition () const { return rg.get_use_toe_heel_transition(); };
+    const std::map<leg_type, double> get_zmp_weight_map () const { return rg.get_zmp_weight_map(); };
     std::vector<std::string> get_footstep_front_leg_names () const {
       std::vector<leg_type> lts;
       for (size_t i = 0; i < footstep_nodes_list[0].size(); i++) {

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -75,7 +75,7 @@ def demoAutoBalancerGetParam():
 def demoAutoBalancerSetParam():
     print >> sys.stderr, "4. setAutoBalancerParam"
     abcp=hcf.abc_svc.getAutoBalancerParam()[1]
-    abcp.default_zmp_offsets = [[0.1,0,0], [0.1,0,0]]
+    abcp.default_zmp_offsets = [[0.1,0,0], [0.1,0,0], [0,0,0], [0,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
     ret=hcf.abc_svc.getAutoBalancerParam()
     if ret[0] and ret[1].default_zmp_offsets == abcp.default_zmp_offsets:
@@ -83,7 +83,7 @@ def demoAutoBalancerSetParam():
     print >> sys.stderr, "  default_zmp_offsets setting check in start and stop"
     hcf.startAutoBalancer();
     hcf.stopAutoBalancer();
-    abcp.default_zmp_offsets = [[0,0,0], [0,0,0]]
+    abcp.default_zmp_offsets = [[0,0,0], [0,0,0], [0,0,0], [0,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
 
 def demoAutoBalancerTestPoses():
@@ -96,7 +96,7 @@ def demoAutoBalancerTestPoses():
 def demoAutoBalancerStartStopCheck():
     print >> sys.stderr, "6. start stop check"
     abcp=hcf.abc_svc.getAutoBalancerParam()[1]
-    abcp.default_zmp_offsets = [[-0.05,0.05,0], [-0.05,0.05,0]]
+    abcp.default_zmp_offsets = [[-0.05,0.05,0], [-0.05,0.05,0], [0,0,0], [0,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
     hcf.setMaxLogLength(1500)
     for pose in pose_list:
@@ -106,7 +106,7 @@ def demoAutoBalancerStartStopCheck():
         hcf.startAutoBalancer();
         hcf.stopAutoBalancer();
         hcf.saveLog("/tmp/test-samplerobot-abc-startstop-{0}".format(pose_list.index(pose)))
-    abcp.default_zmp_offsets = [[0,0,0], [0,0,0]]
+    abcp.default_zmp_offsets = [[0,0,0], [0,0,0], [0,0,0], [0,0,0]]
     hcf.abc_svc.setAutoBalancerParam(abcp)
     hcf.seq_svc.setJointAngles(initial_pose, 1.0)
     hcf.waitInterpolation()


### PR DESCRIPTION
- 歩くときにFootStepから目標ZMPを計算する部分
- 歩いていないときにend-effectorから目標重心位置を計算する部分

の2箇所において，これまでは平均値だったところを，重み付き平均値（zmp_weight_map）を使うように変えました．

@snozawa さん，zmp_offsetの仲間みたいな感じな雰囲気がするのですが，この機能を追加しても問題無さそうでしょうか．
腕を使って移動するときに，「腕にそんなに体重をかけない」を表現するということを意図しています．

![a4](https://cloud.githubusercontent.com/assets/4509039/9502206/e2cbaec8-4c6a-11e5-9e66-09f0ba840919.gif)


※（コミットが混ざってしまいましたが，）ついでにzmp_offsetsを4つに拡張し，eusのインタフェースもこれまで通りに使えるように更新しました． https://github.com/start-jsk/rtmros_common/pull/801
