### PR TITLE
fix checkArrayBetween function

### DIFF
--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -59,7 +59,7 @@ def checkArrayEquality (arr1, arr2, eps=1e-7):
     return all(map(lambda x,y : abs(x-y)<eps, arr1, arr2))
 
 def checkArrayBetween (arr1, arr2, arr3, eps=1e-7):
-    return all(map(lambda x,y,z : abs(x-y)<eps or (z-x)*(y-x) > 0, arr1, arr2, arr3))
+    return all(map(lambda x,y,z : (z-y)*(x-y) <= eps, arr1, arr2, arr3))
 
 def checkJointAngles (var_doc):
     if isinstance(var_doc, list):


### PR DESCRIPTION
@snozawa さん
https://github.com/fkanehiro/hrpsys-base/blob/master/sample/SampleRobot/samplerobot_sequence_player.py#L61-L62 の`checkArrayBetween`は
arr1とarr3の間にarr2が入っているかを確認する関数だと思うのですが，
このPRの変更後の方が正しいように思うのですがご確認いただけますでしょうか．