### PR TITLE
Fix SoftErrorLimiter limitation

### DIFF
--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -283,9 +283,9 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
         }
         // fix joint angle
         if ( llimit > m_qRef.data[i] && prev_angle[i] > m_qRef.data[i] ) // ref < llimit and prev < ref -> OK
-          m_qRef.data[i] = prev_angle[i];
+          m_qRef.data[i] = llimit;
         if ( ulimit < m_qRef.data[i] && prev_angle[i] < m_qRef.data[i] ) // ulimit < ref and ref < prev -> OK
-          m_qRef.data[i] = prev_angle[i];
+          m_qRef.data[i] = ulimit;
         m_servoState.data[i][0] |= (0x200 << OpenHRP::RobotHardwareService::SERVO_ALARM_SHIFT);
         position_limit_error = true;
       }

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -262,7 +262,6 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
 
     // Position limitation for reference joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
-      double error = m_qRef.data[i] - m_qCurrent.data[i];
       /*
         From hrpModel/Body.h
         inline Link* joint(int id) const

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -235,6 +235,22 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
     total_upper_limit.resize(m_qRef.data.length(), std::numeric_limits<double>::max());
     total_lower_limit.resize(m_qRef.data.length(), -std::numeric_limits<double>::max());
 
+      /*
+        From hrpModel/Body.h
+        inline Link* joint(int id) const
+           This function returns a link that has a given joint ID.
+           If there is no link that has a given joint ID,
+           the function returns a dummy link object whose ID is minus one.
+           The maximum id can be obtained by numJoints().
+
+         inline Link* link(int index) const
+           This function returns the link of a given index in the whole link sequence.
+           The order of the sequence corresponds to a link-tree traverse from the root link.
+           The size of the sequence can be obtained by numLinks().
+
+         So use m_robot->joint(i) for llimit/ulimit, lvlimit/ulimit
+       */
+
     // Velocity limitation for reference joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
       double qvel = (m_qRef.data[i] - prev_angle[i]) / dt;
@@ -262,21 +278,6 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
 
     // Position limitation for reference joint angles
     for ( int i = 0; i < m_qRef.data.length(); i++ ){
-      /*
-        From hrpModel/Body.h
-        inline Link* joint(int id) const
-           This function returns a link that has a given joint ID.
-           If there is no link that has a given joint ID,
-           the function returns a dummy link object whose ID is minus one.
-           The maximum id can be obtained by numJoints().
-
-         inline Link* link(int index) const
-           This function returns the link of a given index in the whole link sequence.
-           The order of the sequence corresponds to a link-tree traverse from the root link.
-           The size of the sequence can be obtained by numLinks().
-
-         So use m_robot->joint(i) for llimit/ulimit
-       */
       double llimit = m_robot->joint(i)->llimit;
       double ulimit = m_robot->joint(i)->ulimit;
       if (joint_limit_tables.find(m_robot->joint(i)->name) != joint_limit_tables.end()) {

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -289,7 +289,6 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
         m_servoState.data[i][0] |= (0x200 << OpenHRP::RobotHardwareService::SERVO_ALARM_SHIFT);
         position_limit_error = true;
       }
-      prev_angle[i] = m_qRef.data[i];
     }
     debug_print_position_first = !position_limit_error; // display error info if no error found
 
@@ -311,6 +310,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
         m_servoState.data[i][0] |= (0x040 << OpenHRP::RobotHardwareService::SERVO_ALARM_SHIFT);
         soft_limit_error = true;
       }
+      prev_angle[i] = m_qRef.data[i];
     }
     debug_print_error_first = !soft_limit_error; // display error info if no error found
 

--- a/sample/SampleRobot/samplerobot_soft_error_limiter.py
+++ b/sample/SampleRobot/samplerobot_soft_error_limiter.py
@@ -109,8 +109,8 @@ def testOneLimitTable (self_jointId, target_jointId, limit_table, target_llimit,
         hcf.seq_svc.waitInterpolation()
         # B-2. check joint limit is not violated
         el_out2=rtm.readDataPort(hcf.el.port("q")).data
-        ret2 = abs(rad2deg(el_out2[self_jointId]) - limit_table[int(round(rad2deg(el_out2[target_jointId])-target_llimit))]) < thre \ # Check self and target is on limit table
-            and abs(el_out2[self_jointId] - (limit_table[idx]+angle_violation)) > thre # Check result value is not violated value
+        ret2 = abs(rad2deg(el_out2[self_jointId]) - limit_table[int(round(rad2deg(el_out2[target_jointId])-target_llimit))]) < thre # Check self and target is on limit table
+        ret2 = ret2 and abs(el_out2[self_jointId] - (limit_table[idx]+angle_violation)) > thre # Check result value is not violated value
         # C. results
         if debug:
             print " ret = (", ret1, ",", ret2,")"
@@ -123,10 +123,9 @@ def testOneLimitTable (self_jointId, target_jointId, limit_table, target_llimit,
     return all(ret)
 
 def setAndCheckJointLimit (joint_name):
-    mdlldr=hcf.getBodyInfo("$(PROJECT_DIR)/../model/sample1.wrl")
     print >> sys.stderr, "  ", joint_name
     # ulimit check
-    link_info=filter(lambda x : x.name==joint_name, mdlldr._get_links())[0]
+    link_info=filter(lambda x : x.name==joint_name, bodyinfo._get_links())[0]
     hcf.seq_svc.setJointAngle(joint_name, math.radians(1)+link_info.ulimit[0], 1)
     hcf.waitInterpolation()
     ret = rtm.readDataPort(hcf.el.port("q")).data[link_info.jointId] <= link_info.ulimit[0]
@@ -149,8 +148,7 @@ def demoPositionLimit():
     setAndCheckJointLimit('LARM_SHOULDER_P')
 
 def setAndCheckJointVelocityLimit (joint_name, thre=1e-5, dt=0.002):
-    mdlldr=hcf.getBodyInfo("$(PROJECT_DIR)/../model/sample1.wrl")
-    link_info=filter(lambda x : x.name==joint_name, mdlldr._get_links())[0]
+    link_info=filter(lambda x : x.name==joint_name, bodyinfo._get_links())[0]
     # lvlimit and uvlimit existence check
     if not(len(link_info.lvlimit) == 1 and len(link_info.uvlimit) == 1):
         print >> sys.stderr, "  ", joint_name, " test neglected because no lvlimit and uvlimit are found."
@@ -196,8 +194,7 @@ def demoVelocityLimit():
     setAndCheckJointVelocityLimit('LARM_WRIST_P')
 
 def setAndCheckJointErrorLimit (joint_name, thre=1e-5):
-    mdlldr=hcf.getBodyInfo("$(PROJECT_DIR)/../model/sample1.wrl")
-    link_info=filter(lambda x : x.name==joint_name, mdlldr._get_links())[0]
+    link_info=filter(lambda x : x.name==joint_name, bodyinfo._get_links())[0]
     for is_upper_limit in [True, False]: # uvlimit or lvlimit
         print >> sys.stderr, "  ", joint_name, ", uvlimit" if is_upper_limit else ", lvlimit"
         # Disable error limit for checking vel limit


### PR DESCRIPTION
elのリミットの制限方法を修正しました。
もともといくつか挙動がおかしいところがあり、例えば
- `prev_angle[i] = m_qRef.data[i];`で１周期出力をセットしているのが最終出力になってなかった（このあとerrorのリミットで値が書き換えられる）
- vel=>pos=>errorの順で書き換えられたときに、前のリミットをみたさないことがある

などがあったので、修正しました。
具体的には、
- velのリミットは`(m_qRef -  prev_angle)/dt < uvlimit`<=>`m_qRef < uvlimit *dt + prev_angle`として角度のリミット形式にかきかえられる
- errorのリミットは`(m_qRef - m_qCurrent) < limit`<=>`m_qRef < limit + m_qCurrent`として角度リミット形式にかきかえられる

ため、速度、角度、エラーの３点につきそれぞれ角度形式のリミットを計算して、
最後に`m_qRef=min(速度リミット、角度リミット、エラリミット)`のようにして３点のなかの
一番厳しいリミット値で制限するようにしました。

また、速度・エラーなどもsamplerobot_softerror_imitter.pyでチェックして、多分travisのテストにもされると思います。


よろしくお願いいたします。