### PR TITLE
Fix HGcontroller or PDcontroller order

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -618,7 +618,7 @@ class HrpsysConfigurator:
         @return list of list: List of available components. Each element consists of a list
                  of abbreviated and full names of the component.
         '''
-        return [
+        rtclist = [
             ['seq', "SequencePlayer"],
             ['sh', "StateHolder"],
             ['fk', "ForwardKinematics"],
@@ -634,8 +634,14 @@ class HrpsysConfigurator:
             # ['te', "ThermoEstimator"],
             # ['tl', "ThermoLimiter"],
             ['el', "SoftErrorLimiter"],
-            ['log', "DataLogger"]
-            ]
+            ['log', "DataLogger"],
+        ]
+        if self.hgc:
+            rtclist.append(["hgc", "HGcontroller"])
+        elif self.pdc:
+            rtclist.append(["pdc", "PDcontroller"])
+        return rtclist
+
 
     # public method to configure all RTCs to be activated on rtcd which includes unstable RTCs
     def getRTCListUnstable(self):
@@ -645,7 +651,7 @@ class HrpsysConfigurator:
         @return list of list: List of available unstable components. Each element consists
                  of a list of abbreviated and full names of the component.
         '''
-        return [
+        rtclist = [
             ['seq', "SequencePlayer"],
             ['sh', "StateHolder"],
             ['fk', "ForwardKinematics"],
@@ -663,8 +669,14 @@ class HrpsysConfigurator:
             ['tl', "ThermoLimiter"],
             ['hes', "EmergencyStopper"],
             ['el', "SoftErrorLimiter"],
-            ['log', "DataLogger"]
-            ]
+            ['log', "DataLogger"],
+        ]
+        if self.hgc:
+            rtclist.append(["hgc", "HGcontroller"])
+        elif self.pdc:
+            rtclist.append(["pdc", "PDcontroller"])
+        return rtclist
+
 
     def getJointAngleControllerList(self):
         '''!@brief


### PR DESCRIPTION
HGcontrollerとPDcontrollerのRTC群の中での順番がおかしいように思いましたので、直しました。
今までは
　HGcontroller => 他RTC => シミュレータ =>
　HGcontroller => 他RTC => シミュレータ =>
　...
の順に実行されてる一方、ポートのつなぎ方が
　他RTC => HGcontroller => シミュレータ
となってました。
この場合、「他RTC」の指令値がこの制御周期でシミュレータに渡らず、
次の周期にHGcontrollerに渡った後でわたることになります。
このため、指令値のシミュレータへの到達が１制御周期おくれ、実関節角度値の反映などは
２制御周期おくれることになります。

そのため、getRTCListの中でHGControllerとPDcontrollerの順番を最後に追加しました。

よろしくお願いいたします。