### PR TITLE
Add torque limit ratio for PDcontroller simulation

### DIFF
--- a/rtc/PDcontroller/PDcontroller.h
+++ b/rtc/PDcontroller/PDcontroller.h
@@ -134,7 +134,7 @@ class PDcontroller
   double dt;
   std::ifstream gain;
   std::string gain_fname;
-  hrp::dvector qold, qold_ref, Pgain, Dgain;
+  hrp::dvector qold, qold_ref, Pgain, Dgain, tlimit_ratio;
   size_t dof, loop;
   unsigned int m_debugLevel;
 };

--- a/rtc/PDcontroller/PDcontroller.txt
+++ b/rtc/PDcontroller/PDcontroller.txt
@@ -51,11 +51,17 @@ N/A
 <table>
 <tr><th>name</th><th>type</th><th>unit</th><th>default value</th><th>description</th></tr>
 <tr><td>dt</td><td>double</td><td></td><td>0.005</td><td>sampling time</td></tr>
-<tr><td>pdgains_sim.file_name</td><td>string</td><td></td><td></td><td>File path for PD gain file.</td></tr>
+<tr><td>pdgains_sim_file_name</td><td>string</td><td></td><td></td><td>File path for PD gain file.</td></tr>
 </table>
 
 \section conf Configuration File
 
-N/A
+<table>
+<tr><th>key</th><th>type</th><th>unit</th><th>description</th></tr>
+<tr><td>dt</td><td>double</td><td>[s]</td><td>sampling time</td></tr>
+<tr><td>model</td><td>std::string</td><td></td><td>URL of a VRML model</td></tr>
+<tr><td>pdgains_sim_file_name</td><td>std::string</td><td></td><td>File path for PD gain file.</td></tr>
+<tr><td>pdcontrol_tlimit_ratio</td><td>vector</td><td></td><td>Ratio vector for torque limit of PDcontroller outputs. If not specified, 1.0 by default.</td></tr>
+</table>
 
  */

--- a/sample/SampleRobot/SampleRobot.conf.in
+++ b/sample/SampleRobot/SampleRobot.conf.in
@@ -4,9 +4,6 @@ dt: @CONTROLLER_TIME@
 abc_leg_offset: 0,0.09,0
 end_effectors: lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, larm,LARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708, rarm,RARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708,
 
-# PDcontroller Setting
-pdgains_sim_file_name: @CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/SampleRobot/SampleRobot.PDgain.dat
-
 # CollisionDetector Setting
 collision_pair: RARM_WRIST_P:WAIST LARM_WRIST_P:WAIST RARM_WRIST_P:RLEG_HIP_R LARM_WRIST_P:LLEG_HIP_R RARM_WRIST_R:RLEG_HIP_R LARM_WRIST_R:LLEG_HIP_R LLEG_ANKLE_R:RLEG_ANKLE_R
 #   Collision mask not to control legs joints
@@ -22,3 +19,7 @@ use_limb_collision: true
 
 # ThermoLimiter
 alarm_ratio: 0.75
+
+# PDcontroller Setting
+pdgains_sim_file_name: @CMAKE_INSTALL_PREFIX@/share/hrpsys/samples/SampleRobot/SampleRobot.PDgain.dat
+pdcontrol_tlimit_ratio: 1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1,1


### PR DESCRIPTION
PDcontrollerのトルクリミットに比率をかけられるようにしました。
実機のトルクリミットを設定していると低すぎる場合があるようで、
PD制御をかけたあとのトルク出力が大幅にリミット値より越えてしまいます。
デフォルトは１で挙動はかわらないようになります。

よろしくお願いいたします。