### PR TITLE
[hrpsys_config.py] connect actCapturePoint to DataLogger

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -822,6 +822,7 @@ class HrpsysConfigurator:
             self.connectLoggerPort(self.st, 'actBaseRpy')
             self.connectLoggerPort(self.st, 'currentBasePos')
             self.connectLoggerPort(self.st, 'currentBaseRpy')
+            self.connectLoggerPort(self.st, 'actCapturePoint')
             self.connectLoggerPort(self.st, 'debugData')
         if self.el != None:
             self.connectLoggerPort(self.el, 'q')


### PR DESCRIPTION
実際の重心とモデルの重心の誤差を知りたいので，actCPのログを追加しました．