### PR TITLE
fill time stamp on reference of angles

### DIFF
--- a/rtc/EmergencyStopper/EmergencyStopper.cpp
+++ b/rtc/EmergencyStopper/EmergencyStopper.cpp
@@ -279,6 +279,7 @@ RTC::ReturnCode_t EmergencyStopper::onExecute(RTC::UniqueId ec_id)
         }
         std::cerr << std::endl;
     }
+    m_q.tm = m_qRef.tm;
     m_qOut.write();
 
     m_emergencyMode.data = is_stop_mode;

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -267,6 +267,7 @@ RTC::ReturnCode_t SequencePlayer::onExecute(RTC::UniqueId ec_id)
           m_wrenches[i].data[4] = wrenches[force_i++];
           m_wrenches[i].data[5] = wrenches[force_i++];
         }
+        m_qRef.tm = m_qInit.tm;
         m_qRefOut.write();
         m_tqRefOut.write();
         m_zmpRefOut.write();


### PR DESCRIPTION
qRef (目標関節角度)を出すコンポーネントで、タイムスタンプを入れていない（初期化時のタイムスタンプが入っている）コンポーネントは、
現在関節角度のタイムスタンプと同じになるようにしました。