### PR TITLE
[PDcontroller] read gain file at onActivated

### DIFF
--- a/rtc/PDcontroller/PDcontroller.cpp
+++ b/rtc/PDcontroller/PDcontroller.cpp
@@ -117,6 +117,13 @@ RTC::ReturnCode_t PDcontroller::onShutdown(RTC::UniqueId ec_id)
 RTC::ReturnCode_t PDcontroller::onActivated(RTC::UniqueId ec_id)
 {
   std::cout << m_profile.instance_name << ": on Activated " << std::endl;
+  if(m_angleIn.isNew()){
+    m_angleIn.read();
+    if (dof == 0) {
+        dof = m_angle.data.length();
+        readGainFile();
+    }
+  }
   return RTC::RTC_OK;
 }
 


### PR DESCRIPTION
現象を追いきれていないのですが、onActivateでゲインファイルを読む場合と、
onExecuteでゲインファイルを読む場合でchoreonoidで使った場合にロボットの動作に差が出ます。
https://github.com/fkanehiro/hrpsys-base/issues/790

デバッグメッセージを入れても、動作に差は無いように思うのですが、
onExecuteでゲインファイルを読む場合は発散してしまい、
トルクリミットが入っていないとロボットが飛んでいきます。
トルクリミットを入れても振動しています。

onActivateでゲインファイルを読む場合は、リミットにかかるようなトルクは出ません。

正しい直し方かわからないのですが、onActivateでも同様にゲインをセットするようにすると
以前と同じ挙動になります。