### PR TITLE
Update gopos

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -181,7 +181,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
           coil::stringTo(tmpv[j], end_effectors_str[i*prop_num+6+j].c_str());
         }
         tp.localR = Eigen::AngleAxis<double>(tmpv[3], hrp::Vector3(tmpv[0], tmpv[1], tmpv[2])).toRotationMatrix(); // rotation in VRML is represented by axis + angle
-        tp.manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(ee_base), m_robot->link(ee_target), m_dt, false));
+        tp.manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(ee_base), m_robot->link(ee_target), m_dt, false, std::string(m_profile.instance_name)));
         // Fix for toe joint
         //   Toe joint is defined as end-link joint in the case that end-effector link != force-sensor link
         //   Without toe joints, "end-effector link == force-sensor link" is assumed.

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -133,7 +133,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(), 
                                  CosNaming::NamingContext::_duplicate(naming.getRootContext())
                                  )){
-      std::cerr << m_profile.instance_name << " failed to load model[" << prop["model"] << "]" << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]" << std::endl;
       return RTC::RTC_ERROR;
     }
 

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1140,18 +1140,26 @@ void AutoBalancer::waitABCTransition()
 }
 bool AutoBalancer::goPos(const double& x, const double& y, const double& th)
 {
-  if ( !gg_is_walking && !is_stop_mode) {
+    //  if ( !gg_is_walking && !is_stop_mode) {
+  if ( !is_stop_mode) {
     gg->set_all_limbs(leg_names);
     coordinates start_ref_coords;
     mid_coords(start_ref_coords, 0.5, ikp["rleg"].target_end_coords, ikp["lleg"].target_end_coords);
-    gg->go_pos_param_2_footstep_nodes_list(x, y, th,
-                                           (y > 0 ? boost::assign::list_of(ikp["rleg"].target_end_coords) : boost::assign::list_of(ikp["lleg"].target_end_coords)),
-                                           start_ref_coords,
-                                           (y > 0 ? boost::assign::list_of(RLEG) : boost::assign::list_of(LLEG)));
-    startWalking();
-    return true;
+    bool ret = gg->go_pos_param_2_footstep_nodes_list(x, y, th,
+                                                      (y > 0 ? boost::assign::list_of(ikp["rleg"].target_end_coords) : boost::assign::list_of(ikp["lleg"].target_end_coords)), // Dummy if gg_is_walking
+                                                      start_ref_coords, // Dummy if gg_is_walking
+                                                      (y > 0 ? boost::assign::list_of(RLEG) : boost::assign::list_of(LLEG)), // Dummy if gg_is_walking
+                                                      (!gg_is_walking)); // If gg_is_walking, initialize. Otherwise, not initialize and overwrite footsteps.
+
+    if ( !gg_is_walking ) { // Initializing
+        startWalking();
+    }
+    if (!ret) {
+        std::cerr << "[" << m_profile.instance_name << "] Cannot goPos because of invalid timing." << std::endl;
+    }
+    return ret;
   } else {
-    std::cerr << "[" << m_profile.instance_name << "] Cannot goPos while walking." << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] Cannot goPos while stopping mode." << std::endl;
     return false;
   }
 }

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -386,7 +386,7 @@ namespace rats
     crdtg.get_trajectory_point(ret.pos, hrp::Vector3(start.pos), hrp::Vector3(goal.pos), height);
   };
 
-  bool leg_coords_generator::is_same_footstep_nodes(const std::vector<step_node>& fns_1, const std::vector<step_node>& fns_2)
+  bool leg_coords_generator::is_same_footstep_nodes(const std::vector<step_node>& fns_1, const std::vector<step_node>& fns_2) const
   {
       bool matching_flag = true;
       if (fns_1.size() == fns_2.size()) {

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -508,6 +508,7 @@ namespace rats
             }
         }
     }
+    // rg+lcg initialization
     rg.reset(one_step_len);
     rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list.front(), initial_support_leg_steps, initial_swing_leg_dst_steps);
     if ( preview_controller_ptr != NULL ) {
@@ -695,7 +696,7 @@ namespace rats
     if (velocity_mode_flg == VEL_DOING) velocity_mode_flg = VEL_ENDING;
   };
 
-  void gait_generator::calc_ref_coords_trans_vector_velocity_mode (coordinates& ref_coords, hrp::Vector3& trans, double& dth, const std::vector<step_node>& sup_fns)
+  void gait_generator::calc_ref_coords_trans_vector_velocity_mode (coordinates& ref_coords, hrp::Vector3& trans, double& dth, const std::vector<step_node>& sup_fns) const
   {
     ref_coords = sup_fns.front().worldcoords;
     hrp::Vector3 tmpv(footstep_param.leg_default_translate_pos[sup_fns.front().l_r] * -1.0); /* not fair to every support legs */
@@ -725,14 +726,19 @@ namespace rats
 
   void gait_generator::append_footstep_list_velocity_mode ()
   {
+      append_footstep_list_velocity_mode(footstep_nodes_list);
+  };
+
+  void gait_generator::append_footstep_list_velocity_mode (std::vector< std::vector<step_node> >& _footstep_nodes_list) const
+  {
     coordinates ref_coords;
     hrp::Vector3 trans;
     double dth;
-    calc_ref_coords_trans_vector_velocity_mode(ref_coords, trans, dth, footstep_nodes_list.back());
+    calc_ref_coords_trans_vector_velocity_mode(ref_coords, trans, dth, _footstep_nodes_list.back());
 
     ref_coords.pos += ref_coords.rot * trans;
     ref_coords.rotate(dth, hrp::Vector3(0,0,1));
-    append_go_pos_step_nodes(ref_coords, calc_counter_leg_types_from_footstep_nodes(footstep_nodes_list.back(), all_limbs));
+    append_go_pos_step_nodes(ref_coords, calc_counter_leg_types_from_footstep_nodes(_footstep_nodes_list.back(), all_limbs), _footstep_nodes_list);
   };
 
   void gait_generator::calc_next_coords_velocity_mode (std::vector< std::vector<coordinates> >& ret_list, const size_t idx, const size_t future_step_num)

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -508,6 +508,15 @@ namespace rats
             }
         }
     }
+    // get initial_foot_mid_coords
+    std::vector<coordinates> cv;
+    for (size_t i = 0; i < initial_support_leg_steps.size(); i++) {
+        cv.push_back(initial_support_leg_steps[i].worldcoords);
+    }
+    for (size_t i = 0; i < initial_swing_leg_dst_steps.size(); i++) {
+        cv.push_back(initial_swing_leg_dst_steps[i].worldcoords);
+    }
+    multi_mid_coords(initial_foot_mid_coords, cv);
     // rg+lcg initialization
     rg.reset(one_step_len);
     rg.push_refzmp_from_footstep_nodes_for_dual(footstep_nodes_list.front(), initial_support_leg_steps, initial_swing_leg_dst_steps);
@@ -601,11 +610,32 @@ namespace rats
    *  x, y and theta are simply divided by using stride params
    *  unit system -> x [mm], y [mm], theta [deg]
    */
-  void gait_generator::go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
+  bool gait_generator::go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
                                                            const std::vector<coordinates>& initial_support_legs_coords, coordinates start_ref_coords,
-                                                           const std::vector<leg_type>& initial_support_legs)
+                                                           const std::vector<leg_type>& initial_support_legs,
+                                                           const bool is_initialize)
   {
-    coordinates goal_ref_coords(start_ref_coords);
+    // Get overwrite footstep index
+    size_t overwritable_fs_index = 0;
+    if (!is_initialize) {
+        if (lcg.get_footstep_index() <= get_overwrite_check_timing()) { // ending half
+            overwritable_fs_index = get_overwritable_index()+1;
+        } else { // starting half
+            overwritable_fs_index = get_overwritable_index();
+        }
+    }
+    // Check overwritable_fs_index
+    if (overwritable_fs_index > footstep_nodes_list.size()-1) return false;
+    // Calc goal ref
+    coordinates goal_ref_coords;
+    if (is_initialize) {
+        goal_ref_coords = start_ref_coords;
+    } else {
+        goal_ref_coords = initial_foot_mid_coords;
+        step_node tmpfs = footstep_nodes_list[overwritable_fs_index-1].front();
+        start_ref_coords = tmpfs.worldcoords;
+        start_ref_coords.pos += start_ref_coords.rot * hrp::Vector3(-1*footstep_param.leg_default_translate_pos[tmpfs.l_r]);
+    }
     goal_ref_coords.pos += goal_ref_coords.rot * hrp::Vector3(goal_x, goal_y, 0.0);
     goal_ref_coords.rotate(deg2rad(goal_theta), hrp::Vector3(0,0,1));
     std::cerr << "start ref coords" << std::endl;
@@ -620,13 +650,17 @@ namespace rats
     std::cerr << goal_ref_coords.rot.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
 
     /* initialize */
-    clear_footstep_nodes_list();
-    // For initial double support period
-    std::vector<step_node> initial_footstep_nodes;
-    for (size_t i = 0; i < initial_support_legs.size(); i++) {
-        initial_footstep_nodes.push_back(step_node(initial_support_legs.at(i), initial_support_legs_coords.at(i), 0, default_step_time, 0, 0));
+    std::vector< std::vector<step_node> > new_footstep_nodes_list;
+    if (is_initialize) {
+        // For initial double support period
+        std::vector<step_node> initial_footstep_nodes;
+        for (size_t i = 0; i < initial_support_legs.size(); i++) {
+            initial_footstep_nodes.push_back(step_node(initial_support_legs.at(i), initial_support_legs_coords.at(i), 0, default_step_time, 0, 0));
+        }
+        new_footstep_nodes_list.push_back(initial_footstep_nodes);
+    } else {
+        new_footstep_nodes_list.push_back(footstep_nodes_list[overwritable_fs_index]);
     }
-    footstep_nodes_list.push_back(initial_footstep_nodes);
 
     /* footstep generation loop */
     hrp::Vector3 dp, dr;
@@ -635,31 +669,39 @@ namespace rats
     dr = start_ref_coords.rot.transpose() * dr;
     while ( !(eps_eq(std::sqrt(dp(0)*dp(0)+dp(1)*dp(1)), 0.0, 1e-3*0.1) && eps_eq(dr(2), 0.0, deg2rad(0.5))) ) {
       set_velocity_param(dp(0)/default_step_time, dp(1)/default_step_time, rad2deg(dr(2))/default_step_time);
-      append_footstep_list_velocity_mode();
-      start_ref_coords = footstep_nodes_list.back().front().worldcoords;
-      start_ref_coords.pos += start_ref_coords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_nodes_list.back().front().l_r] * -1.0);
+      append_footstep_list_velocity_mode(new_footstep_nodes_list);
+      start_ref_coords = new_footstep_nodes_list.back().front().worldcoords;
+      start_ref_coords.pos += start_ref_coords.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[new_footstep_nodes_list.back().front().l_r] * -1.0);
       start_ref_coords.difference(dp, dr, goal_ref_coords);
       dp = start_ref_coords.rot.transpose() * dp;
       dr = start_ref_coords.rot.transpose() * dr;
     }
     for (size_t i = 0; i < optional_go_pos_finalize_footstep_num; i++) {
-        append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(footstep_nodes_list.back(), all_limbs));
+        append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(new_footstep_nodes_list.back(), all_limbs), new_footstep_nodes_list);
     }
 
     /* finalize */
     //   Align last foot
-    append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(footstep_nodes_list.back(), all_limbs));
+    append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(new_footstep_nodes_list.back(), all_limbs), new_footstep_nodes_list);
     //   Check align
-    coordinates final_step_coords1 = footstep_nodes_list[footstep_nodes_list.size()-2].front().worldcoords; // Final coords in footstep_node_list
+    coordinates final_step_coords1 = new_footstep_nodes_list[new_footstep_nodes_list.size()-2].front().worldcoords; // Final coords in footstep_node_list
     coordinates final_step_coords2 = start_ref_coords; // Final coords calculated from start_ref_coords + translate pos
-    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[footstep_nodes_list[footstep_nodes_list.size()-2].front().l_r]);
+    final_step_coords2.pos += final_step_coords2.rot * hrp::Vector3(footstep_param.leg_default_translate_pos[new_footstep_nodes_list[new_footstep_nodes_list.size()-2].front().l_r]);
     final_step_coords1.difference(dp, dr, final_step_coords2);
     if ( !(eps_eq(dp.norm(), 0.0, 1e-3*0.1) && eps_eq(dr.norm(), 0.0, deg2rad(0.5))) ) { // If final_step_coords1 != final_step_coords2, add steps to match final_step_coords1 and final_step_coords2
-        append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(footstep_nodes_list.back(), all_limbs));
+        append_go_pos_step_nodes(start_ref_coords, calc_counter_leg_types_from_footstep_nodes(new_footstep_nodes_list.back(), all_limbs), new_footstep_nodes_list);
     }
     //   For Last double support period
-    append_finalize_footstep();
+    if (is_initialize) {
+        append_finalize_footstep(new_footstep_nodes_list);
+        clear_footstep_nodes_list();
+        footstep_nodes_list = new_footstep_nodes_list;
+    } else {
+        set_overwrite_foot_steps_list(new_footstep_nodes_list);
+        set_overwrite_foot_step_index(overwritable_fs_index);
+    }
     print_footstep_nodes_list();
+    return true;
   };
 
   void gait_generator::go_single_step_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta,

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -878,6 +878,7 @@ namespace rats
     emergency_flag emergency_flg;
     bool use_inside_step_limitation;
     std::map<leg_type, std::string> leg_type_map;
+    coordinates initial_foot_mid_coords;
 
     /* preview controller parameters */
     //preview_dynamics_filter<preview_control>* preview_controller_ptr;
@@ -962,9 +963,10 @@ namespace rats
         overwrite_footstep_nodes_list.clear();
         overwrite_footstep_index = 0;
     };
-    void go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
+    bool go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
                                              const std::vector<coordinates>& initial_support_legs_coords, coordinates start_ref_coords,
-                                             const std::vector<leg_type>& initial_support_legs);
+                                             const std::vector<leg_type>& initial_support_legs,
+                                             const bool is_initialize = false);
     void go_single_step_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta, /* [mm] [mm] [mm] [deg] */
                                                const std::string& tmp_swing_leg,
                                                const coordinates& _support_leg_coords);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -165,34 +165,34 @@ namespace rats
             }
         };
         // getter
-        void get_toe_heel_phase_ratio (std::vector<double>& ratio)
+        void get_toe_heel_phase_ratio (std::vector<double>& ratio) const
         {
             for (size_t i = 0; i < NUM_TH_PHASES; i++) ratio[i] = toe_heel_phase_ratio[i];
         };
-        int get_NUM_TH_PHASES () { return NUM_TH_PHASES; };
+        int get_NUM_TH_PHASES () const { return NUM_TH_PHASES; };
         // functions for checking phase and calculating phase time and ratio
-        bool is_phase_starting (const size_t current_count, const toe_heel_phase _phase)
+        bool is_phase_starting (const size_t current_count, const toe_heel_phase _phase) const
         {
             return (current_count == toe_heel_phase_count[_phase]);
         };
-        bool is_between_phases (const size_t current_count, const toe_heel_phase phase0, const toe_heel_phase phase1)
+        bool is_between_phases (const size_t current_count, const toe_heel_phase phase0, const toe_heel_phase phase1) const
         {
             return (toe_heel_phase_count[phase0] <= current_count) && (current_count < toe_heel_phase_count[phase1]);
         };
-        bool is_between_phases (const size_t current_count, const toe_heel_phase phase1)
+        bool is_between_phases (const size_t current_count, const toe_heel_phase phase1) const
         {
             return (current_count < toe_heel_phase_count[phase1]);
         };
-        bool is_no_SOLE1_phase () { return toe_heel_phase_count[TOE2SOLE] == toe_heel_phase_count[SOLE1]; };
-        double calc_phase_period (const toe_heel_phase start_phase, const toe_heel_phase goal_phase, const double _dt)
+        bool is_no_SOLE1_phase () const { return toe_heel_phase_count[TOE2SOLE] == toe_heel_phase_count[SOLE1]; };
+        double calc_phase_period (const toe_heel_phase start_phase, const toe_heel_phase goal_phase, const double _dt) const
         {
             return _dt * (toe_heel_phase_count[goal_phase]-toe_heel_phase_count[start_phase]);
         };
-        double calc_phase_ratio (const size_t current_count, const toe_heel_phase start_phase, const toe_heel_phase goal_phase)
+        double calc_phase_ratio (const size_t current_count, const toe_heel_phase start_phase, const toe_heel_phase goal_phase) const
         {
             return static_cast<double>(current_count-toe_heel_phase_count[start_phase]) / (toe_heel_phase_count[goal_phase]-toe_heel_phase_count[start_phase]);
         };
-        double calc_phase_ratio (const size_t current_count, const toe_heel_phase goal_phase)
+        double calc_phase_ratio (const size_t current_count, const toe_heel_phase goal_phase) const
         {
             return static_cast<double>(current_count) / (toe_heel_phase_count[goal_phase]);
         };
@@ -290,8 +290,8 @@ namespace rats
         if (refzmp_cur_list.size() > refzmp_index ) calc_current_refzmp(rzmp, swing_foot_zmp_offsets, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
         return refzmp_cur_list.size() > refzmp_index;
       };
-      const hrp::Vector3& get_refzmp_cur () { return refzmp_cur_list.front(); };
-      const hrp::Vector3& get_default_zmp_offset (const leg_type lt) { return default_zmp_offsets[lt]; };
+      const hrp::Vector3& get_refzmp_cur () const { return refzmp_cur_list.front(); };
+      const hrp::Vector3& get_default_zmp_offset (const leg_type lt) const { return default_zmp_offsets[lt]; };
       double get_toe_zmp_offset_x () const { return toe_zmp_offset_x; };
       double get_heel_zmp_offset_x () const { return heel_zmp_offset_x; };
       bool get_use_toe_heel_transition () const { return use_toe_heel_transition; };
@@ -371,8 +371,8 @@ namespace rats
         ret = pos;
         current_count++;
       };
-      double get_swing_trajectory_delay_time_offset () { return time_offset; };
-      double get_swing_trajectory_final_distance_weight () { return final_distance_weight; };
+      double get_swing_trajectory_delay_time_offset () const { return time_offset; };
+      double get_swing_trajectory_final_distance_weight () const { return final_distance_weight; };
       // interpolate path vector
       //   tmp_ratio : ratio value [0, 1]
       //   org_point_vec : vector of via points
@@ -465,7 +465,7 @@ namespace rats
       stair_delay_hoffarbib_trajectory_generator () : delay_hoffarbib_trajectory_generator(), way_point_offset(hrp::Vector3(0.03, 0.0, 0.0)) {};
       ~stair_delay_hoffarbib_trajectory_generator () {};
       void set_stair_trajectory_way_point_offset (const hrp::Vector3 _offset) { way_point_offset = _offset; };
-      hrp::Vector3 get_stair_trajectory_way_point_offset() { return way_point_offset; };
+      hrp::Vector3 get_stair_trajectory_way_point_offset() const { return way_point_offset; };
     };
 
     class cycloid_delay_hoffarbib_trajectory_generator : public delay_hoffarbib_trajectory_generator
@@ -501,7 +501,7 @@ namespace rats
         cycloid_delay_kick_hoffarbib_trajectory_generator() : delay_hoffarbib_trajectory_generator(), kick_point_offset(hrp::Vector3(-0.1, 0.0, 0.0)) {};
       void set_cycloid_delay_kick_point_offset (const hrp::Vector3 _offset) { kick_point_offset = _offset; };
       void set_start_rot (const hrp::Matrix33 _offset) { start_rot = _offset; };
-      hrp::Vector3 get_cycloid_delay_kick_point_offset () { return kick_point_offset; };
+      hrp::Vector3 get_cycloid_delay_kick_point_offset () const { return kick_point_offset; };
       hrp::Vector3 interpolate_antecedent_path (const hrp::Vector3& start, const hrp::Vector3& goal, const double height, const double tmp_ratio)
       {
         std::vector<hrp::Vector3> cycloid_path;
@@ -780,7 +780,7 @@ namespace rats
             toe_heel_interpolator->get(&tmp, true);
         }
       };
-      bool is_same_footstep_nodes(const std::vector<step_node>& fns_1, const std::vector<step_node>& fns_2);
+      bool is_same_footstep_nodes(const std::vector<step_node>& fns_1, const std::vector<step_node>& fns_2) const;
       void update_leg_steps (const std::vector< std::vector<step_node> >& fnsl, const double default_double_support_ratio_before, const double default_double_support_ratio_after);
       size_t get_footstep_index() const { return footstep_index; };
       size_t get_lcg_count() const { return lcg_count; };
@@ -824,16 +824,16 @@ namespace rats
           }
       };
       orbit_type get_default_orbit_type () const { return default_orbit_type; };
-      double get_swing_trajectory_delay_time_offset () { return time_offset; };
-      double get_swing_trajectory_final_distance_weight () { return final_distance_weight; };
-      hrp::Vector3 get_stair_trajectory_way_point_offset () { return sdtg.get_stair_trajectory_way_point_offset(); };
-      hrp::Vector3 get_cycloid_delay_kick_point_offset () { return cdktg.get_cycloid_delay_kick_point_offset() ; };
-      double get_toe_pos_offset_x () { return toe_pos_offset_x; };
-      double get_heel_pos_offset_x () { return heel_pos_offset_x; };
+      double get_swing_trajectory_delay_time_offset () const { return time_offset; };
+      double get_swing_trajectory_final_distance_weight () const { return final_distance_weight; };
+      hrp::Vector3 get_stair_trajectory_way_point_offset () const { return sdtg.get_stair_trajectory_way_point_offset(); };
+      hrp::Vector3 get_cycloid_delay_kick_point_offset () const { return cdktg.get_cycloid_delay_kick_point_offset() ; };
+      double get_toe_pos_offset_x () const { return toe_pos_offset_x; };
+      double get_heel_pos_offset_x () const { return heel_pos_offset_x; };
       double get_toe_angle () const { return toe_angle; };
       double get_heel_angle () const { return heel_angle; };
-      double get_foot_dif_rot_angle () { return foot_dif_rot_angle; };
-      bool get_use_toe_joint () { return use_toe_joint; };
+      double get_foot_dif_rot_angle () const { return foot_dif_rot_angle; };
+      bool get_use_toe_joint () const { return use_toe_joint; };
     };
 
   class gait_generator
@@ -977,7 +977,7 @@ namespace rats
     {
       append_finalize_footstep(footstep_nodes_list);
     };
-    void append_finalize_footstep (std::vector< std::vector<step_node> >& _footstep_nodes_list)
+    void append_finalize_footstep (std::vector< std::vector<step_node> >& _footstep_nodes_list) const
     {
       std::vector<step_node> sns = _footstep_nodes_list[_footstep_nodes_list.size()-2];
       for (size_t i = 0; i < sns.size(); i++) {
@@ -1054,7 +1054,7 @@ namespace rats
         print_footstep_nodes_list(overwrite_footstep_nodes_list);
     };
     /* Get overwritable footstep index. For example, if overwritable_footstep_index_offset = 1, overwrite next footstep. If overwritable_footstep_index_offset = 0, overwrite current swinging footstep. */
-    size_t get_overwritable_index ()
+    size_t get_overwritable_index () const
     {
         return lcg.get_footstep_index()+overwritable_footstep_index_offset;
     };
@@ -1067,7 +1067,7 @@ namespace rats
             return false;
         }
     };
-    bool get_footstep_nodes_by_index (std::vector<step_node>& csl, const size_t idx)
+    bool get_footstep_nodes_by_index (std::vector<step_node>& csl, const size_t idx) const
     {
         if (footstep_nodes_list.size()-1 >= idx) {
             csl = footstep_nodes_list.at(idx);
@@ -1089,19 +1089,19 @@ namespace rats
       print_footstep_nodes_list(footstep_nodes_list);
     };
     /* parameter getting */
-    const hrp::Vector3& get_cog () { return cog; };
-    hrp::Vector3 get_cog_vel () {
+    const hrp::Vector3& get_cog () const { return cog; };
+    hrp::Vector3 get_cog_vel () const {
       double refcog_vel[3];
       preview_controller_ptr->get_refcog_vel(refcog_vel);
       return hrp::Vector3(refcog_vel[0], refcog_vel[1], refcog_vel[2]);
     };
-    hrp::Vector3 get_cog_acc () {
+    hrp::Vector3 get_cog_acc () const {
       double refcog_acc[3];
       preview_controller_ptr->get_refcog_acc(refcog_acc);
       return hrp::Vector3(refcog_acc[0], refcog_acc[1], refcog_acc[2]);
     };
-    const hrp::Vector3& get_refzmp () { return refzmp;};
-    hrp::Vector3 get_cart_zmp ()
+    const hrp::Vector3& get_refzmp () const { return refzmp;};
+    hrp::Vector3 get_cart_zmp () const
     {
         double czmp[3];
         preview_controller_ptr->get_cart_zmp(czmp);
@@ -1114,8 +1114,8 @@ namespace rats
       }
       return ret;
     };
-    const std::vector<hrp::Vector3>& get_swing_foot_zmp_offsets () { return swing_foot_zmp_offsets;};
-    std::vector<hrp::Vector3> get_support_foot_zmp_offsets () {
+    const std::vector<hrp::Vector3>& get_swing_foot_zmp_offsets () const { return swing_foot_zmp_offsets;};
+    std::vector<hrp::Vector3> get_support_foot_zmp_offsets () const {
       std::vector<hrp::Vector3> ret;
       for (size_t i = 0; i < lcg.get_support_leg_types().size(); i++) {
           ret.push_back(rg.get_default_zmp_offset(lcg.get_support_leg_types().at(i)));
@@ -1154,7 +1154,7 @@ namespace rats
       return tmp;
     };
     void get_swing_support_mid_coords(coordinates& ret) const { lcg.get_swing_support_mid_coords(ret); };
-    void get_stride_parameters (double& _stride_fwd_x, double& _stride_y, double& _stride_theta, double& _stride_bwd_x)
+    void get_stride_parameters (double& _stride_fwd_x, double& _stride_y, double& _stride_theta, double& _stride_bwd_x) const
     {
       _stride_fwd_x = footstep_param.stride_fwd_x;
       _stride_y = footstep_param.stride_y;
@@ -1173,7 +1173,7 @@ namespace rats
     double get_default_double_support_static_ratio_after () const { return default_double_support_static_ratio_after; };
     double get_default_double_support_ratio_swing_before () const {return default_double_support_ratio_swing_before; };
     double get_default_double_support_ratio_swing_after () const {return default_double_support_ratio_swing_after; };
-    std::vector< std::vector<step_node> > get_remaining_footstep_nodes_list ()
+    std::vector< std::vector<step_node> > get_remaining_footstep_nodes_list () const
     {
         std::vector< std::vector<step_node> > fsnl;
         size_t fsl_size = (footstep_nodes_list.size()>lcg.get_footstep_index() ? footstep_nodes_list.size()-lcg.get_footstep_index() : 0);
@@ -1184,27 +1184,27 @@ namespace rats
         return fsnl;
     };
     orbit_type get_default_orbit_type () const { return lcg.get_default_orbit_type(); };
-    double get_swing_trajectory_delay_time_offset () { return lcg.get_swing_trajectory_delay_time_offset(); };
-    double get_swing_trajectory_final_distance_weight () { return lcg.get_swing_trajectory_final_distance_weight(); };
-    hrp::Vector3 get_stair_trajectory_way_point_offset () { return lcg.get_stair_trajectory_way_point_offset(); };
-    hrp::Vector3 get_cycloid_delay_kick_point_offset () { return lcg.get_cycloid_delay_kick_point_offset(); };
-    double get_gravitational_acceleration () { return gravitational_acceleration; } ;
-    double get_toe_pos_offset_x () { return lcg.get_toe_pos_offset_x(); };
-    double get_heel_pos_offset_x () { return lcg.get_heel_pos_offset_x(); };
+    double get_swing_trajectory_delay_time_offset () const { return lcg.get_swing_trajectory_delay_time_offset(); };
+    double get_swing_trajectory_final_distance_weight () const { return lcg.get_swing_trajectory_final_distance_weight(); };
+    hrp::Vector3 get_stair_trajectory_way_point_offset () const { return lcg.get_stair_trajectory_way_point_offset(); };
+    hrp::Vector3 get_cycloid_delay_kick_point_offset () const { return lcg.get_cycloid_delay_kick_point_offset(); };
+    double get_gravitational_acceleration () const { return gravitational_acceleration; } ;
+    double get_toe_pos_offset_x () const { return lcg.get_toe_pos_offset_x(); };
+    double get_heel_pos_offset_x () const { return lcg.get_heel_pos_offset_x(); };
     double get_toe_angle () const { return lcg.get_toe_angle(); };
     double get_heel_angle () const { return lcg.get_heel_angle(); };
-    double get_foot_dif_rot_angle () { return lcg.get_foot_dif_rot_angle(); };
-    void get_toe_heel_phase_ratio (std::vector<double>& ratio) { thp.get_toe_heel_phase_ratio(ratio); };
-    int get_NUM_TH_PHASES () { return thp.get_NUM_TH_PHASES(); };
-    bool get_use_toe_joint () { return lcg.get_use_toe_joint(); };
-    void get_leg_default_translate_pos (std::vector<hrp::Vector3>& off) { off = footstep_param.leg_default_translate_pos; };
+    double get_foot_dif_rot_angle () const { return lcg.get_foot_dif_rot_angle(); };
+    void get_toe_heel_phase_ratio (std::vector<double>& ratio) const { thp.get_toe_heel_phase_ratio(ratio); };
+    int get_NUM_TH_PHASES () const { return thp.get_NUM_TH_PHASES(); };
+    bool get_use_toe_joint () const { return lcg.get_use_toe_joint(); };
+    void get_leg_default_translate_pos (std::vector<hrp::Vector3>& off) const { off = footstep_param.leg_default_translate_pos; };
     size_t get_overwritable_footstep_index_offset () const { return overwritable_footstep_index_offset; };
     const std::vector<leg_type> calc_counter_leg_types_from_footstep_nodes (const std::vector<step_node>& fns, std::vector<std::string> _all_limbs) const;
     const std::map<leg_type, std::string> get_leg_type_map () const { return leg_type_map; };
     size_t get_optional_go_pos_finalize_footstep_num () const { return optional_go_pos_finalize_footstep_num; };
     bool is_finalizing (const double tm) const { return ((preview_controller_ptr->get_delay()*2 - default_step_time/dt)-finalize_count) <= (tm/dt)-1; };
     size_t get_overwrite_check_timing () const { return static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1;}; // Almost middle of step time
-    void print_param (const std::string& print_str = "")
+    void print_param (const std::string& print_str = "") const
     {
         double stride_fwd_x, stride_y, stride_th, stride_bwd_x;
         get_stride_parameters(stride_fwd_x, stride_y, stride_th, stride_bwd_x);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -966,7 +966,7 @@ namespace rats
     bool go_pos_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_theta, /* [mm] [mm] [deg] */
                                              const std::vector<coordinates>& initial_support_legs_coords, coordinates start_ref_coords,
                                              const std::vector<leg_type>& initial_support_legs,
-                                             const bool is_initialize = false);
+                                             const bool is_initialize = true);
     void go_single_step_param_2_footstep_nodes_list (const double goal_x, const double goal_y, const double goal_z, const double goal_theta, /* [mm] [mm] [mm] [deg] */
                                                const std::string& tmp_swing_leg,
                                                const coordinates& _support_leg_coords);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -830,8 +830,8 @@ namespace rats
       hrp::Vector3 get_cycloid_delay_kick_point_offset () { return cdktg.get_cycloid_delay_kick_point_offset() ; };
       double get_toe_pos_offset_x () { return toe_pos_offset_x; };
       double get_heel_pos_offset_x () { return heel_pos_offset_x; };
-      double get_toe_angle () { return toe_angle; };
-      double get_heel_angle () { return heel_angle; };
+      double get_toe_angle () const { return toe_angle; };
+      double get_heel_angle () const { return heel_angle; };
       double get_foot_dif_rot_angle () { return foot_dif_rot_angle; };
       bool get_use_toe_joint () { return use_toe_joint; };
     };
@@ -886,6 +886,13 @@ namespace rats
     void append_go_pos_step_nodes (const coordinates& _ref_coords,
                                    const std::vector<leg_type>& lts)
     {
+        append_go_pos_step_nodes(_ref_coords, lts, footstep_nodes_list);
+    };
+
+    void append_go_pos_step_nodes (const coordinates& _ref_coords,
+                                   const std::vector<leg_type>& lts,
+                                   std::vector< std::vector<step_node> >& _footstep_nodes_list) const
+    {
       std::vector<step_node> sns;
       for (size_t i = 0; i < lts.size(); i++) {
           sns.push_back(step_node(lts.at(i), _ref_coords,
@@ -893,12 +900,13 @@ namespace rats
                                   lcg.get_toe_angle(), lcg.get_heel_angle()));
           sns.at(i).worldcoords.pos += sns.at(i).worldcoords.rot * footstep_param.leg_default_translate_pos[lts.at(i)];
       }
-      footstep_nodes_list.push_back(sns);
+      _footstep_nodes_list.push_back(sns);
     };
     void overwrite_refzmp_queue(const std::vector< std::vector<step_node> >& fnsl);
-    void calc_ref_coords_trans_vector_velocity_mode (coordinates& ref_coords, hrp::Vector3& trans, double& dth, const std::vector<step_node>& sup_fns);
+    void calc_ref_coords_trans_vector_velocity_mode (coordinates& ref_coords, hrp::Vector3& trans, double& dth, const std::vector<step_node>& sup_fns) const;
     void calc_next_coords_velocity_mode (std::vector< std::vector<coordinates> >& ret_list, const size_t idx, const size_t future_step_num = 3);
     void append_footstep_list_velocity_mode ();
+    void append_footstep_list_velocity_mode (std::vector< std::vector<step_node> >& _footstep_nodes_list) const;
 
 #ifndef HAVE_MAIN
     /* inhibit copy constructor and copy insertion not by implementing */
@@ -1181,8 +1189,8 @@ namespace rats
     double get_gravitational_acceleration () { return gravitational_acceleration; } ;
     double get_toe_pos_offset_x () { return lcg.get_toe_pos_offset_x(); };
     double get_heel_pos_offset_x () { return lcg.get_heel_pos_offset_x(); };
-    double get_toe_angle () { return lcg.get_toe_angle(); };
-    double get_heel_angle () { return lcg.get_heel_angle(); };
+    double get_toe_angle () const { return lcg.get_toe_angle(); };
+    double get_heel_angle () const { return lcg.get_heel_angle(); };
     double get_foot_dif_rot_angle () { return lcg.get_foot_dif_rot_angle(); };
     void get_toe_heel_phase_ratio (std::vector<double>& ratio) { thp.get_toe_heel_phase_ratio(ratio); };
     int get_NUM_TH_PHASES () { return thp.get_NUM_TH_PHASES(); };

--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -90,7 +90,7 @@ CollisionDetector::~CollisionDetector()
 
 RTC::ReturnCode_t CollisionDetector::onInitialize()
 {
-    std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
     // <rtc-template block="bind_config">
     // Bind variables and configuration variable
     bindParameter("debugLevel", m_debugLevel, "0");
@@ -146,7 +146,7 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
     binfo = hrp::loadBodyInfo(prop["model"].c_str(),
 			      CosNaming::NamingContext::_duplicate(naming.getRootContext()));
     if (CORBA::is_nil(binfo)){
-	std::cerr << "failed to load model[" << prop["model"] << "]"
+	std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]"
 		  << std::endl;
 	return RTC::RTC_ERROR;
     }
@@ -155,7 +155,7 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
 #else
     if (!loadBodyFromBodyInfo(m_robot, binfo, true, hrplinkFactory)) {
 #endif // USE_HRPSYSUTIL
-      std::cerr << "failed to load model[" << prop["model"] << "] in "
+      std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "] in "
                 << m_profile.instance_name << std::endl;
       return RTC::RTC_ERROR;
     }
@@ -171,15 +171,15 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
     setupVClipModel(m_robot);
 
     if ( prop["collision_pair"] != "" ) {
-	std::cerr << "prop[collision_pair] ->" << prop["collision_pair"] << std::endl;
+	std::cerr << "[" << m_profile.instance_name << "] prop[collision_pair] ->" << prop["collision_pair"] << std::endl;
 	std::istringstream iss(prop["collision_pair"]);
 	std::string tmp;
 	while (getline(iss, tmp, ' ')) {
 	    size_t pos = tmp.find_first_of(':');
 	    std::string name1 = tmp.substr(0, pos), name2 = tmp.substr(pos+1);
             if ( m_robot->link(name1)==NULL ) {
-                std::cerr << "CollisionDetector: Could not find robot link " << name1 << std::endl;
-		std::cerr << " please choose one of following :";
+                std::cerr << "[" << m_profile.instance_name << "] Could not find robot link " << name1 << std::endl;
+		std::cerr << "[" << m_profile.instance_name << "] please choose one of following :";
 		for (int i=0; i < m_robot->numLinks(); i++) {
 		  std::cerr << " " << m_robot->link(i)->name;
 		}
@@ -187,15 +187,15 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
                 continue;
             }
             if ( m_robot->link(name2)==NULL ) {
-                std::cerr << "Could not find robot link " << name2 << std::endl;
-		std::cerr << " please choose one of following :";
+                std::cerr << "[" << m_profile.instance_name << "] Could not find robot link " << name2 << std::endl;
+		std::cerr << "[" << m_profile.instance_name << "] please choose one of following :";
 		for (int i=0; i < m_robot->numLinks(); i++) {
 		  std::cerr << " " << m_robot->link(i)->name;
 		}
 		std::cerr << std::endl;
                 continue;
             }
-	    std::cerr << "check collisions between " << m_robot->link(name1)->name << " and " <<  m_robot->link(name2)->name << std::endl;
+	    std::cerr << "[" << m_profile.instance_name << "] check collisions between " << m_robot->link(name1)->name << " and " <<  m_robot->link(name2)->name << std::endl;
 	    m_pair[tmp] = new CollisionLinkPair(new VclipLinkPair(m_robot->link(name1), m_VclipLinks[m_robot->link(name1)->index],
                                                                   m_robot->link(name2), m_VclipLinks[m_robot->link(name2)->index], 0));
 	}
@@ -203,7 +203,7 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
 
     if ( prop["collision_loop"] != "" ) {
         coil::stringTo(m_collision_loop, prop["collision_loop"].c_str());
-        std::cerr << "set collision_loop: " << m_collision_loop << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] set collision_loop: " << m_collision_loop << std::endl;
     }
 #ifdef USE_HRPSYSUTIL
     if ( m_use_viewer ) {
@@ -219,25 +219,25 @@ RTC::ReturnCode_t CollisionDetector::onInitialize()
     m_init_collision_mask.resize(m_robot->numJoints()); // collision_mask defined in .conf as [collisoin_mask] 0: move even if collide, 1: do not move when collide
     std::fill(m_init_collision_mask.begin(), m_init_collision_mask.end(), 1);
     if ( prop["collision_mask"] != "" ) {
-	std::cerr << "[co] prop[collision_mask] ->" << prop["collision_mask"] << std::endl;
+	std::cerr << "[" << m_profile.instance_name << "] prop[collision_mask] ->" << prop["collision_mask"] << std::endl;
         coil::vstring mask_str = coil::split(prop["collision_mask"], ",");
         if (mask_str.size() == m_robot->numJoints()) {
             for (size_t i = 0; i < m_robot->numJoints(); i++) {coil::stringTo(m_init_collision_mask[i], mask_str[i].c_str()); }
             for (size_t i = 0; i < m_robot->numJoints(); i++) {
                 if ( m_init_collision_mask[i] == 0 ) {
-                    std::cerr << "[co] CollisionDetector will not control " << m_robot->joint(i)->name << std::endl;
+                    std::cerr << "[" << m_profile.instance_name << "] CollisionDetector will not control " << m_robot->joint(i)->name << std::endl;
                 }
             }
         }else{
-            std::cerr << "[co] ERROR size of collision_mask is differ from robot joint number .. " << mask_str.size()  << ", " << m_robot->numJoints() << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] ERROR size of collision_mask is differ from robot joint number .. " << mask_str.size()  << ", " << m_robot->numJoints() << std::endl;
         }
     }
 
     if ( prop["use_limb_collision"] != "" ) {
-        std::cerr << "[co] prop[use_limb_collision] -> " << prop["use_limb_collision"] << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] prop[use_limb_collision] -> " << prop["use_limb_collision"] << std::endl;
         if ( prop["use_limb_collision"] == "true" ) {
             m_use_limb_collision = true;
-            std::cerr << "[co] Enable use_limb_collision" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] Enable use_limb_collision" << std::endl;
         }
     }
 
@@ -305,14 +305,14 @@ RTC::ReturnCode_t CollisionDetector::onFinalize()
 
 RTC::ReturnCode_t CollisionDetector::onActivated(RTC::UniqueId ec_id)
 {
-    std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+    std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
     m_have_safe_posture = false;
     return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t CollisionDetector::onDeactivated(RTC::UniqueId ec_id)
 {
-    std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+    std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
     return RTC::RTC_OK;
 }
 
@@ -326,7 +326,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
     }
     if ( ! m_enable ) {
         if ( DEBUGP || loop % 100 == 1) {
-            std::cerr << "CAUTION!! The robot is moving without checking self collision detection!!! please send enableCollisionDetection to CollisoinDetection RTC" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] CAUTION!! The robot is moving without checking self collision detection!!! please send enableCollisionDetection to CollisoinDetection RTC" << std::endl;
         }
         if ( m_qRefIn.isNew()) {
             m_qRefIn.read();
@@ -405,7 +405,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
                     m_safe_posture = false;
                     if ( loop%200==0 || last_safe_posture ) {
                         hrp::JointPathPtr jointPath = m_robot->getJointPath(p->link(0),p->link(1));
-                        std::cerr << i << "/" << m_pair.size() << " pair: " << p->link(0)->name << "/" << p->link(1)->name << "(" << jointPath->numJoints() << "), distance = " << c->distance << std::endl;
+                        std::cerr << "[" << m_profile.instance_name << "] " << i << "/" << m_pair.size() << " pair: " << p->link(0)->name << "/" << p->link(1)->name << "(" << jointPath->numJoints() << "), distance = " << c->distance << std::endl;
                     }
                     m_link_collision[p->link(0)->index] = true;
                     m_link_collision[p->link(1)->index] = true;
@@ -449,7 +449,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
             }
             if ( m_use_limb_collision ) {
                if ( loop%200==0 and ! m_safe_posture ) {
-                   std::cerr << "collision_mask : ";
+                   std::cerr << "[" << m_profile.instance_name << "] collision_mask : ";
                     for (size_t i = 0; i < m_robot->numJoints(); i++) {
                         std::cerr << m_robot->joint(i)->name << ":"  << m_curr_collision_mask[i] << " ";
                     }
@@ -502,15 +502,15 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
 #endif
         }
         if ( DEBUGP ) {
-          std::cerr << "check collisions for " << m_pair.size() << " pairs in " << (tm2.sec()-tm1.sec())*1000+(tm2.usec()-tm1.usec())/1000.0 
+          std::cerr << "[" << m_profile.instance_name << "] check collisions for " << m_pair.size() << " pairs in " << (tm2.sec()-tm1.sec())*1000+(tm2.usec()-tm1.usec())/1000.0 
                     << " [msec], safe = " << m_safe_posture << ", time = " << m_recover_time*m_dt << "[s], loop = " << m_loop_for_check << "/" << m_collision_loop << std::endl;
         }
         if ( m_pair.size() == 0 && ( DEBUGP || (loop % ((int)(5/m_dt))) == 1) ) {
-            std::cerr << "CAUTION!! The robot is moving without checking self collision detection!!! please define collision_pair in configuration file" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] CAUTION!! The robot is moving without checking self collision detection!!! please define collision_pair in configuration file" << std::endl;
         }
         if ( ! m_have_safe_posture && ! m_safe_posture ) {
             if ( DEBUGP || (loop % ((int)(5/m_dt))) == 1) {
-                std::cerr << "CAUTION!! The robot is moving while collision detection!!!, since we do not get safe_posture yet" << std::endl;
+                std::cerr << "[" << m_profile.instance_name << "] CAUTION!! The robot is moving while collision detection!!!, since we do not get safe_posture yet" << std::endl;
             }
             for ( int i = 0; i < m_q.data.length(); i++ ) {
                 m_lastsafe_jointdata[i] = m_recover_jointdata[i] = m_q.data[i] = m_qRef.data[i];
@@ -663,12 +663,12 @@ bool CollisionDetector::checkIsSafeTransition(void)
 bool CollisionDetector::enable(void)
 {
     if (m_enable){
-        std::cerr << "CollisionDetector is already enabled." << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] CollisionDetector is already enabled." << std::endl;
         return true;
     }
 
     if (!checkIsSafeTransition()){
-        std::cerr << "CollisionDetector cannot be enabled because of different reference joint angle" << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] CollisionDetector cannot be enabled because of different reference joint angle" << std::endl;
         return false;
     }
 
@@ -684,12 +684,12 @@ bool CollisionDetector::enable(void)
         c->distance = c->pair->computeDistance(c->point0.data(), c->point1.data());
         if ( c->distance <= c->pair->getTolerance() ) {
             hrp::JointPathPtr jointPath = m_robot->getJointPath(p->link(0),p->link(1));
-            std::cerr << "CollisionDetector cannot be enabled because of collision" << std::endl;
-            std::cerr << i << "/" << m_pair.size() << " pair: " << p->link(0)->name << "/" << p->link(1)->name << "(" << jointPath->numJoints() << "), distance = " << c->distance << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] CollisionDetector cannot be enabled because of collision" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] " << i << "/" << m_pair.size() << " pair: " << p->link(0)->name << "/" << p->link(1)->name << "(" << jointPath->numJoints() << "), distance = " << c->distance << std::endl;
             return false;
         }
     }
-    std::cerr << "CollisionDetector is successfully enabled." << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] CollisionDetector is successfully enabled." << std::endl;
 
     m_safe_posture = true;
     m_recover_time = 0;
@@ -701,10 +701,10 @@ bool CollisionDetector::enable(void)
 bool CollisionDetector::disable(void)
 {
     if (!checkIsSafeTransition()){
-        std::cerr << "CollisionDetector cannot be disabled because of different reference joint angle" << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] CollisionDetector cannot be disabled because of different reference joint angle" << std::endl;
         return false;
     }
-    std::cerr << "CollisionDetector is successfully disabled." << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] CollisionDetector is successfully disabled." << std::endl;
     m_enable = false;
     return true;
 }

--- a/rtc/DataLogger/DataLogger.cpp
+++ b/rtc/DataLogger/DataLogger.cpp
@@ -180,7 +180,7 @@ DataLogger::~DataLogger()
 
 RTC::ReturnCode_t DataLogger::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // Registration: InPort/OutPort/Service
   // <rtc-template block="registration">
   // Set InPort buffers

--- a/rtc/EmergencyStopper/EmergencyStopper.cpp
+++ b/rtc/EmergencyStopper/EmergencyStopper.cpp
@@ -113,13 +113,12 @@ RTC::ReturnCode_t EmergencyStopper::onInitialize()
     binfo = hrp::loadBodyInfo(prop["model"].c_str(),
                               CosNaming::NamingContext::_duplicate(naming.getRootContext()));
     if (CORBA::is_nil(binfo)) {
-        std::cerr << "failed to load model[" << prop["model"] << "]"
+        std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]"
                   << std::endl;
         return RTC::RTC_ERROR;
     }
     if (!loadBodyFromBodyInfo(m_robot, binfo)) {
-        std::cerr << "failed to load model[" << prop["model"] << "] in "
-                  << m_profile.instance_name << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]" << std::endl;
         return RTC::RTC_ERROR;
     }
 
@@ -235,13 +234,13 @@ RTC::ReturnCode_t EmergencyStopper::onFinalize()
 
 RTC::ReturnCode_t EmergencyStopper::onActivated(RTC::UniqueId ec_id)
 {
-    std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+    std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
     return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t EmergencyStopper::onDeactivated(RTC::UniqueId ec_id)
 {
-    std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+    std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
     Guard guard(m_mutex);
     if (is_stop_mode) {
         is_stop_mode = false;

--- a/rtc/ForwardKinematics/ForwardKinematics.cpp
+++ b/rtc/ForwardKinematics/ForwardKinematics.cpp
@@ -58,7 +58,7 @@ ForwardKinematics::~ForwardKinematics()
 
 RTC::ReturnCode_t ForwardKinematics::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   coil::Properties& ref = getProperties();
@@ -101,15 +101,13 @@ RTC::ReturnCode_t ForwardKinematics::onInitialize()
   m_refBody = hrp::BodyPtr(new hrp::Body());
   if (!loadBodyFromModelLoader(m_refBody, prop["model"].c_str(), 
                                CosNaming::NamingContext::_duplicate(naming.getRootContext()))){
-    std::cerr << "failed to load model[" << prop["model"] << "] in "
-              << m_profile.instance_name << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]" << std::endl;
     return RTC::RTC_ERROR;
   }
   m_actBody = hrp::BodyPtr(new hrp::Body());
   if (!loadBodyFromModelLoader(m_actBody, prop["model"].c_str(), 
                                CosNaming::NamingContext::_duplicate(naming.getRootContext()))){
-    std::cerr << "failed to load model[" << prop["model"] << "] in "
-              << m_profile.instance_name << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]" << std::endl;
     return RTC::RTC_ERROR;
   }
 
@@ -144,7 +142,7 @@ RTC::ReturnCode_t ForwardKinematics::onShutdown(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t ForwardKinematics::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
   if (m_sensorAttachedLinkName == ""){
     m_sensorAttachedLink = NULL;
   }else{
@@ -160,7 +158,7 @@ RTC::ReturnCode_t ForwardKinematics::onActivated(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t ForwardKinematics::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -227,7 +227,7 @@ RTC::ReturnCode_t ImpedanceController::onInitialize()
         // 3. Check whether joint path is adequate.
         hrp::Link* target_link = m_robot->link(ee_map[ee_name].target_name);
         ImpedanceParam p;
-        p.manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(base_name_map[ee_name]), target_link, m_dt, false));
+        p.manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(base_name_map[ee_name]), target_link, m_dt, false, std::string(m_profile.instance_name)));
         if ( ! p.manip ) {
             std::cerr << "[" << m_profile.instance_name << "]   Invalid joint path from " << base_name_map[ee_name] << " to " << target_link->name << "!! Impedance param for " << sensor_name << " cannot be added!!" << std::endl;
             continue;

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -67,7 +67,7 @@ ImpedanceController::~ImpedanceController()
 
 RTC::ReturnCode_t ImpedanceController::onInitialize()
 {
-    std::cout << "ImpedanceController::onInitialize()" << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
     bindParameter("debugLevel", m_debugLevel, "0");
 
     // Registration: InPort/OutPort/Service
@@ -282,14 +282,14 @@ RTC::ReturnCode_t ImpedanceController::onFinalize()
 
 RTC::ReturnCode_t ImpedanceController::onActivated(RTC::UniqueId ec_id)
 {
-    std::cout << "ImpedanceController::onActivated(" << ec_id << ")" << std::endl;
+    std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
     
     return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t ImpedanceController::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << "ImpedanceController::onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   for ( std::map<std::string, ImpedanceParam>::iterator it = m_impedance_param.begin(); it != m_impedance_param.end(); it++ ) {
       if (it->second.is_active) {
           stopImpedanceControllerNoWait(it->first);

--- a/rtc/ImpedanceController/JointPathEx.cpp
+++ b/rtc/ImpedanceController/JointPathEx.cpp
@@ -86,8 +86,11 @@ Vector3 omegaFromRotEx(const Matrix33& r)
     }
 }
 
-JointPathEx::JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval)
-    : JointPath(base, end), sr_gain(1.0), manipulability_limit(0.1), manipulability_gain(0.001), maxIKPosErrorSqr(1.0e-8), maxIKRotErrorSqr(1.0e-6), maxIKIteration(50), interlocking_joint_pair_indices(), use_inside_joint_weight_retrieval(_use_inside_joint_weight_retrieval) {
+JointPathEx::JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval, const std::string& _debug_print_prefix)
+    : JointPath(base, end), sr_gain(1.0), manipulability_limit(0.1), manipulability_gain(0.001), maxIKPosErrorSqr(1.0e-8), maxIKRotErrorSqr(1.0e-6), maxIKIteration(50), interlocking_joint_pair_indices(), dt(control_cycle),
+      debug_print_prefix(_debug_print_prefix+",JointPathEx"), joint_limit_debug_print_counts(numJoints(), 0),
+      debug_print_freq_count(static_cast<size_t>(0.25/dt)), // once per 0.25[s]
+      use_inside_joint_weight_retrieval(_use_inside_joint_weight_retrieval) {
   for (int i = 0 ; i < numJoints(); i++ ) {
     joints.push_back(joint(i));
   }
@@ -96,7 +99,6 @@ JointPathEx::JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_c
   for (int i = 0 ; i < numJoints(); i++ ) {
       optional_weight_vector[i] = 1.0;
   }
-  dt = control_cycle;
 }
 
 void JointPathEx::setMaxIKError(double epos, double erot) {
@@ -393,15 +395,29 @@ bool JointPathEx::calcInverseKinematics2Loop(const Vector3& dp, const Vector3& o
 
     // upper/lower limit check
     for(int j=0; j < n; ++j){
+      bool is_limit_over = false;
       if ( joints[j]->q > joints[j]->ulimit) {
-        std::cerr << "Upper joint limit error " << joints[j]->name << std::endl;
+        is_limit_over = true;
+        if (joint_limit_debug_print_counts[j] % debug_print_freq_count == 0) {
+            std::cerr << "[" << debug_print_prefix << "] Upper joint limit over " << joints[j]->name
+                      << " (ja=" << joints[j]->q << "[rad], limit=" << joints[j]->ulimit << "[rad], count=" << joint_limit_debug_print_counts[j] << ", debug_print_freq_count=" << debug_print_freq_count << ")" << std::endl;
+        }
         joints[j]->q = joints[j]->ulimit;
       }
       if ( joints[j]->q < joints[j]->llimit) {
-        std::cerr << "Lower joint limit error " << joints[j]->name << std::endl;
+        is_limit_over = true;
+        if (joint_limit_debug_print_counts[j] % debug_print_freq_count == 0) {
+            std::cerr << "[" << debug_print_prefix << "] Lower joint limit over " << joints[j]->name
+                      << " (ja=" << joints[j]->q << "[rad], limit=" << joints[j]->llimit << "[rad], count=" << joint_limit_debug_print_counts[j] << ", debug_print_freq_count=" << debug_print_freq_count << ")" << std::endl;
+        }
         joints[j]->q = joints[j]->llimit;
       }
       joints[j]->q = std::max(joints[j]->q, joints[j]->llimit);
+      if (is_limit_over) {
+          joint_limit_debug_print_counts[j]++;
+      } else {
+          joint_limit_debug_print_counts[j] = 0; // resetting
+      }
     }
 
     calcForwardKinematics();

--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -15,7 +15,7 @@ namespace hrp {
 namespace hrp {
     class JointPathEx : public JointPath {
   public:
-    JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval = true);
+    JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval = true, const std::string& _debug_print_prefix = "");
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
     bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
@@ -53,6 +53,10 @@ namespace hrp {
         //  Currently joint1 = joint2 is assumed.
         std::vector<std::pair<size_t, size_t> > interlocking_joint_pair_indices;
         double sr_gain, manipulability_limit, manipulability_gain, dt;
+        std::string debug_print_prefix;
+        // Print message Hz management
+        std::vector<size_t> joint_limit_debug_print_counts;
+        size_t debug_print_freq_count;
         bool use_inside_joint_weight_retrieval;
     };
 

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -570,7 +570,7 @@ bool SequencePlayer::setTargetPose(const char* gname, const double *xyz, const d
     string base_parent_name = m_robot->joint(indices[0])->parent->name;
     string target_name = m_robot->joint(indices[indices.size()-1])->name;
     // prepare joint path
-    hrp::JointPathExPtr manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(base_parent_name), m_robot->link(target_name), dt));
+    hrp::JointPathExPtr manip = hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(base_parent_name), m_robot->link(target_name), dt, true, std::string(m_profile.instance_name)));
 
     // calc fk
     for (int i=0; i<m_robot->numJoints(); i++){

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -66,7 +66,7 @@ SoftErrorLimiter::~SoftErrorLimiter()
 
 RTC::ReturnCode_t SoftErrorLimiter::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   bindParameter("debugLevel", m_debugLevel, "0");
@@ -108,12 +108,12 @@ RTC::ReturnCode_t SoftErrorLimiter::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(), 
                                CosNaming::NamingContext::_duplicate(naming.getRootContext())
           )){
-      std::cerr << "failed to load model[" << prop["model"] << "] in "
+      std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "] in "
                 << m_profile.instance_name << std::endl;
       return RTC::RTC_ERROR;
   }
 
-  std::cout << "dof = " << m_robot->numJoints() << std::endl;
+  std::cout << "[" << m_profile.instance_name << "] dof = " << m_robot->numJoints() << std::endl;
   if (!m_robot->init()) return RTC::RTC_ERROR;
   m_service0.setRobot(m_robot);
   m_servoState.data.length(m_robot->numJoints());
@@ -165,13 +165,13 @@ RTC::ReturnCode_t SoftErrorLimiter::onShutdown(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t SoftErrorLimiter::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t SoftErrorLimiter::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
@@ -257,7 +257,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       // fixed joint has ulimit = vlimit
       if ( servo_state[i] == 1 && (lvlimit < uvlimit) && ((lvlimit > qvel) || (uvlimit < qvel)) ) {
         if (loop % debug_print_freq == 0 || debug_print_velocity_first ) {
-          std::cerr << "velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
+          std::cerr << "[" << m_profile.instance_name<< "] velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
                     << ", lvlimit =" << lvlimit
                     << ", uvlimit =" << uvlimit
                     << ", servo_state = " <<  ( servo_state[i] ? "ON" : "OFF") << std::endl;
@@ -286,7 +286,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       bool servo_limit_state = (llimit < ulimit) && ((llimit > m_qRef.data[i]) || (ulimit < m_qRef.data[i]));
       if ( servo_state[i] == 1 && servo_limit_state ) {
         if (loop % debug_print_freq == 0 || debug_print_position_first) {
-          std::cerr << "position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
+          std::cerr << "[" << m_profile.instance_name<< "] position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
                     << ", llimit =" << llimit
                     << ", ulimit =" << ulimit
                     << ", servo_state = " <<  ( servo_state[i] ? "ON" : "OFF")
@@ -310,7 +310,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       double error = m_qRef.data[i] - m_qCurrent.data[i];
       if ( servo_state[i] == 1 && fabs(error) > limit ) {
         if (loop % debug_print_freq == 0 || debug_print_error_first ) {
-          std::cerr << "error limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
+          std::cerr << "[" << m_profile.instance_name<< "] error limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
                     << ", qCurrent=" << m_qCurrent.data[i] << " "
                     << ", Error=" << error << " > " << limit << " (limit)"
                     << ", servo_state = " <<  ( 1 ? "ON" : "OFF");

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -235,7 +235,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
           }
       }
       stikp.push_back(ikp);
-      jpe_v.push_back(hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(ee_base), m_robot->link(ee_target), dt, false)));
+      jpe_v.push_back(hrp::JointPathExPtr(new hrp::JointPathEx(m_robot, m_robot->link(ee_base), m_robot->link(ee_target), dt, false, std::string(m_profile.instance_name))));
       // Fix for toe joint
       if (ee_name.find("leg") != std::string::npos && jpe_v.back()->numJoints() == 7) { // leg and has 7dof joint (6dof leg +1dof toe)
           std::vector<double> optw;

--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -73,6 +73,7 @@ StateHolder::~StateHolder()
 
 RTC::ReturnCode_t StateHolder::onInitialize()
 {
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   

--- a/rtc/ThermoEstimator/ThermoEstimator.cpp
+++ b/rtc/ThermoEstimator/ThermoEstimator.cpp
@@ -59,7 +59,7 @@ ThermoEstimator::~ThermoEstimator()
 
 RTC::ReturnCode_t ThermoEstimator::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   bindParameter("debugLevel", m_debugLevel, "0");
@@ -103,7 +103,7 @@ RTC::ReturnCode_t ThermoEstimator::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(),
                                CosNaming::NamingContext::_duplicate(naming.getRootContext())
         )){
-    std::cerr << "failed to load model[" << prop["model"] << "]"
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]"
               << std::endl;
   }
 
@@ -118,13 +118,13 @@ RTC::ReturnCode_t ThermoEstimator::onInitialize()
   } else {
     m_ambientTemp = 25.0;
   }
-  std::cerr <<  m_profile.instance_name << ": ambient temperature: " << m_ambientTemp << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : ambient temperature: " << m_ambientTemp << std::endl;
   
   // set motor heat parameters
   m_motorHeatParams.resize(m_robot->numJoints());
   coil::vstring motorHeatParamsFromConf = coil::split(prop["motor_heat_params"], ",");
   if (motorHeatParamsFromConf.size() != 2 * m_robot->numJoints()) {
-    std::cerr <<  "[WARN]: size of motorHeatParams is " << motorHeatParamsFromConf.size() << ", not equal to 2 * " << m_robot->numJoints() << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] [WARN]: size of motorHeatParams is " << motorHeatParamsFromConf.size() << ", not equal to 2 * " << m_robot->numJoints() << std::endl;
     // motorHeatParam has default values itself
   } else {
     for (int i = 0; i < m_robot->numJoints(); i++) {
@@ -143,7 +143,7 @@ RTC::ReturnCode_t ThermoEstimator::onInitialize()
   // set constant for joint error to torque conversion
   coil::vstring error2tauFromConf = coil::split(prop["error_to_tau_constant"], ",");
   if (error2tauFromConf.size() != m_robot->numJoints()) {
-    std::cerr <<  "[WARN]: size of error2tau is " << error2tauFromConf.size() << ", not equal to " << m_robot->numJoints() << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] [WARN]: size of error2tau is " << error2tauFromConf.size() << ", not equal to " << m_robot->numJoints() << std::endl;
     m_error2tau.resize(0); // invalid 
   } else {
     m_error2tau.resize(m_robot->numJoints());
@@ -187,13 +187,13 @@ RTC::ReturnCode_t ThermoEstimator::onInitialize()
 
 RTC::ReturnCode_t ThermoEstimator::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t ThermoEstimator::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/rtc/ThermoLimiter/ThermoLimiter.cpp
+++ b/rtc/ThermoLimiter/ThermoLimiter.cpp
@@ -56,7 +56,7 @@ ThermoLimiter::~ThermoLimiter()
 
 RTC::ReturnCode_t ThermoLimiter::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   bindParameter("debugLevel", m_debugLevel, "0");
@@ -97,14 +97,14 @@ RTC::ReturnCode_t ThermoLimiter::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(),
                                CosNaming::NamingContext::_duplicate(naming.getRootContext())
         )){
-    std::cerr << "failed to load model[" << prop["model"] << "]"
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]"
               << std::endl;
   }
   // set limit of motor temperature
   coil::vstring motorTemperatureLimitFromConf = coil::split(prop["motor_temperature_limit"], ",");
   m_motorTemperatureLimit.resize(m_robot->numJoints());
   if (motorTemperatureLimitFromConf.size() != m_robot->numJoints()) {
-    std::cerr <<  "[WARN]: size of motor_temperature_limit is " << motorTemperatureLimitFromConf.size() << ", not equal to " << m_robot->numJoints() << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] [WARN]: size of motor_temperature_limit is " << motorTemperatureLimitFromConf.size() << ", not equal to " << m_robot->numJoints() << std::endl;
     for (int i = 0; i < m_robot->numJoints(); i++) {
       m_motorTemperatureLimit[i] = 80.0;
     }
@@ -126,13 +126,13 @@ RTC::ReturnCode_t ThermoLimiter::onInitialize()
   if (prop["ambient_tmp"] != "") {
     coil::stringTo(ambientTemp, prop["ambient_tmp"].c_str());
   }
-  std::cerr <<  m_profile.instance_name << ": ambient temperature: " << ambientTemp << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : ambient temperature: " << ambientTemp << std::endl;
 
   // set limit of motor heat parameters
   coil::vstring motorHeatParamsFromConf = coil::split(prop["motor_heat_params"], ",");
   m_motorHeatParams.resize(m_robot->numJoints());
   if (motorHeatParamsFromConf.size() != 2 * m_robot->numJoints()) {
-    std::cerr <<  "[WARN]: size of motor_heat_param is " << motorHeatParamsFromConf.size() << ", not equal to 2 * " << m_robot->numJoints() << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] [WARN]: size of motor_heat_param is " << motorHeatParamsFromConf.size() << ", not equal to 2 * " << m_robot->numJoints() << std::endl;
     for (int i = 0; i < m_robot->numJoints(); i++) {
       m_motorHeatParams[i].defaultParams();
       m_motorHeatParams[i].temperature = ambientTemp;
@@ -197,13 +197,13 @@ RTC::ReturnCode_t ThermoLimiter::onShutdown(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t ThermoLimiter::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t ThermoLimiter::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] : onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/rtc/TorqueController/TorqueController.cpp
+++ b/rtc/TorqueController/TorqueController.cpp
@@ -58,7 +58,7 @@ TorqueController::~TorqueController()
 
 RTC::ReturnCode_t TorqueController::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   // <rtc-template block="bind_config">
@@ -107,7 +107,7 @@ RTC::ReturnCode_t TorqueController::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(),
                                CosNaming::NamingContext::_duplicate(naming.getRootContext())
         )){
-    std::cerr << "failed to load model[" << prop["model"] << "]"
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "]"
               << std::endl;
   }
   // make torque controller settings
@@ -236,13 +236,13 @@ RTC::ReturnCode_t TorqueController::onShutdown(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t TorqueController::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t TorqueController::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/rtc/TorqueFilter/TorqueFilter.cpp
+++ b/rtc/TorqueFilter/TorqueFilter.cpp
@@ -66,7 +66,7 @@ TorqueFilter::~TorqueFilter()
 
 RTC::ReturnCode_t TorqueFilter::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   bindParameter("debugLevel", m_debugLevel, "0");
@@ -106,7 +106,7 @@ RTC::ReturnCode_t TorqueFilter::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(),
                                CosNaming::NamingContext::_duplicate(naming.getRootContext())
         )){
-    std::cerr << "failed to load model[" << prop["model"] << "] in "
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "] in "
               << m_profile.instance_name << std::endl;
     return RTC::RTC_ERROR;
   }
@@ -117,7 +117,7 @@ RTC::ReturnCode_t TorqueFilter::onInitialize()
   // set gravity compensation flag
   coil::stringTo(m_is_gravity_compensation, prop["gravity_compensation"].c_str());
   if (m_debugLevel > 0) {
-    std::cerr <<  m_profile.instance_name << " : gravity compensation flag: " << m_is_gravity_compensation << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] : gravity compensation flag: " << m_is_gravity_compensation << std::endl;
   }
   
   // set torque offset
@@ -230,13 +230,13 @@ RTC::ReturnCode_t TorqueFilter::onInitialize()
 
 RTC::ReturnCode_t TorqueFilter::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t TorqueFilter::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/rtc/VirtualForceSensor/VirtualForceSensor.cpp
+++ b/rtc/VirtualForceSensor/VirtualForceSensor.cpp
@@ -52,7 +52,7 @@ VirtualForceSensor::~VirtualForceSensor()
 
 RTC::ReturnCode_t VirtualForceSensor::onInitialize()
 {
-  std::cout << m_profile.instance_name << ": onInitialize()" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] onInitialize()" << std::endl;
   // <rtc-template block="bind_config">
   // Bind variables and configuration variable
   bindParameter("debugLevel", m_debugLevel, "0");
@@ -93,7 +93,7 @@ RTC::ReturnCode_t VirtualForceSensor::onInitialize()
   if (!loadBodyFromModelLoader(m_robot, prop["model"].c_str(),
 			       CosNaming::NamingContext::_duplicate(naming.getRootContext())
 	  )){
-    std::cerr << "failed to load model[" << prop["model"] << "] in "
+    std::cerr << "[" << m_profile.instance_name << "] failed to load model[" << prop["model"] << "] in "
               << m_profile.instance_name << std::endl;
     return RTC::RTC_ERROR;
   }
@@ -113,14 +113,14 @@ RTC::ReturnCode_t VirtualForceSensor::onInitialize()
     p.R = Eigen::AngleAxis<double>(tr[6], hrp::Vector3(tr[3],tr[4],tr[5])).toRotationMatrix(); // rotation in VRML is represented by axis + angle
     p.forceOffset = hrp::Vector3(0, 0, 0);
     p.momentOffset = hrp::Vector3(0, 0, 0);
-    std::cerr << "virtual force sensor : " << name << std::endl;
-    std::cerr << "                base : " << p.base_name << std::endl;
-    std::cerr << "              target : " << p.target_name << std::endl;
-    std::cerr << "                T, R : " << p.p[0] << " " << p.p[1] << " " << p.p[2] << std::endl << p.R << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] virtual force sensor : " << name << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "]                 base : " << p.base_name << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "]               target : " << p.target_name << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "]                 T, R : " << p.p[0] << " " << p.p[1] << " " << p.p[2] << std::endl << p.R << std::endl;
     p.path = hrp::JointPathPtr(new hrp::JointPath(m_robot->link(p.base_name), m_robot->link(p.target_name)));
     m_sensors[name] = p;
     if ( m_sensors[name].path->numJoints() == 0 ) {
-      std::cerr << "ERROR : Unknown link path " << m_sensors[name].base_name << " " << m_sensors[name].target_name  << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "] ERROR : Unknown link path " << m_sensors[name].base_name << " " << m_sensors[name].target_name  << std::endl;
       return RTC::RTC_ERROR;
     }
   }
@@ -164,13 +164,13 @@ RTC::ReturnCode_t VirtualForceSensor::onShutdown(RTC::UniqueId ec_id)
 
 RTC::ReturnCode_t VirtualForceSensor::onActivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onActivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onActivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 
 RTC::ReturnCode_t VirtualForceSensor::onDeactivated(RTC::UniqueId ec_id)
 {
-  std::cout << m_profile.instance_name<< ": onDeactivated(" << ec_id << ")" << std::endl;
+  std::cerr << "[" << m_profile.instance_name<< "] onDeactivated(" << ec_id << ")" << std::endl;
   return RTC::RTC_OK;
 }
 

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -14,10 +14,12 @@ except:
     import time
 
 def init ():
-    global hcf
+    global hcf, hrpsys_version
     hcf = HrpsysConfigurator()
     hcf.getRTCList = hcf.getRTCListUnstable
     hcf.init ("SampleRobot(Robot)0", "$(PROJECT_DIR)/../model/sample1.wrl")
+    hrpsys_version = hcf.seq.ref.get_component_profile().version
+    print("hrpsys_version = %s"%hrpsys_version)
 
 def demo():
     init()
@@ -32,6 +34,8 @@ def demo():
     hcf.startImpedance("larm")
     hcf.stopImpedance("larm")
     hcf.stopImpedance("rarm")
+    if hrpsys_version < '315.5.0':
+        return
 
     # 1. Getter check
     print >> sys.stderr, "1. Getter check"

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -26,6 +26,13 @@ def demo():
     hcf.seq_svc.setJointAngles(initial_pose, 2.0)
     hcf.seq_svc.waitInterpolation()
 
+    # 0. startImpedance + stopImpedance python interface
+    print >> sys.stderr, "0. startImpedance + stopImpedance python interface"
+    hcf.startImpedance("rarm")
+    hcf.startImpedance("larm")
+    hcf.stopImpedance("larm")
+    hcf.stopImpedance("rarm")
+
     # 1. Getter check
     print >> sys.stderr, "1. Getter check"
     ret1=hcf.ic_svc.getImpedanceControllerParam("rarm")

--- a/test/test-samplerobot-impedance.py
+++ b/test/test-samplerobot-impedance.py
@@ -7,24 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_impedance_controller
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_impedance_controller.init()
-    hcf = samplerobot_impedance_controller.hcf
-    initial_pose = [-7.779e-005,  -0.378613,  -0.000209793,  0.832038,  -0.452564,  0.000244781,  0.31129,  -0.159481,  -0.115399,  -0.636277,  0,  0,  0,  -7.77902e-005,  -0.378613,  -0.000209794,  0.832038,  -0.452564,  0.000244781,  0.31129,  0.159481,  0.115399,  -0.636277,  0,  0,  0,  0,  0,  0]
-    hcf.seq_svc.setJointAngles(initial_pose, 2.0)
-    hcf.seq_svc.waitInterpolation()
-    hcf.startImpedance("rarm")
-    time.sleep(2)
-    hcf.startImpedance("larm")
-    time.sleep(2)
-    hcf.stopImpedance("larm")
-    hcf.stopImpedance("rarm")
+class TestSampleRobotImpedanceController(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_impedance_controller.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_impedance', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_impedance', TestSampleRobotImpedanceController, sys.argv)
 
 
 


### PR DESCRIPTION
@garaemon 
goPos中にtargetのx,y,thをかえられるようにしました。
x,y,thは、歩き始めの最初の立ち位置基準です。
```
hcf.abc_svc.goPos(0.2,0,0)
# ちょっとまつ
hcf.abc_svc.goPos(0.3,0.2,0)
```
として上がいたときに、一番最初の立ち位置基準の0.2,0,0をめざしつつ、
上書き後は一番最初の立ち位置基準の0.3,0.2,0にむかってあるいていきます。

footstep群は上書きあつかいになります。
ちゃんとしたサンプルはそのうちあげます。

setFootstepとgoPosとで、ちゃんぽんできない気がします。
（エラーチェックもまだ）

よろしくお願いします。