### PR TITLE
Separate transition interpolator

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -228,6 +228,7 @@ module OpenHRP
       /// Transition time [s] for adjust foot step
       double adjust_footstep_transition_time;
       StrSequence leg_names;
+      StrSequence limbs;
       /// Flag for inverse kinematics (IK). If true, IK has failed before.
       boolean has_ik_failed;
       /// IK position threshold [m]

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -230,12 +230,11 @@ class AutoBalancer
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
 
-  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, leg_names_interpolator_ratio, ik_interpolator_ratio;
+  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, ik_interpolator_ratio;
   std::vector<double> limbs_interpolator_ratio_vector;
   interpolator *zmp_offset_interpolator;
   interpolator *transition_interpolator, *ik_interpolator;
   interpolator *adjust_footstep_interpolator;
-  interpolator *leg_names_interpolator;
   std::vector< boost::shared_ptr<interpolator> > limbs_interpolator_vector;
   hrp::Vector3 input_zmp, input_basePos;
   hrp::Matrix33 input_baseRot;
@@ -249,6 +248,7 @@ class AutoBalancer
   bool is_legged_robot, is_stop_mode, has_ik_failed, is_hand_fix_mode;
   int loop, ik_error_debug_print_freq;
   bool graspless_manip_mode;
+  bool ik_initialize_flag;
   std::string graspless_manip_arm;
   hrp::Vector3 graspless_manip_p_gain;
   rats::coordinates graspless_manip_reference_trans_coords;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -221,7 +221,8 @@ class AutoBalancer
   std::map<std::string, size_t> contact_states_index_map;
   std::map<std::string, hrp::VirtualForceSensorParam> m_vfs;
   std::vector<std::string> sensor_names, leg_names;
-  hrp::dvector qorg, qrefv;
+  std::vector<bool> deactivate_flag_list;
+  hrp::dvector qorg, qrefv, q_prev_deactivate;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R;
   rats::coordinates fix_leg_coords;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -230,11 +230,13 @@ class AutoBalancer
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
 
-  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, leg_names_interpolator_ratio;
+  double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, leg_names_interpolator_ratio, ik_interpolator_ratio;
+  std::vector<double> limbs_interpolator_ratio_vector;
   interpolator *zmp_offset_interpolator;
-  interpolator *transition_interpolator;
+  interpolator *transition_interpolator, *ik_interpolator;
   interpolator *adjust_footstep_interpolator;
   interpolator *leg_names_interpolator;
+  std::vector< boost::shared_ptr<interpolator> > limbs_interpolator_vector;
   hrp::Vector3 input_zmp, input_basePos;
   hrp::Matrix33 input_baseRot;
 


### PR DESCRIPTION
limbsとleg_namesをabcが入っている最中でも変更できるようにしました．

@snozawa さん
この過程で transition_interpolatorを分けて，leg_names_interpolatorを消したのですが，ご確認していただけますでしょうか．

PR以前はtransition_interpolatorは

1. ref_basePos を補間する
1. rel_ref_zmp を補間する
1. angle-vector を補間する
1. ikの速度項をなます

という役割を担っていたと思うのですが，

| ref_basePosを補間する | rel_ref_zmpを補間する | angle-vectorを補間する | ikの速度項をなます |
| --- | --- | --- | --- |
| transition_interpolator | transition_interpolator | limbs_interpolator_vector | ik_interpolator |

という補間器に分けて，

| | transition_interpolator | limbs_interpolator_vector | ik_interpolator |
| --- | --- | --- | --- |
| startABCparam | x | x | x |
| stopABCparam | x | x | | 
| leg_namesを変えたとき | | | x |
| limbsを変えたとき | | x | x |

としました．

@YutaKojio さん，https://github.com/jsk-ros-pkg/jsk_control/issues/469 は（根本的には治っていませんが，二足歩行モードのみで使っている分には）このPRで発生しなくなったかと思います．