### PR TITLE
Add el log for final reference joint angles output for both Stable RTC users and Unstable RTC Users

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -808,6 +808,8 @@ class HrpsysConfigurator:
             self.connectLoggerPort(self.st, 'currentBasePos')
             self.connectLoggerPort(self.st, 'currentBaseRpy')
             self.connectLoggerPort(self.st, 'debugData')
+        if self.el != None:
+            self.connectLoggerPort(self.el, 'q')
         if self.rh != None:
             self.connectLoggerPort(self.rh, 'emergencySignal',
                                    'emergencySignal')


### PR DESCRIPTION
elの出力関節ポートをdataLoggerでログとることにしました。
Unstable RTCユーザもStable RTCユーザも、最終目標関節出力がこれにできると思います。
よろしくお願いします。