### PR TITLE
disable emergency stop while walking by default

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -171,6 +171,8 @@ module OpenHRP
       /// Emergency signal checking mode
       EmergencyCheckMode emergency_check_mode;
       sequence<AutoBalancerService::Footstep> end_effector_list;
+      /// whether an emergency stop is used while walking
+      boolean is_estop_while_walking;
     };
 
     /**

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -374,6 +374,7 @@ class HrpsysConfigurator:
             connectPorts(self.abc.port("controlSwingSupportTime"), self.st.port("controlSwingSupportTime"))
             connectPorts(self.rh.port("q"), self.st.port("qCurrent"))
             connectPorts(self.seq.port("qRef"), self.st.port("qRefSeq"))
+            connectPorts(self.abc.port("walkingStates"), self.st.port("walkingStates"))
             if self.es:
                 connectPorts(self.st.port("emergencySignal"), self.es.port("emergencySignal"))
             connectPorts(self.st.port("emergencySignal"), self.abc.port("emergencySignal"))

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -60,6 +60,7 @@ AutoBalancer::AutoBalancer(RTC::Manager* manager)
       m_controlSwingSupportTimeOut("controlSwingSupportTime", m_controlSwingSupportTime),
       m_cogOut("cogOut", m_cog),
       m_AutoBalancerServicePort("AutoBalancerService"),
+      m_walkingStatesOut("walkingStates", m_walkingStates),
       // </rtc-template>
       move_base_gain(0.8),
       m_robot(hrp::BodyPtr()),
@@ -99,6 +100,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     addOutPort("contactStates", m_contactStatesOut);
     addOutPort("controlSwingSupportTime", m_controlSwingSupportTimeOut);
     addOutPort("cogOut", m_cogOut);
+    addOutPort("walkingStates", m_walkingStatesOut);
   
     // Set service provider to Ports
     m_AutoBalancerServicePort.registerProvider("service0", "AutoBalancerService", m_service0);
@@ -249,6 +251,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
       gg->set_default_zmp_offsets(default_zmp_offsets);
     }
     gg_is_walking = gg_solved = false;
+    m_walkingStates.data = false;
     fix_leg_coords = coordinates();
 
     // load virtual force sensors
@@ -546,6 +549,9 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
     m_contactStatesOut.write();
     m_controlSwingSupportTime.tm = m_qRef.tm;
     m_controlSwingSupportTimeOut.write();
+    m_walkingStates.data = gg_is_walking;
+    m_walkingStates.tm = m_qRef.tm;
+    m_walkingStatesOut.write();
 
     for (unsigned int i=0; i<m_ref_forceOut.size(); i++){
         m_force[i].tm = m_qRef.tm;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -153,6 +153,8 @@ class AutoBalancer
   OutPort<TimedBooleanSeq> m_contactStatesOut;
   TimedDoubleSeq m_controlSwingSupportTime;
   OutPort<TimedDoubleSeq> m_controlSwingSupportTimeOut;
+  TimedBoolean m_walkingStates;
+  OutPort<TimedBoolean> m_walkingStatesOut;
   std::vector<TimedDoubleSeq> m_force;
   std::vector<OutPort<TimedDoubleSeq> *> m_ref_forceOut;
   std::vector<TimedPoint3D> m_limbCOPOffset;

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -52,6 +52,7 @@ Stabilizer::Stabilizer(RTC::Manager* manager)
     m_contactStatesIn("contactStates", m_contactStates),
     m_controlSwingSupportTimeIn("controlSwingSupportTime", m_controlSwingSupportTime),
     m_qRefSeqIn("qRefSeq", m_qRefSeq),
+    m_walkingStatesIn("walkingStates", m_walkingStates),
     m_qRefOut("q", m_qRef),
     m_tauOut("tau", m_tau),
     m_zmpOut("zmp", m_zmp),
@@ -109,6 +110,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   addInPort("contactStates", m_contactStatesIn);
   addInPort("controlSwingSupportTime", m_controlSwingSupportTimeIn);
   addInPort("qRefSeq", m_qRefSeqIn);
+  addInPort("walkingStates", m_walkingStatesIn);
 
   // Set OutPort buffer
   addOutPort("q", m_qRefOut);
@@ -486,6 +488,9 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
     is_seq_interpolating = true;
   } else {
     is_seq_interpolating = false;
+  }
+  if (m_walkingStatesIn.isNew()){
+    m_walkingStatesIn.read();
   }
 
   if (is_legged_robot) {

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -260,6 +260,7 @@ class Stabilizer
   double dt;
   int transition_count, loop;
   bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, initial_cp_too_large_error;
+  bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
   std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -160,6 +160,7 @@ class Stabilizer
   RTC::TimedDoubleSeq m_COPInfo;
   RTC::TimedLong m_emergencySignal;
   RTC::TimedDoubleSeq m_qRefSeq;
+  RTC::TimedBoolean m_walkingStates;
   // for debug ouput
   RTC::TimedPoint3D m_originRefZmp, m_originRefCog, m_originRefCogVel, m_originNewZmp;
   RTC::TimedPoint3D m_originActZmp, m_originActCog, m_originActCogVel;
@@ -182,6 +183,7 @@ class Stabilizer
   RTC::InPort<RTC::TimedDoubleSeq> m_controlSwingSupportTimeIn;
   std::vector<RTC::InPort<RTC::TimedPoint3D> *> m_limbCOPOffsetIn;
   RTC::InPort<RTC::TimedDoubleSeq> m_qRefSeqIn;
+  RTC::InPort<RTC::TimedBoolean> m_walkingStatesIn;
 
   std::vector<RTC::TimedDoubleSeq> m_wrenches;
   std::vector<RTC::InPort<RTC::TimedDoubleSeq> *> m_wrenchesIn;


### PR DESCRIPTION
歩行中はemergency stopが働かないようにしました．
なお，euslispから
```(send *ri* :set-st-param :is-estop-while-walking t)```
を実行すれば歩行中でもemergency stopが働くようになります．

cc: @mmurooka さん，@snozawa さん