### PR TITLE
Fix for oldubuntu compile

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -391,7 +391,10 @@ def findRTCmanager(hostname=None, rnc=None):
             mgr = None
         return mgr
 
-    import CORBA
+    try:
+        import CORBA
+    except:
+        print('import CORBA failed in findRTCmanager and neglect it for old python environment.')
     # fqdn
     mgr = None
     hostnames = [hostname, hostname.split(".")[0],

--- a/rtc/ServoController/CMakeLists.txt
+++ b/rtc/ServoController/CMakeLists.txt
@@ -1,5 +1,20 @@
 set(comp_sources ServoController.cpp ServoControllerService_impl.cpp)
 set(libs hrpModel-3.1 hrpCollision-3.1 hrpUtil-3.1 hrpsysBaseStub)
+if (CMAKE_COMPILER_IS_GNUCC)
+    execute_process(COMMAND ${CMAKE_C_COMPILER} -dumpversion
+                    OUTPUT_VARIABLE GCC_VERSION)
+    string(REGEX MATCHALL "[0-9]+" GCC_VERSION_COMPONENTS
+    ${GCC_VERSION})
+    list(GET GCC_VERSION_COMPONENTS 0 GCC_MAJOR)
+    list(GET GCC_VERSION_COMPONENTS 1 GCC_MINOR)
+    if (GCC_VERSION VERSION_LESS 4.3)
+       message(STATUS "GCC version (${GCC_MAJOR}.${GCC_MINOR}) must be at least 4.3 for binary format in ServoSerial.h!")
+#    else()
+#       message(STATUS "HOGE GCC version must be at least 4.3 for binary format in ServoSerial.h! ${GCC_MAJOR} ${GCC_MINOR}")
+    endif()
+    add_definitions(-DDONOT_USE_BINARY_FORMAT)
+endif()
+
 add_library(ServoController SHARED ${comp_sources})
 target_link_libraries(ServoController ${libs})
 set_target_properties(ServoController PROPERTIES PREFIX "")

--- a/rtc/ServoController/ServoSerial.h
+++ b/rtc/ServoController/ServoSerial.h
@@ -290,22 +290,38 @@ public:
       ret = -1;
     }
 
+#ifdef DONOT_USE_BINARY_FORMAT
+    if ( flags & 0x0002 ) {
+#else
     if ( flags & 0b00000010 ) {
+#endif
       fprintf(stderr, "[ServoSerial] Failed to receive packet from servo(id:%d) Fail to process received packet\n", id);
       ret = -1;
     }
 
+#ifdef DONOT_USE_BINARY_FORMAT
+    if ( flags & 0x0008 ) {
+#else
     if ( flags & 0b00001000 ) {
+#endif
       fprintf(stderr, "[ServoSerial] Failed to receive packet from servo(id:%d) fail to write Flash ROM\n", id);
       ret = -1;
     }
 
+#ifdef DONOT_USE_BINARY_FORMAT
+    if ( flags & 0x0020 ) {
+#else
     if ( flags & 0b00100000 ) {
+#endif
       fprintf(stderr, "[ServoSerial] Failed to receive packet from servo(id:%d) temperature limit warning\n", id);
       ret = -1;
     }
 
+#ifdef DONOT_USE_BINARY_FORMAT
+    if ( flags & 0x0080 ) {
+#else
     if ( flags & 0b10000000 ) {
+#endif
       fprintf(stderr, "[ServoSerial] Failed to receive packet from servo(id:%d) Temperature limit error\n", id);
       ret = -1;
     }


### PR DESCRIPTION
古いロボット環境でビルドするためのdiffのうちの一部をコミットします．
1. ServoSerialでbinary formatをつかっているところを，binary formatが採用されたgcc4.3以降かどうかのチェックを加えました．(http://stackoverflow.com/questions/8217564/error-invalid-suffix-b11111111111111111111111111111111-on-integer-constant)．ちなみに，古いロボット環境はgcc 4.2.4でした
2. rtm.pyのfindRTCManeger関数の中でimport CORBAしてる箇所が，古いpython 2.5.2の環境でエラーとなりますが，逆にこれがなくても動作するのでそこもチェックするようにしました．

よろしくお願いいたします．
