### PR TITLE
[Stabilizer.cpp] fix typo of https://github.com/fkanehiro/hrpsys-base…

### DIFF
--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -878,8 +878,6 @@ void Stabilizer::getActualParameters ()
         }
         // Actual ee frame =>
         ikp.ee_d_foot_rpy = (target->R * ikp.localR).transpose() * (foot_origin_rot * ikp.d_foot_rpy);
-        // Convert actual world frame => actual foot_origin frame for debug data port
-        ikp.ref_moment = foot_origin_rot.transpose() * ikp.ref_moment;
       }
 
       if (eefm_use_force_difference_control) {


### PR DESCRIPTION
…/pull/895

https://github.com/fkanehiro/hrpsys-base/pull/895 のときの消し忘れでしょうか？ > @snozawa さん

上の変更のときに数行上で同じ回転行列をかけているので，二回かけてしまっているように見えます．