### PR TITLE
Add a port and methods to read command torques

### DIFF
--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -52,6 +52,7 @@ RobotHardware::RobotHardware(RTC::Manager* manager)
     m_qOut("q", m_q),
     m_dqOut("dq", m_dq),
     m_tauOut("tau", m_tau),
+    m_ctauOut("ctau", m_ctau),
     m_servoStateOut("servoState", m_servoState),
     m_emergencySignalOut("emergencySignal", m_emergencySignal),
     m_RobotHardwareServicePort("RobotHardwareService"),
@@ -77,6 +78,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   addOutPort("q", m_qOut);
   addOutPort("dq", m_dqOut);
   addOutPort("tau", m_tauOut);
+  addOutPort("ctau", m_ctauOut);
   addOutPort("servoState", m_servoStateOut);
   addOutPort("emergencySignal", m_emergencySignalOut);
 
@@ -126,6 +128,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   m_q.data.length(m_robot->numJoints());
   m_dq.data.length(m_robot->numJoints());
   m_tau.data.length(m_robot->numJoints());
+  m_ctau.data.length(m_robot->numJoints());
   m_servoState.data.length(m_robot->numJoints());
   m_qRef.data.length(m_robot->numJoints());
   m_dqRef.data.length(m_robot->numJoints());
@@ -269,6 +272,8 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
   m_dq.tm = tm;
   m_robot->readJointTorques(m_tau.data.get_buffer());
   m_tau.tm = tm;
+  m_robot->readJointCommandTorques(m_ctau.data.get_buffer());
+  m_ctau.tm = tm;
   for (unsigned int i=0; i<m_rate.size(); i++){
       double rate[3];
       m_robot->readGyroSensor(i, rate);
@@ -316,6 +321,7 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
   m_qOut.write();
   m_dqOut.write();
   m_tauOut.write();
+  m_ctauOut.write();
   m_servoStateOut.write();
   for (unsigned int i=0; i<m_rateOut.size(); i++){
       m_rateOut[i]->write();

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -143,6 +143,10 @@ class RobotHardware
   */
   TimedDoubleSeq m_tau;
   /**
+     \brief array of commanded torques of joint with jointId
+  */
+  TimedDoubleSeq m_ctau;
+  /**
      \brief vector of actual acceleration (vector length = number of acceleration sensors)
   */
   std::vector<TimedAcceleration3D> m_acc;
@@ -163,6 +167,7 @@ class RobotHardware
   OutPort<TimedDoubleSeq> m_qOut;
   OutPort<TimedDoubleSeq> m_dqOut;
   OutPort<TimedDoubleSeq> m_tauOut;
+  OutPort<TimedDoubleSeq> m_ctauOut;
   std::vector<OutPort<TimedAcceleration3D> *> m_accOut;
   std::vector<OutPort<TimedAngularVelocity3D> *> m_rateOut;
   std::vector<OutPort<TimedDoubleSeq> *> m_forceOut;

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -426,6 +426,11 @@ int robot::readJointTorques(double *o_torques)
     return read_actual_torques(o_torques);
 }
 
+int robot::readJointCommandTorques(double *o_torques)
+{
+    return read_command_torques(o_torques);
+}
+
 void robot::readGyroSensor(unsigned int i_rank, double *o_rates)
 {
     read_gyro_sensor(i_rank, o_rates);

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -169,6 +169,13 @@ public:
     int readJointTorques(double *o_torques);
 
     /**
+       \brief read array of all commanded joint torques[Nm]
+       \param o_torques array of all commanded joint torques
+       \param TRUE if read successfully, FALSE otherwise
+     */
+    int readJointCommandTorques(double *o_torques);
+
+    /**
        \brief read gyro sensor output
        \param i_rank rank of gyro sensor
        \param o_rates array of angular velocities(length = 3) [rad/s]


### PR DESCRIPTION
This pull request adds support to read the command torques, as well as the actual torques. We also add a port to output them.

They differ when the robot has torque sensing capabilities (Thus they are the same in simulation). 

This is useful to check if both agree, which allows us to troubleshoot malfunctioning hardware or incorrect parameters.