### PR TITLE
Set is_hand_fix_mode false by default same as startautobalancer in [rleg, lleg].

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -321,7 +321,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
 
     is_stop_mode = false;
     has_ik_failed = false;
-    is_hand_fix_mode = true;
+    is_hand_fix_mode = false;
 
     pos_ik_thre = 0.1*1e-3; // [m]
     rot_ik_thre = (1e-2)*M_PI/180.0; // [rad]


### PR DESCRIPTION
is_hand_fix_mode をデフォルトfalseにかえました。
```
startAutoBalancer([rleg,lleg,rarm, larm])
```
で起動したときのデフォルトの挙動が`[rleg, lleg]`のときと同じになり、明示的に手先を固定したい人でない限り同じになります。
よろしくお願いします。