### PR TITLE
Add c++ 11 support, and lock sequence player

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -17,6 +17,8 @@ option(ENABLE_INSTALL_RPATH "Enable RPATH setting for installed binary files" OF
 set(CMAKE_INSTALL_RPATH "${CMAKE_INSTALL_PREFIX}/lib")
 set(CMAKE_INSTALL_RPATH_USE_LINK_PATH TRUE)
 
+set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} "-std=c++11")
+
 # commands
 if(UNIX)
   set(RMDIR rm -fr)

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1088,9 +1088,9 @@ bool AutoBalancer::goPos(const double& x, const double& y, const double& th)
     coordinates start_ref_coords;
     mid_coords(start_ref_coords, 0.5, ikp["rleg"].target_end_coords, ikp["lleg"].target_end_coords);
     gg->go_pos_param_2_footstep_nodes_list(x, y, th,
-                                           (y > 0 ? boost::assign::list_of(ikp["rleg"].target_end_coords) : boost::assign::list_of(ikp["lleg"].target_end_coords)),
+        {(y > 0 ? ikp["rleg"].target_end_coords : ikp["lleg"].target_end_coords)},
                                            start_ref_coords,
-                                           (y > 0 ? boost::assign::list_of(RLEG) : boost::assign::list_of(LLEG)));
+                                           {(y > 0 ? RLEG : LLEG)});
     startWalking();
     return true;
   } else {

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -235,7 +235,10 @@ namespace rats
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           double zmp_weight_initial_value[4] = {1.0, 1.0, 0.1, 0.1};
-          zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, zmp_weight_initial_value[0])(LLEG, zmp_weight_initial_value[1])(RARM, zmp_weight_initial_value[2])(LARM, zmp_weight_initial_value[3]);
+          zmp_weight_map = {{RLEG, zmp_weight_initial_value[0]},
+                            {LLEG, zmp_weight_initial_value[1]},
+                            {RARM, zmp_weight_initial_value[2]},
+                            {LARM, zmp_weight_initial_value[3]}};
           zmp_weight_interpolator = boost::shared_ptr<interpolator>(new interpolator(4, dt));
           zmp_weight_interpolator->set(zmp_weight_initial_value); /* set initial value */
       };
@@ -299,7 +302,10 @@ namespace rats
           if (!zmp_weight_interpolator->isEmpty()) {
               double zmp_weight_output[4];
               zmp_weight_interpolator->get(zmp_weight_output, true);
-              zmp_weight_map = boost::assign::map_list_of<leg_type, double>(RLEG, zmp_weight_output[0])(LLEG, zmp_weight_output[1])(RARM, zmp_weight_output[2])(LARM, zmp_weight_output[3]);
+              zmp_weight_map = {{RLEG, zmp_weight_output[0]},
+                                {LLEG, zmp_weight_output[1]},
+                                {RARM, zmp_weight_output[2]},
+                                {LARM, zmp_weight_output[3]}};
           }
       };
     };
@@ -576,9 +582,9 @@ namespace rats
           foot_ratio_interpolator(NULL), swing_foot_rot_ratio_interpolator(NULL), toe_heel_interpolator(NULL),
           toe_pos_offset_x(0.0), heel_pos_offset_x(0.0), toe_angle(0.0), heel_angle(0.0), foot_dif_rot_angle(0.0), use_toe_joint(false)
       {
-        support_leg_types = boost::assign::list_of<leg_type>(RLEG);
-        swing_leg_types = boost::assign::list_of<leg_type>(LLEG);
-        current_swing_time = boost::assign::list_of<double>(0.0)(0.0)(0.0)(0.0);
+        support_leg_types = {RLEG};
+        swing_leg_types = {LLEG};
+        current_swing_time = {{0.0},{0.0},{0.0},{0.0}};
         rdtg.set_dt(dt);
         sdtg.set_dt(dt);
         cdtg.set_dt(dt);
@@ -835,9 +841,9 @@ namespace rats
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
         use_inside_step_limitation(true),
         preview_controller_ptr(NULL) {
-        swing_foot_zmp_offsets = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
-        prev_que_sfzos = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
-        leg_type_map = boost::assign::map_list_of<leg_type, std::string>(RLEG, "rleg")(LLEG, "lleg")(RARM, "rarm")(LARM, "larm");
+        swing_foot_zmp_offsets = {hrp::Vector3::Zero()};
+        prev_que_sfzos = {hrp::Vector3::Zero()};
+        leg_type_map = {{RLEG, "rleg"},{LLEG, "lleg"},{RARM, "rarm"},{LARM, "larm"}};
     };
     ~gait_generator () {
       if ( preview_controller_ptr != NULL ) {

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -76,14 +76,14 @@ private:
                 fprintf(fp, "%f ", cogpos);
             }
             // Foot pos
-            tmp_string_vector = boost::assign::list_of("rleg");
+            tmp_string_vector = {"rleg"};
             hrp::Vector3 rfoot_pos = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.pos : gg->get_swing_leg_steps().front().worldcoords.pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", rfoot_pos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), rfoot_pos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), rfoot_pos(ii));
             }
-            tmp_string_vector = boost::assign::list_of("lleg");
+            tmp_string_vector = {"lleg"};
             hrp::Vector3 lfoot_pos = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.pos : gg->get_swing_leg_steps().front().worldcoords.pos;
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", lfoot_pos(ii));
@@ -92,24 +92,24 @@ private:
             }
             // Foot rot
             hrp::Vector3 rpy;
-            tmp_string_vector = boost::assign::list_of("rleg");
+            tmp_string_vector = {"rleg"};
             hrp::Matrix33 rfoot_rot = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.rot : gg->get_swing_leg_steps().front().worldcoords.rot;
             rpy = hrp::rpyFromRot(rfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
-            tmp_string_vector = boost::assign::list_of("lleg");
+            tmp_string_vector = {"lleg"};
             hrp::Matrix33 lfoot_rot = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.rot : gg->get_swing_leg_steps().front().worldcoords.rot;
             rpy = hrp::rpyFromRot(lfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
             }
             // ZMP offsets
-            tmp_string_vector = boost::assign::list_of("rleg");
+            tmp_string_vector = {"rleg"};
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
-            tmp_string_vector = boost::assign::list_of("lleg");
+            tmp_string_vector = {"lleg"};
             for (size_t ii = 0; ii < 3; ii++) {
                 fprintf(fp, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
@@ -348,7 +348,7 @@ private:
     {
         parse_params();
         gg->print_param();
-        gg->initialize_gait_parameter(cog, boost::assign::list_of(initial_support_leg_step), boost::assign::list_of(initial_swing_leg_dst_step));
+        gg->initialize_gait_parameter(cog, {initial_support_leg_step}, {initial_swing_leg_dst_step});
         while ( !gg->proc_one_tick() );
         //gg->print_footstep_list();
         plot_walk_pattern();
@@ -356,7 +356,7 @@ private:
 
     void gen_and_plot_walk_pattern()
     {
-        std::vector<std::string> tmp_string_vector = boost::assign::list_of("rleg");
+        std::vector<std::string> tmp_string_vector = {"rleg"};
         if (gg->get_footstep_front_leg_names() == tmp_string_vector) {
             step_node initial_support_leg_step = step_node(LLEG, coordinates(leg_pos[1]), 0, 0, 0, 0);
             step_node initial_swing_leg_dst_step = step_node(RLEG, coordinates(leg_pos[0]), 0, 0, 0, 0);
@@ -385,11 +385,11 @@ public:
         /* initialize sample footstep_list */
         parse_params();
         std::vector< std::vector<step_node> > fnsl;
-        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnsl.push_back(boost::assign::list_of(step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
-        fnsl.push_back(boost::assign::list_of(step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())));
+        fnsl.push_back({step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())});
+        fnsl.push_back({step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(0, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())});
+        fnsl.push_back({step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(100*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())});
+        fnsl.push_back({step_node("lleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[1])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())});
+        fnsl.push_back({step_node("rleg", coordinates(hrp::Vector3(hrp::Vector3(200*1e-3, 0, 0)+leg_pos[0])), gg->get_default_step_height(), gg->get_default_step_time(), gg->get_toe_angle(), gg->get_heel_angle())});
         gg->set_foot_steps_list(fnsl);
         gen_and_plot_walk_pattern();
     };

--- a/rtc/ImpedanceController/JointPathEx.cpp
+++ b/rtc/ImpedanceController/JointPathEx.cpp
@@ -186,7 +186,7 @@ bool JointPathEx::calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatri
         } else {
             r = fabs( (pow((jmax - jmin),2) * (( 2 * jang) - jmax - jmin)) /
                       (4 * pow((jmax - jang),2) * pow((jang - jmin),2)) );
-            if (isnan(r)) r = 0;
+            if (std::isnan((double)r)) r = 0;
         }
 
         // If use_inside_joint_weight_retrieval = true (true by default), use T. F. Chang and R.-V. Dubeby weight retrieval inward.
@@ -368,7 +368,7 @@ bool JointPathEx::calcInverseKinematics2Loop(const Vector3& dp, const Vector3& o
     // check nan / inf
     bool solve_linear_equation = true;
     for(int j=0; j < n; ++j){
-      if ( isnan(dq(j)) || isinf(dq(j)) ) {
+      if ( std::isnan((double)dq(j)) || std::isinf((double)dq(j)) ) {
         solve_linear_equation = false;
         break;
       }

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
@@ -167,7 +167,7 @@ class RemoveForceSensorLinkOffset
   void printForceMomentOffsetParam(const std::string& i_name_);
 
   std::map<std::string, ForceMomentOffsetParam> m_forcemoment_offset_param;
-  static const double grav = 9.80665; /* [m/s^2] */
+  static constexpr double grav = 9.80665; /* [m/s^2] */
   double m_dt;
   hrp::BodyPtr m_robot;
   unsigned int m_debugLevel;

--- a/rtc/SequencePlayer/interpolator.cpp
+++ b/rtc/SequencePlayer/interpolator.cpp
@@ -267,6 +267,7 @@ void interpolator::push(const double *x_, const double *v_, const double *a_, bo
 
 void interpolator::pop()
 {
+  std::lock_guard<std::mutex> lock(pop_mutex_);
   if (length > 0){
     length--;
     double *&vs = q.front();
@@ -283,6 +284,7 @@ void interpolator::pop()
 
 void interpolator::pop_back()
 {
+  std::lock_guard<std::mutex> lock(pop_mutex_);
   if (length > 0){
     length--;
     double *&vs = q.back();

--- a/rtc/SequencePlayer/interpolator.h
+++ b/rtc/SequencePlayer/interpolator.h
@@ -3,6 +3,7 @@
 
 #include <deque>
 #include <string>
+#include <mutex>
 
 using namespace std;
 
@@ -89,6 +90,7 @@ private:
   void linear_interpolation(double &remain_t_,
 			    double gx,
 			    double &xx, double &vv, double &aa);
+  std::mutex pop_mutex_;
 };
 
 #endif


### PR DESCRIPTION
Hello,

This is a pull request that does two things:
- Fix #836 by using mutex
- Switch to C++11

I switched to C++11 to be able to use the std::lock_guard construct. I know that upgrading to C++11 may pose problem to some users, especially if their robots still use older versions of Ubuntu. I do not know about JSK ( @k-okada ) or other labs. 

This efficiently solves the problem for the Sequence Player, I was able to clear and restart the sequence more than 10 times in row without crash.

For the C++11 port, it was just a matter of removing ambiguous calls to isnan/isinf and boost::assign plus adding a constexpr were necessary.

Please tell me your opinion,
Hervé