### PR TITLE
include directoryの表記をソースファイルとpkg-configを使った場合で同じにする

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,25 @@ if(UNIX)
     add_definitions(${OPENHRP_DEFINITIONS})
 endif()
 
-include_directories(${PROJECT_SOURCE_DIR}/lib)
-include_directories(${CMAKE_BINARY_DIR}/idl)
+execute_process(
+  COMMAND mkdir -p ${CMAKE_BINARY_DIR}/hrpsys
+)
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/hrpsys/io)
+  execute_process(
+    COMMAND ln -s ${PROJECT_SOURCE_DIR}/lib/io ${CMAKE_BINARY_DIR}/hrpsys/io
+   )
+endif()
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/hrpsys/util)
+  execute_process(
+    COMMAND ln -s ${PROJECT_SOURCE_DIR}/lib/util ${CMAKE_BINARY_DIR}/hrpsys/util
+   )
+endif()
+if (NOT EXISTS ${CMAKE_BINARY_DIR}/hrpsys/idl)
+  execute_process(
+    COMMAND ln -s ${CMAKE_BINARY_DIR}/idl ${CMAKE_BINARY_DIR}/hrpsys/idl
+   )
+endif()
+include_directories(${CMAKE_BINARY_DIR})
 
 if(ENABLE_INSTALL_RPATH)
   set(CMAKE_INSTALL_RPATH "$ORIGIN/../lib:$ORIGIN/../../../lib:${OPENHRP_LIBRARY_DIRS}")

--- a/ec/hrpEC/hrpEC-art.cpp
+++ b/ec/hrpEC/hrpEC-art.cpp
@@ -2,7 +2,7 @@
 #include <iostream>
 #include "hrpEC.h"
 #include <rtm/ECFactory.h>
-#include "io/iob.h"
+#include "hrpsys/io/iob.h"
 #include <linux/art_task.h>
 
 namespace RTC

--- a/ec/hrpEC/hrpEC-common.cpp
+++ b/ec/hrpEC/hrpEC-common.cpp
@@ -1,5 +1,5 @@
 #include "hrpEC.h"
-#include "io/iob.h"
+#include "hrpsys/io/iob.h"
 #ifdef OPENRTM_VERSION_TRUNK
 #include <rtm/RTObjectStateMachine.h>
 #endif

--- a/ec/hrpEC/hrpEC.cpp
+++ b/ec/hrpEC/hrpEC.cpp
@@ -2,7 +2,7 @@
 
 #include "hrpEC.h"
 #include <rtm/ECFactory.h>
-#include "io/iob.h"
+#include "hrpsys/io/iob.h"
 
 #include <iostream>
 

--- a/ec/hrpEC/hrpEC.h
+++ b/ec/hrpEC/hrpEC.h
@@ -11,7 +11,7 @@
 #include <rtm/Manager.h>
 #include <rtm/PeriodicExecutionContext.h>
 
-#include "ExecutionProfileService.hh"
+#include "hrpsys/idl/ExecutionProfileService.hh"
 
 namespace RTC
 {

--- a/lib/util/BodyRTC.h
+++ b/lib/util/BodyRTC.h
@@ -10,8 +10,8 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
-#include "Img.hh"
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/Img.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 class InPortHandlerBase;
 class OutPortHandlerBase;

--- a/lib/util/GLbodyRTC.cpp
+++ b/lib/util/GLbodyRTC.cpp
@@ -1,4 +1,4 @@
-#include "util/GLbodyRTC.h"
+#include "hrpsys/util/GLbodyRTC.h"
 
 const char* GLbodyRTC::glbodyrtc_spec[] =
 {

--- a/lib/util/GLbodyRTC.h
+++ b/lib/util/GLbodyRTC.h
@@ -1,8 +1,8 @@
 #ifndef __GLBODYRTC_H__
 #define __GLBODYRTC_H__
 
-#include "util/BodyRTC.h"
-#include "util/GLbody.h"
+#include "hrpsys/util/BodyRTC.h"
+#include "hrpsys/util/GLbody.h"
 
 class GLbodyRTC : public BodyRTC, public GLbody
 {

--- a/lib/util/PortHandler.h
+++ b/lib/util/PortHandler.h
@@ -2,9 +2,9 @@
 #define __PORT_HANDLER_H__
 
 #include <rtm/idl/InterfaceDataTypes.hh>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "BodyRTC.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 namespace hrp{
     class ForceSensor;

--- a/lib/util/ProjectUtil.h
+++ b/lib/util/ProjectUtil.h
@@ -3,8 +3,8 @@
 #include <hrpModel/Body.h>
 #include <hrpModel/ConstraintForceSolver.h>
 #include <hrpModel/ColdetLinkPair.h>
-#include "util/Project.h"
-#include "util/OpenRTMUtil.h"
+#include "hrpsys/util/Project.h"
+#include "hrpsys/util/OpenRTMUtil.h"
 
 typedef boost::function2<hrp::BodyPtr, const std::string&, const ModelItem&> BodyFactory;
 

--- a/lib/util/SDLUtil.cpp
+++ b/lib/util/SDLUtil.cpp
@@ -7,11 +7,11 @@
 #include <GL/glut.h>
 #endif
 #include <SDL.h>
-#include "util/ThreadedObject.h"
-#include "util/LogManagerBase.h"
-#include "util/GLsceneBase.h"
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
+#include "hrpsys/util/ThreadedObject.h"
+#include "hrpsys/util/LogManagerBase.h"
+#include "hrpsys/util/GLsceneBase.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
 #include "SDLUtil.h"
 
 

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -14,7 +14,7 @@
 #include "AutoBalancer.h"
 #include <hrpModel/JointPath.h>
 #include <hrpUtil/MatrixSolvers.h>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 
 
 typedef coil::Guard<coil::Mutex> Guard;

--- a/rtc/AutoBalancer/AutoBalancerService_impl.h
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef AUTOBALANCERSERVICESVC_IMPL_H
 #define AUTOBALANCERSERVICESVC_IMPL_H
 
-#include "AutoBalancerService.hh"
+#include "hrpsys/idl/AutoBalancerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/AutoBalancer/PreviewController.h
+++ b/rtc/AutoBalancer/PreviewController.h
@@ -5,7 +5,7 @@
 #include <queue>
 #include <deque>
 #include <hrpUtil/Eigen3d.h>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 
 namespace rats
 {

--- a/rtc/AverageFilter/AverageFilter.cpp
+++ b/rtc/AverageFilter/AverageFilter.cpp
@@ -10,7 +10,7 @@
 #include <math.h>
 #include <limits>
 #include "AverageFilter.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/AverageFilter/AverageFilter.h
+++ b/rtc/AverageFilter/AverageFilter.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/CameraImageLoader/CameraImageLoader.h
+++ b/rtc/CameraImageLoader/CameraImageLoader.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/CameraImageViewer/CameraImageViewer.h
+++ b/rtc/CameraImageViewer/CameraImageViewer.h
@@ -18,7 +18,7 @@
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <cv.h>
 #include <highgui.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/CaptureController/CameraCaptureService_impl.h
+++ b/rtc/CaptureController/CameraCaptureService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __CAMERA_CAPTURE_SERVICE_H__
 #define __CAMERA_CAPTURE_SERVICE_H__
 
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 class CaptureController;
 

--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -15,11 +15,11 @@
 #include <hrpUtil/Eigen4d.h>
 #include <hrpCollision/ColdetModel.h>
 #ifdef USE_HRPSYSUTIL
-#include "util/GLbody.h"
-#include "util/GLutil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLutil.h"
 #endif // USE_HRPSYSUTIL
-#include "util/BVutil.h"
-#include "RobotHardwareService.hh"
+#include "hrpsys/util/BVutil.h"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 #include "CollisionDetector.h"
 

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -21,12 +21,12 @@
 #include <hrpModel/ModelLoaderUtil.h>
 #ifdef USE_HRPSYSUTIL
 #include "GLscene.h"
-#include "util/SDLUtil.h"
-#include "util/LogManager.h"
+#include "hrpsys/util/SDLUtil.h"
+#include "hrpsys/util/LogManager.h"
 #endif // USE_HRPSYSUTIL
 #include "TimedPosture.h"
 #include "interpolator.h"
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 
 #include "VclipLinkPair.h"
 #include "CollisionDetectorService_impl.h"

--- a/rtc/CollisionDetector/CollisionDetectorService_impl.h
+++ b/rtc/CollisionDetector/CollisionDetectorService_impl.h
@@ -2,7 +2,7 @@
 #ifndef COLLISIONDETECTORSERVICE_IMPL_H
 #define COLLISIONDETECTORSERVICE_IMPL_H
 
-#include "CollisionDetectorService.hh"
+#include "hrpsys/idl/CollisionDetectorService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/CollisionDetector/CollisionDetectorViewer.cpp
+++ b/rtc/CollisionDetector/CollisionDetectorViewer.cpp
@@ -7,16 +7,16 @@
 #else
 #include <GL/glut.h>
 #endif
-#include "util/ProjectUtil.h"
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
-#include "util/SDLUtil.h"
-#include "util/LogManager.h"
-#include "util/BVutil.h"
+#include "hrpsys/util/ProjectUtil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
+#include "hrpsys/util/SDLUtil.h"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/util/BVutil.h"
 #include "TimedPosture.h"
 #include "GLscene.h"
-#include "CollisionDetectorService.hh"
+#include "hrpsys/idl/CollisionDetectorService.hh"
 
 using namespace hrp;
 using namespace OpenHRP;

--- a/rtc/CollisionDetector/GLscene.cpp
+++ b/rtc/CollisionDetector/GLscene.cpp
@@ -7,13 +7,13 @@
 #include <GL/glut.h>
 #endif
 #include <sys/time.h>
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
 #include "TimedPosture.h"
 #include "GLscene.h"
-#include "CollisionDetectorService.hh"
+#include "hrpsys/idl/CollisionDetectorService.hh"
 
 
 using namespace OpenHRP;

--- a/rtc/CollisionDetector/GLscene.h
+++ b/rtc/CollisionDetector/GLscene.h
@@ -2,7 +2,7 @@
 #define __GLSCENE_H__
 
 #include <hrpModel/ColdetLinkPair.h>
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class LogManagerBase;
 

--- a/rtc/DataLogger/DataLogger.cpp
+++ b/rtc/DataLogger/DataLogger.cpp
@@ -8,8 +8,8 @@
  */
 
 #include "DataLogger.h"
-#include "util/Hrpsys.h"
-#include "pointcloud.hh"
+#include "hrpsys/util/Hrpsys.h"
+#include "hrpsys/idl/pointcloud.hh"
 
 
 typedef coil::Guard<coil::Mutex> Guard;

--- a/rtc/DataLogger/DataLogger.h
+++ b/rtc/DataLogger/DataLogger.h
@@ -20,7 +20,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/DataLogger/DataLoggerService_impl.h
+++ b/rtc/DataLogger/DataLoggerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __DATA_LOGGER_SERVICE_IMPL_H__
 #define __DATA_LOGGER_SERVICE_IMPL_H__
 
-#include "DataLoggerService.hh"
+#include "hrpsys/idl/DataLoggerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/EmergencyStopper/EmergencyStopper.cpp
+++ b/rtc/EmergencyStopper/EmergencyStopper.cpp
@@ -7,13 +7,13 @@
  * $Id$
  */
 
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include <math.h>
 #include <hrpModel/Link.h>
 #include <hrpModel/Sensor.h>
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 #include "EmergencyStopper.h"
 

--- a/rtc/EmergencyStopper/EmergencyStopper.h
+++ b/rtc/EmergencyStopper/EmergencyStopper.h
@@ -19,7 +19,7 @@
 #include <rtm/idl/ExtendedDataTypesSkel.h>
 #include <hrpModel/Body.h>
 #include "interpolator.h"
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include <queue>
 
 // Service implementation headers

--- a/rtc/EmergencyStopper/EmergencyStopperService_impl.h
+++ b/rtc/EmergencyStopper/EmergencyStopperService_impl.h
@@ -1,7 +1,7 @@
 #ifndef __EMERGENCYSTOPPER_SERVICE_H__
 #define __EMERGENCYSTOPPER_SERVICE_H__
 
-#include "EmergencyStopperService.hh"
+#include "hrpsys/idl/EmergencyStopperService.hh"
 
 class EmergencyStopper;
 

--- a/rtc/ExtractCameraImage/ExtractCameraImage.h
+++ b/rtc/ExtractCameraImage/ExtractCameraImage.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/ForwardKinematics/ForwardKinematicsService_impl.h
+++ b/rtc/ForwardKinematics/ForwardKinematicsService_impl.h
@@ -1,7 +1,7 @@
 #ifndef __FORWARD_KINEMATICS_SERVICE_IMPL_H__
 #define __FORWARD_KINEMATICS_SERVICE_IMPL_H__
 
-#include "ForwardKinematicsService.hh"
+#include "hrpsys/idl/ForwardKinematicsService.hh"
 
 class ForwardKinematics;
 

--- a/rtc/GraspController/GraspController.cpp
+++ b/rtc/GraspController/GraspController.cpp
@@ -8,10 +8,10 @@
  */
 
 #include "GraspController.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 #include <hrpModel/Link.h>
 

--- a/rtc/GraspController/GraspController.h
+++ b/rtc/GraspController/GraspController.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/GraspController/GraspControllerService_impl.h
+++ b/rtc/GraspController/GraspControllerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __GRAP_CONTROLLER_SERVICE_H__
 #define __GRAP_CONTROLLER_SERVICE_H__
 
-#include "GraspControllerService.hh"
+#include "hrpsys/idl/GraspControllerService.hh"
 
 class GraspController;
 

--- a/rtc/ImageData2CameraImage/ImageData2CameraImage.h
+++ b/rtc/ImageData2CameraImage/ImageData2CameraImage.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -15,7 +15,7 @@
 #include "JointPathEx.h"
 #include <hrpModel/JointPath.h>
 #include <hrpUtil/MatrixSolvers.h>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 #include <boost/assign.hpp>
 
 #define MAX_TRANSITION_COUNT (static_cast<int>(2/m_dt))

--- a/rtc/ImpedanceController/ImpedanceControllerService_impl.h
+++ b/rtc/ImpedanceController/ImpedanceControllerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef IMPEDANCESERVICESVC_IMPL_H
 #define IMPEDANCESERVICESVC_IMPL_H
 
-#include "ImpedanceControllerService.hh"
+#include "hrpsys/idl/ImpedanceControllerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/Joystick2PanTiltAngles/Joystick2PanTiltAngles.cpp
+++ b/rtc/Joystick2PanTiltAngles/Joystick2PanTiltAngles.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "Joystick2PanTiltAngles.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/Joystick2Velocity2D/Joystick2Velocity2D.cpp
+++ b/rtc/Joystick2Velocity2D/Joystick2Velocity2D.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "Joystick2Velocity2D.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/Joystick2Velocity3D/Joystick2Velocity3D.cpp
+++ b/rtc/Joystick2Velocity3D/Joystick2Velocity3D.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "Joystick2Velocity3D.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/JpegDecoder/JpegDecoder.h
+++ b/rtc/JpegDecoder/JpegDecoder.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/JpegEncoder/JpegEncoder.h
+++ b/rtc/JpegEncoder/JpegEncoder.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/KalmanFilter/EKFilter.h
+++ b/rtc/KalmanFilter/EKFilter.h
@@ -4,7 +4,7 @@
 
 #include <hrpUtil/EigenTypes.h>
 #include <iostream>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 
 namespace hrp{
   typedef Eigen::Matrix<double, 7, 7> Matrix77;

--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "KalmanFilter.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include <math.h>

--- a/rtc/KalmanFilter/KalmanFilterService_impl.h
+++ b/rtc/KalmanFilter/KalmanFilterService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __KALMANFILTER_SERVICE_H__
 #define __KALMANFILTER_SERVICE_H__
 
-#include "KalmanFilterService.hh"
+#include "hrpsys/idl/KalmanFilterService.hh"
 
 class KalmanFilter;
 

--- a/rtc/KalmanFilter/RPYKalmanFilter.h
+++ b/rtc/KalmanFilter/RPYKalmanFilter.h
@@ -3,7 +3,7 @@
 
 #include <hrpUtil/EigenTypes.h>
 #include <hrpUtil/Eigen3d.h>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 namespace hrp{
   typedef Eigen::Vector2d Vector2;
   typedef Eigen::Matrix2d Matrix22;

--- a/rtc/MLSFilter/MLSFilter.cpp
+++ b/rtc/MLSFilter/MLSFilter.cpp
@@ -11,7 +11,7 @@
 #include <pcl/point_types.h>
 #include <pcl/surface/mls.h>
 #include "MLSFilter.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/MLSFilter/MLSFilter.h
+++ b/rtc/MLSFilter/MLSFilter.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/NullComponent/NullComponent.cpp
+++ b/rtc/NullComponent/NullComponent.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "NullComponent.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/NullComponent/NullService_impl.h
+++ b/rtc/NullComponent/NullService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __NULL_SERVICE_H__
 #define __NULL_SERVICE_H__
 
-#include "NullService.hh"
+#include "hrpsys/idl/NullService.hh"
 
 class NullService_impl
 	: public virtual POA_OpenHRP::NullService,

--- a/rtc/OGMap3DViewer/OGMap3DViewer.h
+++ b/rtc/OGMap3DViewer/OGMap3DViewer.h
@@ -20,7 +20,7 @@
 //Open CV headder
 #include <cv.h>
 #include <highgui.h>
-#include "OGMap3DService.hh"
+#include "hrpsys/idl/OGMap3DService.hh"
 
 class GLbody;
 class CMapSceneNode;

--- a/rtc/OccupancyGridMap3D/OGMap3DService_impl.h
+++ b/rtc/OccupancyGridMap3D/OGMap3DService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __OGMap3DService_H__
 #define __OGMap3DService_H__
 
-#include "OGMap3DService.hh"
+#include "hrpsys/idl/OGMap3DService.hh"
 
 class OccupancyGridMap3D;
 

--- a/rtc/OccupancyGridMap3D/OccupancyGridMap3D.h
+++ b/rtc/OccupancyGridMap3D/OccupancyGridMap3D.h
@@ -17,7 +17,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/InterfaceDataTypes.hh>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 namespace octomap{
     class OcTree;

--- a/rtc/PCDLoader/PCDLoader.cpp
+++ b/rtc/PCDLoader/PCDLoader.cpp
@@ -11,7 +11,7 @@
 #include <pcl/point_types.h>
 #include <pcl/filters/statistical_outlier_removal.h>
 #include "PCDLoader.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/PCDLoader/PCDLoader.h
+++ b/rtc/PCDLoader/PCDLoader.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/PlaneRemover/PlaneRemover.cpp
+++ b/rtc/PlaneRemover/PlaneRemover.cpp
@@ -12,7 +12,7 @@
 #include <pcl/segmentation/sac_segmentation.h>
 #include <pcl/filters/extract_indices.h>
 #include "PlaneRemover.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/PlaneRemover/PlaneRemover.h
+++ b/rtc/PlaneRemover/PlaneRemover.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/RGB2Gray/RGB2Gray.h
+++ b/rtc/RGB2Gray/RGB2Gray.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/Range2PointCloud/Range2PointCloud.h
+++ b/rtc/Range2PointCloud/Range2PointCloud.h
@@ -17,7 +17,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/InterfaceDataTypes.hh>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
@@ -2,7 +2,7 @@
 #ifndef REMOVEFORCESENSORLINKOFFSETSERVICE_IMPL_H
 #define REMOVEFORCESENSORLINKOFFSETSERVICE_IMPL_H
 
-#include "RemoveForceSensorLinkOffsetService.hh"
+#include "hrpsys/idl/RemoveForceSensorLinkOffsetService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/ResizeImage/ResizeImage.h
+++ b/rtc/ResizeImage/ResizeImage.h
@@ -17,7 +17,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <cv.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -10,7 +10,7 @@
 #include <rtm/CorbaNaming.h>
 #include "RobotHardware.h"
 #include "robot.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 #include <hrpModel/Sensor.h>
 #include <hrpModel/ModelLoaderUtil.h>

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -17,7 +17,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 
 #include <hrpModel/Body.h>
 

--- a/rtc/RobotHardware/RobotHardwareService_impl.h
+++ b/rtc/RobotHardware/RobotHardwareService_impl.h
@@ -4,7 +4,7 @@
 #define ROBOTHARDWARESERVICE_IMPL_H
 
 #include <boost/intrusive_ptr.hpp>
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 #include "robot.h"
 

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -6,9 +6,9 @@
 #include <hrpModel/Sensor.h>
 #include <hrpModel/Link.h>
 #include "defs.h"
-#include "io/iob.h"
+#include "hrpsys/io/iob.h"
 #include "robot.h"
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 
 #define CALIB_COUNT	(10*200)
 #define GAIN_COUNT	( 5*200)

--- a/rtc/RotateImage/RotateImage.h
+++ b/rtc/RotateImage/RotateImage.h
@@ -17,7 +17,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <cv.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/SORFilter/SORFilter.cpp
+++ b/rtc/SORFilter/SORFilter.cpp
@@ -11,7 +11,7 @@
 #include <pcl/point_types.h>
 #include <pcl/filters/statistical_outlier_removal.h>
 #include "SORFilter.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/SORFilter/SORFilter.h
+++ b/rtc/SORFilter/SORFilter.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -11,7 +11,7 @@
 #include <hrpModel/Link.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include "SequencePlayer.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <hrpModel/JointPath.h>
 #include <hrpUtil/MatrixSolvers.h>
 #include "../ImpedanceController/JointPathEx.h"

--- a/rtc/SequencePlayer/SequencePlayerService_impl.h
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef SEQPLAYSERVICESVC_IMPL_H
 #define SEQPLAYSERVICESVC_IMPL_H
 
-#include "SequencePlayerService.hh"
+#include "hrpsys/idl/SequencePlayerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/SequencePlayer/timeUtil.cpp
+++ b/rtc/SequencePlayer/timeUtil.cpp
@@ -1,5 +1,5 @@
 #include <fstream>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 #include "timeUtil.h"
 
 

--- a/rtc/ServoController/ServoController.cpp
+++ b/rtc/ServoController/ServoController.cpp
@@ -11,7 +11,7 @@
 #include <hrpModel/Link.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include "ServoController.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 #include "ServoSerial.h"
 

--- a/rtc/ServoController/ServoControllerService_impl.h
+++ b/rtc/ServoController/ServoControllerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __SERVOCONTROLLER_SERVICE_H__
 #define __SERVOCONTROLLER_SERVICE_H__
 
-#include "ServoControllerService.hh"
+#include "hrpsys/idl/ServoControllerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/Simulator/RTCBody.h
+++ b/rtc/Simulator/RTCBody.h
@@ -7,7 +7,7 @@
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <rtm/idl/ExtendedDataTypesSkel.h>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 
 class RTCBody : public hrp::Body
 {

--- a/rtc/Simulator/Simulator.cpp
+++ b/rtc/Simulator/Simulator.cpp
@@ -14,7 +14,7 @@
 #include <hrpModel/ModelLoaderUtil.h>
 #include <hrpModel/OnlineViewerUtil.h>
 #include <hrpModel/Link.h>
-#include "util/Project.h"
+#include "hrpsys/util/Project.h"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/Simulator/Simulator.h
+++ b/rtc/Simulator/Simulator.h
@@ -21,7 +21,7 @@
 #include <hrpModel/World.h>
 #include <hrpUtil/OnlineViewerUtil.h>
 
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "RTCBody.h"
 
 // Service implementation headers

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -8,10 +8,10 @@
  */
 
 #include "SoftErrorLimiter.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 
 #include <math.h>
 #include <vector>

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "JointLimitTable.h"
 
 // Service implementation headers

--- a/rtc/SoftErrorLimiter/SoftErrorLimiterService_impl.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiterService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __SOFT_ERROR_LIMITER_SERVICE_H__
 #define __SOFT_ERROR_LIMITER_SERVICE_H__
 
-#include "SoftErrorLimiterService.hh"
+#include "hrpsys/idl/SoftErrorLimiterService.hh"
 #include "robot.h"
 
 class SoftErrorLimiterService_impl

--- a/rtc/SoftErrorLimiter/robot.cpp
+++ b/rtc/SoftErrorLimiter/robot.cpp
@@ -1,5 +1,5 @@
 #include "robot.h"
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 
 #define DEFAULT_ANGLE_ERROR_LIMIT (0.2 - 0.02) // [rad]
 

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -12,7 +12,7 @@
 #include <hrpModel/Sensor.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include "Stabilizer.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include <math.h>
 #include <boost/lambda/lambda.hpp>
 

--- a/rtc/Stabilizer/StabilizerService_impl.h
+++ b/rtc/Stabilizer/StabilizerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __KALMANFILTER_SERVICE_H__
 #define __KALMANFILTER_SERVICE_H__
 
-#include "StabilizerService.hh"
+#include "hrpsys/idl/StabilizerService.hh"
 
 class Stabilizer;
 

--- a/rtc/Stabilizer/testZMPDistributor.cpp
+++ b/rtc/Stabilizer/testZMPDistributor.cpp
@@ -5,7 +5,7 @@
 #include <stdio.h>
 #include <cstdio>
 #include <iostream>
-#include "util/Hrpsys.h" // added for QNX compile
+#include "hrpsys/util/Hrpsys.h" // added for QNX compile
 
 class testZMPDistributor
 {

--- a/rtc/StateHolder/StateHolderService_impl.h
+++ b/rtc/StateHolder/StateHolderService_impl.h
@@ -2,7 +2,7 @@
 #ifndef STATEHOLDERSERVICE_IMPL_H
 #define STATEHOLDERSERVICE_IMPL_H
 
-#include "StateHolderService.hh"
+#include "hrpsys/idl/StateHolderService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/StateHolder/TimeKeeperService_impl.h
+++ b/rtc/StateHolder/TimeKeeperService_impl.h
@@ -2,7 +2,7 @@
 #ifndef TIMEKEEPERSERVICE_IMPL_H
 #define TIMEKEEPERSERVICE_IMPL_H
 
-#include "TimeKeeperService.hh"
+#include "hrpsys/idl/TimeKeeperService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/ThermoEstimator/ThermoEstimator.cpp
+++ b/rtc/ThermoEstimator/ThermoEstimator.cpp
@@ -13,7 +13,7 @@
  */
 
 #include "ThermoEstimator.h"
-#include "RobotHardwareService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include <hrpUtil/MatrixSolvers.h>

--- a/rtc/ThermoEstimator/ThermoEstimator.h
+++ b/rtc/ThermoEstimator/ThermoEstimator.h
@@ -21,7 +21,7 @@
 #include <hrpModel/Link.h>
 #include <hrpModel/JointPath.h>
 
-#include "HRPDataTypes.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "MotorHeatParam.h"
 
 // Service implementation headers

--- a/rtc/ThermoLimiter/ThermoLimiterService_impl.h
+++ b/rtc/ThermoLimiter/ThermoLimiterService_impl.h
@@ -2,7 +2,7 @@
 #ifndef THERMOLIMITERSERVICESVC_IMPL_H
 #define THERMOLIMITERSERVICESVC_IMPL_H
 
-#include "ThermoLimiterService.hh"
+#include "hrpsys/idl/ThermoLimiterService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/TorqueController/MotorTorqueController.cpp
+++ b/rtc/TorqueController/MotorTorqueController.cpp
@@ -9,7 +9,7 @@
  */
 
 #include "MotorTorqueController.h"
-// #include "util/Hrpsys.h"
+// #include "hrpsys/util/Hrpsys.h"
 #include <iostream>
 #include <cmath>
 #include <boost/version.hpp>

--- a/rtc/TorqueController/TorqueController.cpp
+++ b/rtc/TorqueController/TorqueController.cpp
@@ -8,7 +8,7 @@
  */
 
 #include "TorqueController.h"
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>

--- a/rtc/TorqueController/TorqueControllerService_impl.h
+++ b/rtc/TorqueController/TorqueControllerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __NULL_SERVICE_H__
 #define __NULL_SERVICE_H__
 
-#include "TorqueControllerService.hh"
+#include "hrpsys/idl/TorqueControllerService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/UndistortImage/UndistortImage.h
+++ b/rtc/UndistortImage/UndistortImage.h
@@ -18,7 +18,7 @@
 #include <rtm/idl/BasicDataTypeSkel.h>
 #include <cv.h>
 #include <highgui.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/VideoCapture/CameraCaptureService_impl.h
+++ b/rtc/VideoCapture/CameraCaptureService_impl.h
@@ -2,7 +2,7 @@
 #ifndef __CAMERA_CAPTURE_SERVICE_H__
 #define __CAMERA_CAPTURE_SERVICE_H__
 
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 
 class VideoCapture;
 

--- a/rtc/VideoCapture/VideoCapture.cpp
+++ b/rtc/VideoCapture/VideoCapture.cpp
@@ -7,7 +7,7 @@
  * $Id$
  */
 
-#include "util/VectorConvert.h"
+#include "hrpsys/util/VectorConvert.h"
 #include "VideoCapture.h"
 
 // Module specification

--- a/rtc/VideoCapture/VideoCapture.h
+++ b/rtc/VideoCapture/VideoCapture.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "Img.hh"
+#include "hrpsys/idl/Img.hh"
 #include "camera.h"
 
 // Service implementation headers

--- a/rtc/Viewer/GLscene.cpp
+++ b/rtc/Viewer/GLscene.cpp
@@ -7,11 +7,11 @@
 #include <GL/glut.h>
 #endif
 #include <sys/time.h>
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
-#include "HRPDataTypes.hh"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "GLscene.h"
 
 using namespace OpenHRP;

--- a/rtc/Viewer/GLscene.h
+++ b/rtc/Viewer/GLscene.h
@@ -1,7 +1,7 @@
 #ifndef __GLSCENE_H__
 #define __GLSCENE_H__
 
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class LogManagerBase;
 

--- a/rtc/Viewer/RTCGLbody.cpp
+++ b/rtc/Viewer/RTCGLbody.cpp
@@ -3,8 +3,8 @@
 #if 0
 #include "IrrModel.h"
 #else
-#include "util/GLbody.h"
-#include "util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
 #endif
 
 RTCGLbody::RTCGLbody(GLbody *i_body, RTC::DataFlowComponentBase *comp) : 

--- a/rtc/Viewer/Viewer.cpp
+++ b/rtc/Viewer/Viewer.cpp
@@ -9,11 +9,11 @@
 
 #include <rtm/CorbaNaming.h>
 
-#include "util/Project.h"
+#include "hrpsys/util/Project.h"
 #include <hrpModel/ModelLoaderUtil.h>
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
 #include "GLscene.h"
 #include "RTCGLbody.h"
 #include "Viewer.h"

--- a/rtc/Viewer/Viewer.h
+++ b/rtc/Viewer/Viewer.h
@@ -16,9 +16,9 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "util/LogManager.h"
-#include "util/SDLUtil.h"
-#include "HRPDataTypes.hh"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/util/SDLUtil.h"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "GLscene.h"
 
 class RTCGLbody;

--- a/rtc/VirtualCamera/GLscene.cpp
+++ b/rtc/VirtualCamera/GLscene.cpp
@@ -7,11 +7,11 @@
 #include <GL/glut.h>
 #endif
 #include <sys/time.h>
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
-#include "HRPDataTypes.hh"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/idl/HRPDataTypes.hh"
 #include "GLscene.h"
 
 using namespace OpenHRP;

--- a/rtc/VirtualCamera/GLscene.h
+++ b/rtc/VirtualCamera/GLscene.h
@@ -1,7 +1,7 @@
 #ifndef __GLSCENE_H__
 #define __GLSCENE_H__
 
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class LogManagerBase;
 

--- a/rtc/VirtualCamera/RTCGLbody.cpp
+++ b/rtc/VirtualCamera/RTCGLbody.cpp
@@ -1,6 +1,6 @@
 #include <rtm/DataFlowComponentBase.h>
-#include "util/GLbody.h"
-#include "util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
 #include "RTCGLbody.h"
 
 RTCGLbody::RTCGLbody(GLbody *i_body, RTC::DataFlowComponentBase *comp) : 

--- a/rtc/VirtualCamera/VirtualCamera.cpp
+++ b/rtc/VirtualCamera/VirtualCamera.cpp
@@ -14,12 +14,12 @@
 #endif
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
-#include "util/Project.h"
-#include "util/VectorConvert.h"
-#include "util/GLcamera.h"
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
+#include "hrpsys/util/Project.h"
+#include "hrpsys/util/VectorConvert.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
 #include "VirtualCamera.h"
 #include "RTCGLbody.h"
 #include "GLscene.h"

--- a/rtc/VirtualCamera/VirtualCamera.h
+++ b/rtc/VirtualCamera/VirtualCamera.h
@@ -21,11 +21,11 @@
 #include <cv.h>
 #include <highgui.h>
 //
-#include "util/LogManager.h"
-#include "util/SDLUtil.h"
-#include "Img.hh"
-#include "HRPDataTypes.hh"
-#include "pointcloud.hh"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/util/SDLUtil.h"
+#include "hrpsys/idl/Img.hh"
+#include "hrpsys/idl/HRPDataTypes.hh"
+#include "hrpsys/idl/pointcloud.hh"
 #include "GLscene.h"
 class GLcamera;
 class RTCGLbody;

--- a/rtc/VirtualForceSensor/VirtualForceSensorService_impl.h
+++ b/rtc/VirtualForceSensor/VirtualForceSensorService_impl.h
@@ -2,7 +2,7 @@
 #ifndef IMPEDANCESERVICESVC_IMPL_H
 #define IMPEDANCESERVICESVC_IMPL_H
 
-#include "VirtualForceSensorService.hh"
+#include "hrpsys/idl/VirtualForceSensorService.hh"
 
 using namespace OpenHRP;
 

--- a/rtc/VoxelGridFilter/VoxelGridFilter.cpp
+++ b/rtc/VoxelGridFilter/VoxelGridFilter.cpp
@@ -11,7 +11,7 @@
 #include <pcl/point_types.h>
 #include <pcl/filters/voxel_grid.h>
 #include "VoxelGridFilter.h"
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Module specification
 // <rtc-template block="module_spec">

--- a/rtc/VoxelGridFilter/VoxelGridFilter.h
+++ b/rtc/VoxelGridFilter/VoxelGridFilter.h
@@ -16,7 +16,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
-#include "pointcloud.hh"
+#include "hrpsys/idl/pointcloud.hh"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">

--- a/rtc/WavPlayer/WavPlayerService_impl.cpp
+++ b/rtc/WavPlayer/WavPlayerService_impl.cpp
@@ -2,7 +2,7 @@
 #include <cstdlib>
 #include <cstdio>
 #include <pthread.h>
-#include "util/Hrpsys.h"
+#include "hrpsys/util/Hrpsys.h"
 #include "WavPlayerService_impl.h"
 
 

--- a/rtc/WavPlayer/WavPlayerService_impl.h
+++ b/rtc/WavPlayer/WavPlayerService_impl.h
@@ -2,7 +2,7 @@
 #ifndef WAVPLAYSERVICESVC_IMPL_H
 #define WAVPLAYSERVICESVC_IMPL_H
 
-#include "WavPlayerService.hh"
+#include "hrpsys/idl/WavPlayerService.hh"
 
 using namespace OpenHRP;
 

--- a/util/monitor/GLscene.cpp
+++ b/util/monitor/GLscene.cpp
@@ -7,10 +7,10 @@
 #include <GL/glut.h>
 #endif
 #include <sys/time.h>
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
 #include "TimedRobotState.h"
 #include "GLscene.h"
 

--- a/util/monitor/GLscene.h
+++ b/util/monitor/GLscene.h
@@ -2,7 +2,7 @@
 #define __GLSCENE_H__
 
 #include <hrpModel/ColdetLinkPair.h>
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class LogManagerBase;
 

--- a/util/monitor/Monitor.cpp
+++ b/util/monitor/Monitor.cpp
@@ -1,6 +1,6 @@
 #include <rtm/CorbaNaming.h>
 #include "Monitor.h"
-#include "util/OpenRTMUtil.h"
+#include "hrpsys/util/OpenRTMUtil.h"
 #include "GLscene.h"
 
 Monitor::Monitor(CORBA::ORB_var orb, const std::string &i_hostname,

--- a/util/monitor/Monitor.h
+++ b/util/monitor/Monitor.h
@@ -1,7 +1,7 @@
 #include <string>
-#include "util/ThreadedObject.h"
-#include "util/LogManager.h"
-#include "StateHolderService.hh"
+#include "hrpsys/util/ThreadedObject.h"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/idl/StateHolderService.hh"
 #include "TimedRobotState.h"
 #include "hrpModel/Body.h"
 

--- a/util/monitor/TimedRobotState.h
+++ b/util/monitor/TimedRobotState.h
@@ -1,8 +1,8 @@
 #ifndef __TIMED_ROBOT_STATE_H__
 #define __TIMED_ROBOT_STATE_H__
 
-#include "RobotHardwareService.hh"
-#include "StateHolderService.hh"
+#include "hrpsys/idl/RobotHardwareService.hh"
+#include "hrpsys/idl/StateHolderService.hh"
 
 typedef struct
 {

--- a/util/monitor/main.cpp
+++ b/util/monitor/main.cpp
@@ -8,11 +8,11 @@
 #else
 #include <GL/glut.h>
 #endif
-#include "util/ProjectUtil.h"
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
-#include "util/SDLUtil.h"
+#include "hrpsys/util/ProjectUtil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
+#include "hrpsys/util/SDLUtil.h"
 #include "GLscene.h"
 #include "Monitor.h"
 

--- a/util/simulator/GLscene.cpp
+++ b/util/simulator/GLscene.cpp
@@ -9,10 +9,10 @@
 #endif
 #include <boost/bind.hpp>
 #include <hrpModel/Sensor.h>
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
 #include "SceneState.h"
 #include "GLscene.h"
 

--- a/util/simulator/GLscene.h
+++ b/util/simulator/GLscene.h
@@ -1,7 +1,7 @@
 #ifndef __GLSCENE_H__
 #define __GLSCENE_H__
 
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class GLscene : public GLsceneBase
 {

--- a/util/simulator/PyBody.h
+++ b/util/simulator/PyBody.h
@@ -1,6 +1,6 @@
 #include <boost/python.hpp>
-#include "util/BodyRTC.h"
-#include "util/GLbody.h"
+#include "hrpsys/util/BodyRTC.h"
+#include "hrpsys/util/GLbody.h"
 
 class PyLink;
 class PySimulator;

--- a/util/simulator/PyLink.cpp
+++ b/util/simulator/PyLink.cpp
@@ -2,7 +2,7 @@
 #include <rtm/Manager.h>
 #include <rtm/CorbaNaming.h>
 #include <hrpModel/ModelLoaderUtil.h>
-#include <util/GLutil.h>
+#include "hrpsys/util/GLutil.h"
 #include "PyLink.h"
 #include "PyBody.h"
 #include "PyShape.h"

--- a/util/simulator/PyLink.h
+++ b/util/simulator/PyLink.h
@@ -2,7 +2,7 @@
 #define __PYLINK_H__
 
 #include <boost/python.hpp>
-#include "util/GLlink.h"
+#include "hrpsys/util/GLlink.h"
 
 class PyShape;
 

--- a/util/simulator/PyShape.h
+++ b/util/simulator/PyShape.h
@@ -2,7 +2,7 @@
 #define __PYSHAPE_H__
 
 #include <boost/python.hpp>
-#include "util/GLshape.h"
+#include "hrpsys/util/GLshape.h"
 
 class PyShape : public GLshape
 {

--- a/util/simulator/PySimulator.cpp
+++ b/util/simulator/PySimulator.cpp
@@ -13,12 +13,12 @@
 #include <GL/glut.h>
 #endif
 #include <SDL_thread.h>
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
-#include "util/Project.h"
-#include "util/OpenRTMUtil.h"
-#include "util/BVutil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
+#include "hrpsys/util/Project.h"
+#include "hrpsys/util/OpenRTMUtil.h"
+#include "hrpsys/util/BVutil.h"
 #include "PyBody.h"
 #include "PyLink.h"
 #include "PyShape.h"

--- a/util/simulator/PySimulator.h
+++ b/util/simulator/PySimulator.h
@@ -1,7 +1,7 @@
 #ifndef __PYSIMULATOR_H__
 #define __PYSIMULATOR_H__
 
-#include "util/SDLUtil.h"
+#include "hrpsys/util/SDLUtil.h"
 #include "Simulator.h"
 #include "GLscene.h"
 

--- a/util/simulator/Simulator.cpp
+++ b/util/simulator/Simulator.cpp
@@ -1,5 +1,5 @@
 #include "Simulator.h"
-#include "util/BodyRTC.h"
+#include "hrpsys/util/BodyRTC.h"
 
 Simulator::Simulator(LogManager<SceneState> *i_log) 
   : log(i_log), adjustTime(false)

--- a/util/simulator/Simulator.h
+++ b/util/simulator/Simulator.h
@@ -2,10 +2,10 @@
 #include <hrpModel/World.h>
 #include <hrpModel/ConstraintForceSolver.h>
 #include <hrpUtil/TimeMeasure.h>
-#include "util/Project.h"
-#include "util/ThreadedObject.h"
-#include "util/LogManager.h"
-#include "util/ProjectUtil.h"
+#include "hrpsys/util/Project.h"
+#include "hrpsys/util/ThreadedObject.h"
+#include "hrpsys/util/LogManager.h"
+#include "hrpsys/util/ProjectUtil.h"
 #include "SceneState.h"
 
 class BodyRTC;

--- a/util/simulator/main.cpp
+++ b/util/simulator/main.cpp
@@ -10,13 +10,13 @@
 #include <GL/glut.h>
 #endif
 #include <SDL_thread.h>
-#include "util/GLbodyRTC.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
-#include "util/Project.h"
-#include "util/OpenRTMUtil.h"
-#include "util/SDLUtil.h"
-#include "util/BVutil.h"
+#include "hrpsys/util/GLbodyRTC.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
+#include "hrpsys/util/Project.h"
+#include "hrpsys/util/OpenRTMUtil.h"
+#include "hrpsys/util/SDLUtil.h"
+#include "hrpsys/util/BVutil.h"
 #include "Simulator.h"
 #include "GLscene.h"
 

--- a/util/viewer/GLscene.cpp
+++ b/util/viewer/GLscene.cpp
@@ -7,10 +7,10 @@
 #else
 #include <GL/gl.h>
 #endif
-#include "util/GLcamera.h"
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/LogManager.h"
+#include "hrpsys/util/GLcamera.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/LogManager.h"
 #include "GLscene.h"
 
 using namespace OpenHRP;

--- a/util/viewer/GLscene.h
+++ b/util/viewer/GLscene.h
@@ -3,7 +3,7 @@
 
 #include <SDL/SDL_thread.h>
 #include <hrpCorba/ModelLoader.hh>
-#include "util/GLsceneBase.h"
+#include "hrpsys/util/GLsceneBase.h"
 
 class LogManagerBase;
 

--- a/util/viewer/OnlineViewer_impl.cpp
+++ b/util/viewer/OnlineViewer_impl.cpp
@@ -1,9 +1,9 @@
 #include <cstdio>
 #include <iostream>
 #include <hrpModel/ModelLoaderUtil.h>
-#include "util/GLbody.h"
-#include "util/GLlink.h"
-#include "util/GLutil.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLutil.h"
 #include "OnlineViewer_impl.h"
 #include "GLscene.h"
 

--- a/util/viewer/OnlineViewer_impl.h
+++ b/util/viewer/OnlineViewer_impl.h
@@ -1,7 +1,7 @@
 #include <hrpCorba/OnlineViewer.hh>
 #include <map>
 #include <string>
-#include "util/LogManager.h"
+#include "hrpsys/util/LogManager.h"
 
 class GLscene;
 class GLbody;

--- a/util/viewer/main.cpp
+++ b/util/viewer/main.cpp
@@ -7,10 +7,10 @@
 #endif
 #include <SDL/SDL_timer.h>
 #include <hrpModel/ModelLoaderUtil.h>
-#include "util/GLlink.h"
-#include "util/GLbody.h"
-#include "util/GLutil.h"
-#include "util/SDLUtil.h"
+#include "hrpsys/util/GLlink.h"
+#include "hrpsys/util/GLbody.h"
+#include "hrpsys/util/GLutil.h"
+#include "hrpsys/util/SDLUtil.h"
 #include "OnlineViewer_impl.h"
 #include "GLscene.h"
 


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/803
の変更にともなって、
ソースファイルでのinclude の表記とpkg-configを使った場合のincludeの表記が
同じになるように修正しました。

 (io/iob.h -> hrpsys/io/iob.h,
  xxx.hh -> hrpsys/idl/xxx.hh,
  util/xxx.h -> hrpsys/util/xxx.h)