### PR TITLE
Devide double support (static) ratio into before and after

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -157,13 +157,13 @@ module OpenHRP
       double default_step_time;
       /// Step height [m]
       double default_step_height;
-      /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
+      /// Ratio of first double support period. Ratio is included in (0, 1). First double support period time is default_double_support_ratio_before*default_step_time.
       double default_double_support_ratio_before;
-      /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
+      /// Ratio of last double support period. Ratio is included in (0, 1). Last double support period time is default_double_support_ratio_after*default_step_time.
       double default_double_support_ratio_after;
-      /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
+      /// Ratio of first double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio_before >= default_double_support_static_ratio_before..
       double default_double_support_static_ratio_before;
-      /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
+      /// Ratio of last double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio_after >= default_double_support_static_ratio_after..
       double default_double_support_static_ratio_after;
       /// Ratio of double support period before swing. Ratio is included in (0, 1).
       double default_double_support_ratio_swing_before;

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -160,7 +160,9 @@ module OpenHRP
       /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
       double default_double_support_ratio;
       /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
-      double default_double_support_static_ratio;
+      double default_double_support_static_ratio_before;
+      /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
+      double default_double_support_static_ratio_after;
       /// Ratio of double support period before swing. Ratio is included in (0, 1).
       double default_double_support_ratio_swing_before;
       /// Ratio of double support period after swing. Ratio is included in (0, 1).

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -157,10 +157,14 @@ module OpenHRP
       double default_step_time;
       /// Step height [m]
       double default_step_height;
+      /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
+      double default_double_support_ratio;
       /// Ratio of first double support period. Ratio is included in (0, 1). First double support period time is default_double_support_ratio_before*default_step_time.
       double default_double_support_ratio_before;
       /// Ratio of last double support period. Ratio is included in (0, 1). Last double support period time is default_double_support_ratio_after*default_step_time.
       double default_double_support_ratio_after;
+      /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
+      double default_double_support_static_ratio;
       /// Ratio of first double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio_before >= default_double_support_static_ratio_before..
       double default_double_support_static_ratio_before;
       /// Ratio of last double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio_after >= default_double_support_static_ratio_after..

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -158,7 +158,9 @@ module OpenHRP
       /// Step height [m]
       double default_step_height;
       /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
-      double default_double_support_ratio;
+      double default_double_support_ratio_before;
+      /// Ratio of double support period. Ratio is included in (0, 1). Double support period time is default_double_support_ratio*default_step_time.
+      double default_double_support_ratio_after;
       /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..
       double default_double_support_static_ratio_before;
       /// Ratio of double support static period in which reference ZMP does not move. Ratio is included in (0, 1). default_double_support_ratio >= default_double_support_static_ratio..

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1321,14 +1321,20 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_leg_default_translate_pos(off);
   gg->set_default_step_time(i_param.default_step_time);
   gg->set_default_step_height(i_param.default_step_height);
-  gg->set_default_double_support_ratio_before(i_param.default_double_support_ratio_before);
-  gg->set_default_double_support_ratio_after(i_param.default_double_support_ratio_after);
-  gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio_before);
-  gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio_after);
+  gg->set_default_double_support_ratio_before(i_param.default_double_support_ratio/2.0);
+  gg->set_default_double_support_ratio_after(i_param.default_double_support_ratio/2.0);
+  gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio/2.0);
+  gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio/2.0);
+  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio/2.0);
+  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio/2.0);
+  // gg->set_default_double_support_ratio_before(i_param.default_double_support_ratio_before);
+  // gg->set_default_double_support_ratio_after(i_param.default_double_support_ratio_after);
+  // gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio_before);
+  // gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio_after);
   // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_before);
   // gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_after);
-  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
-  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_swing_after);
+  // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
+  // gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_swing_after);
   if (i_param.default_orbit_type == OpenHRP::AutoBalancerService::SHUFFLING) {
     gg->set_default_orbit_type(SHUFFLING);
   } else if (i_param.default_orbit_type == OpenHRP::AutoBalancerService::CYCLOID) {
@@ -1388,6 +1394,8 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   i_param.default_double_support_static_ratio_after = gg->get_default_double_support_static_ratio_after();
   i_param.default_double_support_ratio_swing_before = gg->get_default_double_support_ratio_swing_before();
   i_param.default_double_support_ratio_swing_after = gg->get_default_double_support_ratio_swing_after();
+  i_param.default_double_support_ratio = i_param.default_double_support_ratio_before + i_param.default_double_support_ratio_after;
+  i_param.default_double_support_static_ratio = i_param.default_double_support_static_ratio_before + i_param.default_double_support_static_ratio_after;
   if (gg->get_default_orbit_type() == SHUFFLING) {
     i_param.default_orbit_type = OpenHRP::AutoBalancerService::SHUFFLING;
   } else if (gg->get_default_orbit_type() == CYCLOID) {

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1321,11 +1321,12 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_leg_default_translate_pos(off);
   gg->set_default_step_time(i_param.default_step_time);
   gg->set_default_step_height(i_param.default_step_height);
-  gg->set_default_double_support_ratio(i_param.default_double_support_ratio);
+  gg->set_default_double_support_ratio_before(i_param.default_double_support_ratio_before);
+  gg->set_default_double_support_ratio_after(i_param.default_double_support_ratio_after);
   gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio_before);
   gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio_after);
-  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio/2);
-  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio/2);
+  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_before);
+  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_after);
   // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
   // gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_swing_after);
   if (i_param.default_orbit_type == OpenHRP::AutoBalancerService::SHUFFLING) {
@@ -1381,7 +1382,8 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   }
   i_param.default_step_time = gg->get_default_step_time();
   i_param.default_step_height = gg->get_default_step_height();
-  i_param.default_double_support_ratio = gg->get_default_double_support_ratio();
+  i_param.default_double_support_ratio_before = gg->get_default_double_support_ratio_before();
+  i_param.default_double_support_ratio_after = gg->get_default_double_support_ratio_after();
   i_param.default_double_support_static_ratio_before = gg->get_default_double_support_static_ratio_before();
   i_param.default_double_support_static_ratio_after = gg->get_default_double_support_static_ratio_after();
   i_param.default_double_support_ratio_swing_before = gg->get_default_double_support_ratio_swing_before();

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1325,10 +1325,10 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_default_double_support_ratio_after(i_param.default_double_support_ratio_after);
   gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio_before);
   gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio_after);
-  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_before);
-  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_after);
-  // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
-  // gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_swing_after);
+  // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_before);
+  // gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_after);
+  gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
+  gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio_swing_after);
   if (i_param.default_orbit_type == OpenHRP::AutoBalancerService::SHUFFLING) {
     gg->set_default_orbit_type(SHUFFLING);
   } else if (i_param.default_orbit_type == OpenHRP::AutoBalancerService::CYCLOID) {

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1322,7 +1322,8 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_default_step_time(i_param.default_step_time);
   gg->set_default_step_height(i_param.default_step_height);
   gg->set_default_double_support_ratio(i_param.default_double_support_ratio);
-  gg->set_default_double_support_static_ratio(i_param.default_double_support_static_ratio);
+  gg->set_default_double_support_static_ratio_before(i_param.default_double_support_static_ratio_before);
+  gg->set_default_double_support_static_ratio_after(i_param.default_double_support_static_ratio_after);
   gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio/2);
   gg->set_default_double_support_ratio_swing_after(i_param.default_double_support_ratio/2);
   // gg->set_default_double_support_ratio_swing_before(i_param.default_double_support_ratio_swing_before);
@@ -1381,7 +1382,8 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   i_param.default_step_time = gg->get_default_step_time();
   i_param.default_step_height = gg->get_default_step_height();
   i_param.default_double_support_ratio = gg->get_default_double_support_ratio();
-  i_param.default_double_support_static_ratio = gg->get_default_double_support_static_ratio();
+  i_param.default_double_support_static_ratio_before = gg->get_default_double_support_static_ratio_before();
+  i_param.default_double_support_static_ratio_after = gg->get_default_double_support_static_ratio_after();
   i_param.default_double_support_ratio_swing_before = gg->get_default_double_support_ratio_swing_before();
   i_param.default_double_support_ratio_swing_after = gg->get_default_double_support_ratio_swing_after();
   if (gg->get_default_orbit_type() == SHUFFLING) {

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -109,10 +109,11 @@ namespace rats
     //std::cerr << "single " << fns[fs_index-1].l_r << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
+  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
   {
     size_t cnt = one_step_count - refzmp_count; // current counter (0 -> one_step_count)
-    size_t double_support_count_half = (0.5 * default_double_support_ratio) * one_step_count;
+    size_t double_support_count_half_before = default_double_support_ratio_before * one_step_count;
+    size_t double_support_count_half_after = default_double_support_ratio_after * one_step_count;
     size_t double_support_static_count_half_before = default_double_support_static_ratio_before * one_step_count;
     size_t double_support_static_count_half_after = default_double_support_static_ratio_after * one_step_count;
     for (size_t i = 0; i < swing_leg_types_list[refzmp_index].size(); i++) {
@@ -139,8 +140,8 @@ namespace rats
             swing_foot_zmp_offsets.front()(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
         }
         zmp_diff = swing_foot_zmp_offsets.front()(0)-default_zmp_offsets[swing_leg_types_list[refzmp_index].front()](0);
-        if ((is_second_phase() && ( cnt < double_support_count_half )) ||
-            (is_second_last_phase() && ( cnt > one_step_count - double_support_count_half ))) {
+        if ((is_second_phase() && ( cnt < double_support_count_half_before )) ||
+            (is_second_last_phase() && ( cnt > one_step_count - double_support_count_half_after ))) {
             // "* 0.5" is for double supprot period
             zmp_diff *= 0.5;
         }
@@ -159,15 +160,15 @@ namespace rats
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = (is_second_last_phase()?1.0:0.5);
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
-    } else if ( cnt < double_support_count_half ) { // Start double support period
+    } else if ( cnt < double_support_count_half_before ) { // Start double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axises_list[refzmp_index-1].front();
-      double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half_before)) * (double_support_count_half-cnt);
+      double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half_before-double_support_static_count_half_before)) * (double_support_count_half_before-cnt);
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
-    } else if ( cnt > one_step_count - double_support_count_half ) { // End double support period
+    } else if ( cnt > one_step_count - double_support_count_half_after ) { // End double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axises_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
-      double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half_after)) * (cnt - 1 - (one_step_count - double_support_count_half));
+      double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half_after-double_support_static_count_half_after)) * (cnt - 1 - (one_step_count - double_support_count_half_after));
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else {
       ret = refzmp_cur_list[refzmp_index];
@@ -511,7 +512,7 @@ namespace rats
   {
     hrp::Vector3 rzmp;
     std::vector<hrp::Vector3> sfzos;
-    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
+    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
     if (!refzmp_exist_p) {
       finalize_count++;
       rzmp = prev_que_rzmp;
@@ -779,7 +780,7 @@ namespace rats
     bool not_solved = true;
     while (not_solved) {
       std::vector<hrp::Vector3> sfzos;
-      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
+      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
       not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, refzmp_exist_p);
       rg.update_refzmp(footstep_nodes_list);
     }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -109,11 +109,12 @@ namespace rats
     //std::cerr << "single " << fns[fs_index-1].l_r << " [" << refzmp_cur_list.back()(0) << " " << refzmp_cur_list.back()(1) << " " << refzmp_cur_list.back()(2) << "]" << std::endl;
   };
 
-  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const
+  void refzmp_generator::calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
   {
     size_t cnt = one_step_count - refzmp_count; // current counter (0 -> one_step_count)
     size_t double_support_count_half = (0.5 * default_double_support_ratio) * one_step_count;
-    size_t double_support_static_count_half = (0.5 * default_double_support_static_ratio) * one_step_count;
+    size_t double_support_static_count_half_before = default_double_support_static_ratio_before * one_step_count;
+    size_t double_support_static_count_half_after = default_double_support_static_ratio_after * one_step_count;
     for (size_t i = 0; i < swing_leg_types_list[refzmp_index].size(); i++) {
         swing_foot_zmp_offsets.push_back(default_zmp_offsets[swing_leg_types_list[refzmp_index].at(i)]);
     }
@@ -148,12 +149,12 @@ namespace rats
     // Calculate total reference ZMP
     if (is_start_double_support_phase() || is_end_double_support_phase()) {
       ret = refzmp_cur_list[refzmp_index];
-    } else if ( cnt < double_support_static_count_half ) { // Start double support static period
+    } else if ( cnt < double_support_static_count_half_before ) { // Start double support static period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axises_list[refzmp_index-1].front();
-      double ratio = (is_second_phase()?1.0:0.5); 
+      double ratio = (is_second_phase()?1.0:0.5);
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
-    } else if ( cnt > one_step_count - double_support_static_count_half ) { // End double support static period
+    } else if ( cnt > one_step_count - double_support_static_count_half_after ) { // End double support static period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axises_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
       double ratio = (is_second_last_phase()?1.0:0.5);
@@ -161,12 +162,12 @@ namespace rats
     } else if ( cnt < double_support_count_half ) { // Start double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index];
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index-1] + zmp_diff * foot_x_axises_list[refzmp_index-1].front();
-      double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (double_support_count_half-cnt);
+      double ratio = ((is_second_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half_before)) * (double_support_count_half-cnt);
       ret = (1 - ratio) * current_support_zmp + ratio * prev_support_zmp;
     } else if ( cnt > one_step_count - double_support_count_half ) { // End double support period
       hrp::Vector3 current_support_zmp = refzmp_cur_list[refzmp_index+1] + zmp_diff * foot_x_axises_list[refzmp_index+1].front();
       hrp::Vector3 prev_support_zmp = refzmp_cur_list[refzmp_index];
-      double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half)) * (cnt - 1 - (one_step_count - double_support_count_half));
+      double ratio = ((is_second_last_phase()?1.0:0.5) / (double_support_count_half-double_support_static_count_half_after)) * (cnt - 1 - (one_step_count - double_support_count_half));
       ret = (1 - ratio) * prev_support_zmp + ratio * current_support_zmp;
     } else {
       ret = refzmp_cur_list[refzmp_index];
@@ -510,7 +511,7 @@ namespace rats
   {
     hrp::Vector3 rzmp;
     std::vector<hrp::Vector3> sfzos;
-    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
+    bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
     if (!refzmp_exist_p) {
       finalize_count++;
       rzmp = prev_que_rzmp;
@@ -778,7 +779,7 @@ namespace rats
     bool not_solved = true;
     while (not_solved) {
       std::vector<hrp::Vector3> sfzos;
-      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio);
+      bool refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
       not_solved = !preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, refzmp_exist_p);
       rg.update_refzmp(footstep_nodes_list);
     }

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -216,7 +216,7 @@ namespace rats
       toe_heel_phase_counter* thp_ptr;
       bool use_toe_heel_transition;
       boost::shared_ptr<interpolator> zmp_weight_interpolator;
-      void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after);
+      void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after);
       const bool is_start_double_support_phase () const { return refzmp_index == 0; };
       const bool is_second_phase () const { return refzmp_index == 1; };
       const bool is_second_last_phase () const { return refzmp_index == refzmp_cur_list.size()-2; };
@@ -285,9 +285,9 @@ namespace rats
           }
       };
       // getter
-      bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
+      bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
       {
-        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offsets, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
+        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offsets, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
         return refzmp_cur_list.size() > refzmp_index;
       };
       const hrp::Vector3& get_refzmp_cur () { return refzmp_cur_list.front(); };
@@ -829,7 +829,7 @@ namespace rats
     double dt; /* control loop [s] */
     std::vector<std::string> all_limbs;
     double default_step_time;
-    double default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after;
+    double default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after;
     double default_double_support_ratio_swing_before; /*first double support time for leg coords generator */
     double default_double_support_ratio_swing_after; /*last double support time for leg coords generator */
     double gravitational_acceleration;
@@ -876,7 +876,7 @@ namespace rats
         : footstep_nodes_list(), overwrite_footstep_nodes_list(), thp(), rg(&thp, _dt), lcg(_dt, &thp), all_limbs(_all_limbs),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
-        dt(_dt), default_step_time(1.0), default_double_support_ratio(0.2), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
+        dt(_dt), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
         use_inside_step_limitation(true),
@@ -947,7 +947,8 @@ namespace rats
     };
     /* parameter setting */
     void set_default_step_time (const double _default_step_time) { default_step_time = _default_step_time; };
-    void set_default_double_support_ratio (const double _default_double_support_ratio) { default_double_support_ratio = _default_double_support_ratio; };
+    void set_default_double_support_ratio_before (const double _default_double_support_ratio_before) { default_double_support_ratio_before = _default_double_support_ratio_before; };
+    void set_default_double_support_ratio_after (const double _default_double_support_ratio_after) { default_double_support_ratio_after = _default_double_support_ratio_after; };
     void set_default_double_support_static_ratio_before (const double _default_double_support_static_ratio_before) { default_double_support_static_ratio_before = _default_double_support_static_ratio_before; };
     void set_default_double_support_static_ratio_after (const double _default_double_support_static_ratio_after) { default_double_support_static_ratio_after = _default_double_support_static_ratio_after; };
     void set_default_double_support_ratio_swing_before (const double _default_double_support_ratio_swing_before) { default_double_support_ratio_swing_before = _default_double_support_ratio_swing_before; };
@@ -1107,7 +1108,8 @@ namespace rats
     std::vector<leg_type> get_current_support_states() const { return lcg.get_current_support_states();};
     double get_default_step_time () const { return default_step_time; };
     double get_default_step_height () const { return lcg.get_default_step_height(); };
-    double get_default_double_support_ratio () const { return default_double_support_ratio; };
+    double get_default_double_support_ratio_before () const { return default_double_support_ratio_before; };
+    double get_default_double_support_ratio_after () const { return default_double_support_ratio_after; };
     double get_default_double_support_static_ratio_before () const { return default_double_support_static_ratio_before; };
     double get_default_double_support_static_ratio_after () const { return default_double_support_static_ratio_after; };
     double get_default_double_support_ratio_swing_before () const {return default_double_support_ratio_swing_before; };
@@ -1153,7 +1155,7 @@ namespace rats
         std::cerr << std::endl;
         std::cerr << "[" << print_str << "]   default_step_time = " << get_default_step_time() << "[s]" << std::endl;
         std::cerr << "[" << print_str << "]   default_step_height = " << get_default_step_height() << "[m]" << std::endl;
-        std::cerr << "[" << print_str << "]   default_double_support_ratio = " << get_default_double_support_ratio() << ", default_double_support_static_ratio_before = " << get_default_double_support_static_ratio_before() << ", default_double_support_static_ratio_after = " << get_default_double_support_static_ratio_after() << ", default_double_support_static_ratio_swing_before = " << get_default_double_support_ratio_swing_before() << ", default_double_support_static_ratio_swing_after = " << get_default_double_support_ratio_swing_after() << std::endl;
+        std::cerr << "[" << print_str << "]   default_double_support_ratio_before = " << get_default_double_support_ratio_before() << ", default_double_support_ratio_before = " << get_default_double_support_ratio_after() << ", default_double_support_static_ratio_before = " << get_default_double_support_static_ratio_before() << ", default_double_support_static_ratio_after = " << get_default_double_support_static_ratio_after() << ", default_double_support_static_ratio_swing_before = " << get_default_double_support_ratio_swing_before() << ", default_double_support_static_ratio_swing_after = " << get_default_double_support_ratio_swing_after() << std::endl;
         std::cerr << "[" << print_str << "]   default_orbit_type = ";
         if (get_default_orbit_type() == SHUFFLING) {
             std::cerr << "SHUFFLING" << std::endl;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -216,7 +216,7 @@ namespace rats
       toe_heel_phase_counter* thp_ptr;
       bool use_toe_heel_transition;
       boost::shared_ptr<interpolator> zmp_weight_interpolator;
-      void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const;
+      void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after);
       const bool is_start_double_support_phase () const { return refzmp_index == 0; };
       const bool is_second_phase () const { return refzmp_index == 1; };
       const bool is_second_last_phase () const { return refzmp_index == refzmp_cur_list.size()-2; };
@@ -285,9 +285,9 @@ namespace rats
           }
       };
       // getter
-      bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio) const
+      bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
       {
-        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offsets, default_double_support_ratio, default_double_support_static_ratio);
+        if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offsets, default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
         return refzmp_cur_list.size() > refzmp_index;
       };
       const hrp::Vector3& get_refzmp_cur () { return refzmp_cur_list.front(); };
@@ -829,7 +829,7 @@ namespace rats
     double dt; /* control loop [s] */
     std::vector<std::string> all_limbs;
     double default_step_time;
-    double default_double_support_ratio, default_double_support_static_ratio;
+    double default_double_support_ratio, default_double_support_static_ratio_before, default_double_support_static_ratio_after;
     double default_double_support_ratio_swing_before; /*first double support time for leg coords generator */
     double default_double_support_ratio_swing_after; /*last double support time for leg coords generator */
     double gravitational_acceleration;
@@ -876,7 +876,7 @@ namespace rats
         : footstep_nodes_list(), overwrite_footstep_nodes_list(), thp(), rg(&thp, _dt), lcg(_dt, &thp), all_limbs(_all_limbs),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
-        dt(_dt), default_step_time(1.0), default_double_support_ratio(0.2), default_double_support_static_ratio(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
+        dt(_dt), default_step_time(1.0), default_double_support_ratio(0.2), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
         use_inside_step_limitation(true),
@@ -948,7 +948,8 @@ namespace rats
     /* parameter setting */
     void set_default_step_time (const double _default_step_time) { default_step_time = _default_step_time; };
     void set_default_double_support_ratio (const double _default_double_support_ratio) { default_double_support_ratio = _default_double_support_ratio; };
-    void set_default_double_support_static_ratio (const double _default_double_support_static_ratio) { default_double_support_static_ratio = _default_double_support_static_ratio; };
+    void set_default_double_support_static_ratio_before (const double _default_double_support_static_ratio_before) { default_double_support_static_ratio_before = _default_double_support_static_ratio_before; };
+    void set_default_double_support_static_ratio_after (const double _default_double_support_static_ratio_after) { default_double_support_static_ratio_after = _default_double_support_static_ratio_after; };
     void set_default_double_support_ratio_swing_before (const double _default_double_support_ratio_swing_before) { default_double_support_ratio_swing_before = _default_double_support_ratio_swing_before; };
     void set_default_double_support_ratio_swing_after (const double _default_double_support_ratio_swing_after) { default_double_support_ratio_swing_after = _default_double_support_ratio_swing_after; };
     void set_default_zmp_offsets(const std::vector<hrp::Vector3>& tmp) { rg.set_default_zmp_offsets(tmp); };
@@ -1107,7 +1108,8 @@ namespace rats
     double get_default_step_time () const { return default_step_time; };
     double get_default_step_height () const { return lcg.get_default_step_height(); };
     double get_default_double_support_ratio () const { return default_double_support_ratio; };
-    double get_default_double_support_static_ratio () const { return default_double_support_static_ratio; };
+    double get_default_double_support_static_ratio_before () const { return default_double_support_static_ratio_before; };
+    double get_default_double_support_static_ratio_after () const { return default_double_support_static_ratio_after; };
     double get_default_double_support_ratio_swing_before () const {return default_double_support_ratio_swing_before; };
     double get_default_double_support_ratio_swing_after () const {return default_double_support_ratio_swing_after; };
     std::vector< std::vector<step_node> > get_remaining_footstep_nodes_list ()
@@ -1151,7 +1153,7 @@ namespace rats
         std::cerr << std::endl;
         std::cerr << "[" << print_str << "]   default_step_time = " << get_default_step_time() << "[s]" << std::endl;
         std::cerr << "[" << print_str << "]   default_step_height = " << get_default_step_height() << "[m]" << std::endl;
-        std::cerr << "[" << print_str << "]   default_double_support_ratio = " << get_default_double_support_ratio() << ", default_double_support_static_ratio = " << get_default_double_support_static_ratio() << ", default_double_support_static_ratio_swing_before = " << get_default_double_support_ratio_swing_before() << ", default_double_support_static_ratio_swing_after = " << get_default_double_support_ratio_swing_after() << std::endl;
+        std::cerr << "[" << print_str << "]   default_double_support_ratio = " << get_default_double_support_ratio() << ", default_double_support_static_ratio_before = " << get_default_double_support_static_ratio_before() << ", default_double_support_static_ratio_after = " << get_default_double_support_static_ratio_after() << ", default_double_support_static_ratio_swing_before = " << get_default_double_support_ratio_swing_before() << ", default_double_support_static_ratio_swing_after = " << get_default_double_support_ratio_swing_after() << std::endl;
         std::cerr << "[" << print_str << "]   default_orbit_type = ";
         if (get_default_orbit_type() == SHUFFLING) {
             std::cerr << "SHUFFLING" << std::endl;

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -672,8 +672,10 @@ public:
                       std::cerr << "No such default-orbit-type " << arg_strs[i] << std::endl;
                   }
               }
-          } else if ( arg_strs[i]== "--default-double-support-static-ratio" ) {
-              if (++i < arg_strs.size()) gg->set_default_double_support_static_ratio(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-static-ratio-before" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_static_ratio_before(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-static-ratio-after" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_static_ratio_after(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--swing-trajectory-delay-time-offset" ) {
               if (++i < arg_strs.size()) gg->set_swing_trajectory_delay_time_offset(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--swing-trajectory-final-distance-weight" ) {

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -563,7 +563,8 @@ public:
         gg->set_toe_angle(20);
         gg->set_heel_angle(5);
         gg->set_default_step_time(1.5);
-        gg->set_default_double_support_ratio(0.2);
+        gg->set_default_double_support_ratio_before(0.1);
+        gg->set_default_double_support_ratio_after(0.1);
         double ratio[7] = {0.02, 0.28, 0.2, 0.0, 0.2, 0.25, 0.05};
         std::vector<double> ratio2(ratio, ratio+gg->get_NUM_TH_PHASES());
         gg->set_toe_heel_phase_ratio(ratio2);
@@ -650,8 +651,10 @@ public:
               if (++i < arg_strs.size()) gg->set_default_step_time(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--default-step-height" ) {
               if (++i < arg_strs.size()) gg->set_default_step_height(atof(arg_strs[i].c_str()));
-          } else if ( arg_strs[i]== "--default-double-support-ratio" ) {
-              if (++i < arg_strs.size()) gg->set_default_double_support_ratio(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-ratio-before" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_ratio_before(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-ratio-after" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_ratio_after(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--default-orbit-type" ) {
               if (++i < arg_strs.size()) {
                   if (arg_strs[i] == "SHUFFLING") {


### PR DESCRIPTION
default_double_support_ratioをdefault_double_support_ratio_beforeとdefault_double_support_ratio_afterに分け，
default_double_support_static_ratioも同様に前後で２つに分けました．
デフォルトでは外部からbeforeとafterの変数を変更できないようになっており，今までと同様に使えるようになっています．