### PR TITLE
Update gg overwrite

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -761,9 +761,9 @@ namespace rats
     }
     /* fill preview controller queue by new refzmp */
     hrp::Vector3 rzmp;
-    std::vector<hrp::Vector3> sfzos;
     bool not_solved = true;
     while (not_solved) {
+      std::vector<hrp::Vector3> sfzos;
       bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
       not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, refzmp_exist_p);
       rg.update_refzmp(footstep_nodes_list);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -51,12 +51,12 @@ namespace rats
                                    (sn.l_r==RARM)?std::string("rarm"):
                                    (sn.l_r==LARM)?std::string("larm"):
                                    std::string("rleg")) << "]" << std::endl;
-            os << "  pos =" << std::endl;
-            os << (sn.worldcoords.pos).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
-            os << "  rot =" << std::endl;
-            os << (sn.worldcoords.rot).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
-            os << "  step_height = " << sn.step_height << "[m], step_time = " << sn.step_time << "[s]" << std::endl;
-            os << "  toe_angle = " << sn.toe_angle << "[deg], heel_angle = " << sn.heel_angle << "[deg]" << std::endl;
+            os << "  pos =";
+            os << (sn.worldcoords.pos).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", " [", "]")) << std::endl;
+            os << "  rot =";
+            os << (sn.worldcoords.rot).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "", " [", "]")) << std::endl;
+            os << "  step_height = " << sn.step_height << "[m], step_time = " << sn.step_time << "[s], "
+               << "toe_angle = " << sn.toe_angle << "[deg], heel_angle = " << sn.heel_angle << "[deg]";
             return os;
         };
     };
@@ -980,9 +980,8 @@ namespace rats
     void print_footstep_nodes_list (const std::vector< std::vector<step_node> > _footstep_nodes_list) const
     {
         for (size_t i = 0; i < _footstep_nodes_list.size(); i++) {
-            std::cerr << "foot step index : " << i << std::endl;
             for (size_t j = 0; j < _footstep_nodes_list.at(i).size(); j++) {
-                std::cerr << _footstep_nodes_list.at(i).at(j) << std::endl;
+                std::cerr << "[" << i << "] " << _footstep_nodes_list.at(i).at(j) << std::endl;
             }
         }
     };


### PR DESCRIPTION
AutoBalancer内でのfootstepのprintを、行数をへらしました。
（改行をへらしたので、print内容はへってないと思います、確認してもらえると助かります@eisoku9618）

また、overwrite時にswing foot zmp offset が初期化されてないのを修正しました

よろしくお願いいたします。