### PR TITLE
Add a compile option to disable digitalInput function

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -154,6 +154,12 @@ install(FILES
 
 add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")
 
+option(NO_DIGITAL_INPUT "Disable readDigitalInput and lengthDigitalInput" OFF)
+if(NO_DIGITAL_INPUT)
+  add_definitions(-DNO_DIGITAL_INPUT)
+  message(STATUS "Disablng readDigitalInput and lengthDigitalInput")
+endif()
+
 option(ROBOT_IOB_VERSION "Supported robot IOB version (lib/io/iob.h)")
 if("${ROBOT_IOB_VERSION}" STREQUAL "OFF")
   set(ROBOT_IOB_VERSION 2)

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -731,12 +731,20 @@ void robot::readExtraServoState(int id, int *state)
 
 bool robot::readDigitalInput(char *o_din)
 {
+#ifndef NO_DIGITAL_INPUT
     return read_digital_input(o_din);
+#else
+    return false;
+#endif
 }
 
 int robot::lengthDigitalInput()
 {
+#ifndef NO_DIGITAL_INPUT
     return length_digital_input();
+#else
+    return 0;
+#endif
 }
 
 bool robot::writeDigitalOutput(const char *i_dout)


### PR DESCRIPTION
This pull request adds a compile option called NO_DIGITAL_INPUT. When enabled, it replaces the normal call to the I/O lib by a default implementation for the functions readDigitalInput and lengthDigitalInput.

This option has to be turned on when those functions are not present in the I/O library, as is the case on the current version at JRL.

Cheers,
Hervé Audren