### PR TITLE
Add leg names interpolator

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1330,6 +1330,7 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
 
 bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::AutoBalancerParam& i_param)
 {
+  Guard guard(m_mutex);
   std::cerr << "[" << m_profile.instance_name << "] setAutoBalancerParam" << std::endl;
   double *default_zmp_offsets_array = new double[ikp.size()*3];
   move_base_gain = i_param.move_base_gain;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -224,10 +224,11 @@ class AutoBalancer
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
 
-  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time;
+  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, leg_names_interpolator_ratio;
   interpolator *zmp_offset_interpolator;
   interpolator *transition_interpolator;
   interpolator *adjust_footstep_interpolator;
+  interpolator *leg_names_interpolator;
   hrp::Vector3 input_zmp, input_basePos;
   hrp::Matrix33 input_baseRot;
 


### PR DESCRIPTION
leg_names をMODE_ABCの最中に変えられるように補間器を入れてみました．
leg_namesは

- 重心計算
- fixLegToCoordsのターゲット
- 支持脚の特定

に使っています．

@snozawa さん， setAutoBalancerの最初にGuardを入れないと上手く行かない時があったので入れてみたのですが，こちらは問題ないでしょうか？

test-samplerobot-abc.pyは通ることは確認しています．