### PR TITLE
[AutoBalancerService.idl, StabilizerService.idl, AutoBalancer.cpp, St…

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -14,6 +14,19 @@ module OpenHRP
     typedef double DblArray4[4];
 
     /**
+     * @struct EndEffector
+     * @brief EndEffector for one limb.
+     */
+    struct EndEffector
+    {
+      /// position [m]
+      DblArray3 pos;
+      /// orientation by quaternion (w,x,y,z)
+      DblArray4 rot;
+      /// end effector name
+      string name;
+    };
+    /**
      * @struct Footstep
      * @brief Foot step for one leg.
      */
@@ -246,7 +259,7 @@ module OpenHRP
       double rot_ik_thre;
       /// Flag for fix hand while walking.
       boolean is_hand_fix_mode;
-      sequence<Footstep> end_effector_list;
+      sequence<EndEffector> end_effector_list;
     };
 
     /**

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -2,7 +2,6 @@
  * @file StabilizerService.idl
  * @brief Services for the stabilizer interface
  */
-#include "AutoBalancerService.idl"
 
 module OpenHRP
 {
@@ -60,6 +59,20 @@ module OpenHRP
      */
     struct SupportPolygonVertices {
         sequence<TwoDimensionVertex> vertices;
+    };
+
+    /**
+     * @struct EndEffector
+     * @brief EndEffector for one limb.
+     */
+    struct EndEffector
+    {
+      /// position [m]
+      DblArray3 pos;
+      /// orientation by quaternion (w,x,y,z)
+      DblArray4 rot;
+      /// end effector name
+      string name;
     };
 
     /**
@@ -171,7 +184,7 @@ module OpenHRP
       sequence< sequence<double, 3> > foot_origin_offset;
       /// Emergency signal checking mode
       EmergencyCheckMode emergency_check_mode;
-      sequence<AutoBalancerService::Footstep> end_effector_list;
+      sequence<EndEffector> end_effector_list;
       /// whether an emergency stop is used while walking
       boolean is_estop_while_walking;
     };

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1565,7 +1565,7 @@ void Stabilizer::getParameter(OpenHRP::StabilizerService::stParam& i_stp)
   i_stp.end_effector_list.length(stikp.size());
   for (size_t i = 0; i < stikp.size(); i++) {
       const rats::coordinates cur_ee = rats::coordinates(stikp.at(i).localp, stikp.at(i).localR);
-      OpenHRP::AutoBalancerService::Footstep ret_ee;
+      OpenHRP::StabilizerService::EndEffector ret_ee;
       // position
       memcpy(ret_ee.pos, cur_ee.pos.data(), sizeof(double)*3);
       // rotation
@@ -1575,7 +1575,7 @@ void Stabilizer::getParameter(OpenHRP::StabilizerService::stParam& i_stp)
       ret_ee.rot[2] = qt.y();
       ret_ee.rot[3] = qt.z();
       // name
-      ret_ee.leg = stikp.at(i).ee_name.c_str();
+      ret_ee.name = stikp.at(i).ee_name.c_str();
       // set
       i_stp.end_effector_list[i] = ret_ee;
   }
@@ -1695,7 +1695,7 @@ void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
   is_estop_while_walking = i_stp.is_estop_while_walking;
   if (control_mode == MODE_IDLE) {
       for (size_t i = 0; i < i_stp.end_effector_list.length(); i++) {
-          std::vector<STIKParam>::iterator it = std::find_if(stikp.begin(), stikp.end(), (&boost::lambda::_1->* &std::vector<STIKParam>::value_type::ee_name == std::string(i_stp.end_effector_list[i].leg)));
+          std::vector<STIKParam>::iterator it = std::find_if(stikp.begin(), stikp.end(), (&boost::lambda::_1->* &std::vector<STIKParam>::value_type::ee_name == std::string(i_stp.end_effector_list[i].name)));
           memcpy(it->localp.data(), i_stp.end_effector_list[i].pos, sizeof(double)*3);
           it->localR = (Eigen::Quaternion<double>(i_stp.end_effector_list[i].rot[0], i_stp.end_effector_list[i].rot[1], i_stp.end_effector_list[i].rot[2], i_stp.end_effector_list[i].rot[3])).normalized().toRotationMatrix();
       }


### PR DESCRIPTION
…abilizer.cpp] dupricate end-effecor struct in abc idl and st idl and delete dependency st idl to abc idl for simplicity

https://github.com/fkanehiro/hrpsys-base/pull/878 https://github.com/start-jsk/rtmros_common/pull/862 でSTとABCの2つのRTCに渡るIDLの構造体を，重複するのを避けるために，st.idlをabc.idlに依存させていましたが，

https://github.com/start-jsk/rtmros_common/pull/872 のように簡単な話ではなかったようなので， @snozawa さんと話して，重複を許してみました．