### PR TITLE
[ThermoEstimator] Fix default param to make temperature rise slower

### DIFF
--- a/rtc/ThermoEstimator/MotorHeatParam.h
+++ b/rtc/ThermoEstimator/MotorHeatParam.h
@@ -30,8 +30,8 @@ class MotorHeatParam
   // default params for motor heat param
   void defaultParams(){
     temperature = 30.0;
-    currentCoeffs = 0.00003;
-    thermoCoeffs = 0.001;
+    currentCoeffs = 0.00001;
+    thermoCoeffs = 0.0012;
   } 
 
 };


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/861 に関係して, ThermoEstimatorのデフォルトパラメータを温度上昇が緩やかになるように変更しました.
これでsamplerobotのシミュレーション等での過剰な温度制限がなくなることを期待しています. > @eisoku9618 