### PR TITLE
get all q log

### DIFF
--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -333,6 +333,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
             for ( int i = 0; i < m_q.data.length(); i++ ) {
                 m_q.data[i] = m_qRef.data[i];
             }
+            m_q.tm = m_qRef.tm;
             m_qOut.write();
         }
     }
@@ -516,6 +517,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
             }
         }
         //
+        m_q.tm = m_qRef.tm;
         m_qOut.write();
 
         // beep sound for collision alert

--- a/rtc/TorqueController/TorqueController.cpp
+++ b/rtc/TorqueController/TorqueController.cpp
@@ -250,12 +250,7 @@ RTC::ReturnCode_t TorqueController::onExecute(RTC::UniqueId ec_id)
 { 
   m_loop++;
 
-  // make timestamp
-  coil::TimeValue coiltm(coil::gettimeofday());
   hrp::dvector dq(m_robot->numJoints());
-  RTC::Time tm;
-  tm.sec = coiltm.sec();
-  tm.nsec = coiltm.usec()*1000;
   
   // update port
   if (m_tauCurrentInIn.isNew()) {
@@ -303,7 +298,7 @@ RTC::ReturnCode_t TorqueController::onExecute(RTC::UniqueId ec_id)
     }
   }
 
-  m_qRefOut.tm = tm;
+  m_qRefOut.tm = m_qRefIn.tm;
   m_qRefOutOut.write();
 
   return RTC::RTC_OK;


### PR DESCRIPTION
ロボットが意図せず動かない時にどのRTCが犯人なのか特定したい，ということがたまにあると思うのですが，どうするのがお勧めでしょうか？

思いついた方法として，

1. rtprintで各コンポーネントの"q"を1個ずつ見ていく
1. "q"のログをすべて取る

があったので，後者のPRを作って見ました．

---

ついでですが，最新のhrpsys+最新のhrpsys_ros_bridgeではロボットがabcで歩かない気がしていますが，僕だけでしょうか？
（身近にある2台のPCで起きている．）

このPRを使って調べたところ，ros_bridgeを上げるとなぜかcoがすべての関節角度を止めてしまっている気がします．（最新のhrpsys単体では起きない）

ちなみに，hrpsys_ros_bridgeを``git clean -xfd``してforce-cmakeしてビルドしなおしてもeusからはabc/stとかのパラメータを取得できない症状も起きています．

![a](https://cloud.githubusercontent.com/assets/4509039/11894419/4f8bc388-a5ba-11e5-9e97-8c0e66227c94.png)