### PR TITLE
Update samplerobot python unittest

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -386,7 +386,12 @@ case $TEST_PACKAGE in
                 rostest $test_file && travis_time_end || export TMP_EXIT_STATUS=$?
                 if [ "$TMP_EXIT_STATUS" != 0 ]; then
                     export EXIT_STATUS=$TMP_EXIT_STATUS
+                    # Print results of rostest-*.xml files
                     find ~/.ros/test_results -type f -iname "*`basename $test_file .test`.xml" -print -exec echo "=== {} ===" \; -exec cat {} \;
+                    # Print results of each rosunit-*.xml file
+                    #   Get rosunit*.xml file path from rostest-*.xml file by usig awk and cut.
+                    #   Files are assumed to include "xxx results are in [/home/xxx/rosunit-yy.xml]"
+                    cat $(find ~/.ros/test_results -type f -iname "*`basename $test_file .test`.xml" -print -exec echo "=== {} ===" \; -exec cat {} \; | grep "results are in" | awk -F'results are in ' '{print $2}' | cut -d\[ -f2 | cut -d\] -f1)
                     travis_time_end 31
                 fi
             done

--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -66,19 +66,19 @@ def checkJointAngles (var_doc):
         p = var_doc
     else:
         p = var_doc['pos']
-    ret = checkArrayEquality(rtm.readDataPort(hcf.sh.port("qOut")).data, p)
+    ret = checkArrayEquality(hcf.sh_svc.getCommand().jointRefs, p)
     print "  pos => ", ret
 
 def checkJointAnglesBetween(from_doc, to_doc):
     p0 =  from_doc if isinstance(from_doc, list) else from_doc['pos']
     p1 =    to_doc if isinstance(  to_doc, list) else   to_doc['pos']
-    ret = checkArrayBetween(p0, rtm.readDataPort(hcf.sh.port("qOut")).data, p1)
+    ret = checkArrayBetween(p0, hcf.sh_svc.getCommand().jointRefs, p1)
     print "  pos => ", ret
     assert(ret is True)
 
 def checkZmp(var_doc):
-    zmp=rtm.readDataPort(hcf.sh.port("zmpOut")).data
-    ret = checkArrayEquality([zmp.x, zmp.y, zmp.z], var_doc['zmp'])
+    zmp=hcf.sh_svc.getCommand().zmp
+    ret = checkArrayEquality([zmp[0], zmp[1], zmp[2]], var_doc['zmp'])
     print "  zmp => ", ret
     assert(ret is True)
 

--- a/test/test-samplerobot-abc.py
+++ b/test/test-samplerobot-abc.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_auto_balancer
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_auto_balancer.demo()
+class TestSampleRobotAutoBalancer(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_auto_balancer.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_auto_balancer', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_auto_balancer', TestSampleRobotAutoBalancer, sys.argv)
 
 
 

--- a/test/test-samplerobot-collision.py
+++ b/test/test-samplerobot-collision.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_collision_detector
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_collision_detector.demo()
+class TestSampleRobotCollisionDetector(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_collision_detector.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_collision_detector', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_collision_detector', TestSampleRobotCollisionDetector, sys.argv)
 
 
 

--- a/test/test-samplerobot-datalogger.py
+++ b/test/test-samplerobot-datalogger.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_data_logger
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_data_logger.demo()
+class TestSampleRobotDataLogger(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_data_logger.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_data_logger', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_data_logger', TestSampleRobotDataLogger, sys.argv)
 
 
 

--- a/test/test-samplerobot-el.py
+++ b/test/test-samplerobot-el.py
@@ -7,14 +7,16 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_soft_error_limiter
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_soft_error_limiter.demo()
+class TestSampleRobotSoftErrorLimiter(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_soft_error_limiter.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
     import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_soft_error_limiter', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_soft_error_limiter', TestSampleRobotSoftErrorLimiter, sys.argv)
 
 
 

--- a/test/test-samplerobot-emergency.py
+++ b/test/test-samplerobot-emergency.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_emergency_stopper
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_emergency_stopper.demo()
+class TestSampleRobotEmergencyStopper(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_emergency_stopper.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_emergency_stopper', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_emergency_stopper', TestSampleRobotEmergencyStopper, sys.argv)
 
 
 

--- a/test/test-samplerobot-kf.py
+++ b/test/test-samplerobot-kf.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_kalman_filter
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_kalman_filter.demo()
+class TestSampleRobotKalmanFilter(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_kalman_filter.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_kalman_filter', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_kalman_filter', TestSampleRobotKalmanFilter, sys.argv)
 
 
 

--- a/test/test-samplerobot-rmfo.py
+++ b/test/test-samplerobot-rmfo.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_remove_force_offset
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_remove_force_offset.demo()
+class TestSampleRobotRemoveForceOffset(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_remove_force_offset.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_remove_force_offset', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_remove_force_offset', TestSampleRobotRemoveForceOffset, sys.argv)
 
 
 

--- a/test/test-samplerobot-sequence.py
+++ b/test/test-samplerobot-sequence.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_sequence_player
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_sequence_player.demo()
+class TestSampleRobotSequencePlayer(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_sequence_player.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_sequence_player', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_sequence_player', TestSampleRobotSequencePlayer, sys.argv)
 
 
 

--- a/test/test-samplerobot-st.py
+++ b/test/test-samplerobot-st.py
@@ -7,14 +7,15 @@ from subprocess import check_output
 sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--variable=prefix']).rstrip(),'share/hrpsys/samples/SampleRobot/')) # set path to SampleRobot
 
 import samplerobot_stabilizer
+import unittest, rostest
 
-if __name__ == '__main__':
-    samplerobot_stabilizer.demo()
+class TestSampleRobotStabilizer(unittest.TestCase):
+    def test_demo (self):
+        samplerobot_stabilizer.demo()
 
 ## IGNORE ME: this code used for rostest
 if [s for s in sys.argv if "--gtest_output=xml:" in s] :
-    import unittest, rostest
-    rostest.run('hrpsys', 'samplerobot_stabilizer', unittest.TestCase, sys.argv)
+    rostest.run('hrpsys', 'samplerobot_stabilizer', TestSampleRobotStabilizer, sys.argv)
 
 
 


### PR DESCRIPTION
samplerobotのpythonサンプルのテストがunittestになってなくて、
えらーがおきてもrostestのrespawnが走らなかったので、unittestにしました。
また、出力がかくされますが、.travis.shのなかでエラーしたときに
出力をprintする箇所でrosunitの各テストの標準出力・エラー出力を出すようにしました。