### PR TITLE
Exec USE_SRC_OPENHRP3=true tests in faster orders to make debug of these tests easy.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,10 @@ env:
     - TEST_TYPE=iob         TEST_PACKAGE=hrpsys
     - TEST_TYPE=stable_rtc  TEST_PACKAGE=hrpsys
     # compile source code with ros-related tools, they are compiled with catkin and test with rostest
+    #    Exec USE_SRC_OPENHRP3=true tests in faster orders to make debug of these tests easy.
+    - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
+    - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
+    #    USE_SRC_OPENHRP3=false tests
     - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys-base
     - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hrpsys-base
     - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hrpsys-tools
@@ -31,8 +35,6 @@ env:
     - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hrpsys-ros-bridge
     - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge
     - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge
-    - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
-    - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
 script: source .travis.sh
 after_success:
   - set +x


### PR DESCRIPTION
最近１５、１６番の
```
    - TEST_TYPE=work_with_downstream  TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
    - TEST_TYPE=work_with_315_1_10    TEST_PACKAGE=hironx-ros-bridge USE_SRC_OPENHRP3=true
```
のテストが頻繁に失敗するので、デバッグも含めて諸々確認のために
travis上のテスト順序を少しはやめに実行されるようにしてみました。

おそらく、他の挙動はまったく変わらず、テストの実行が開始される順番がはやくなると思います。
また、番号は15,16=>7,8になると思います。

よろしくお願いします。