### PR TITLE
[Stabilizer.cpp, ZMPDistributor.h] do not distribute force to swing legs

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -104,6 +104,8 @@ module OpenHRP
       sequence<sequence<double, 3> > eefm_pos_damping_gain;
       /// Sequence of all end-effector position damping time constant for double support phase [s] (x,y,z).
       sequence<sequence<double, 3> > eefm_pos_time_const_support;
+      /// Sequence of all swing leg rotation spring gain (r,p,y).
+      sequence<sequence<double, 3> > eefm_swing_rot_spring_gain;
       /// Sequence of all end-effector position compensation limit [m]
       sequence<double> eefm_pos_compensation_limit;
       /// Sequence of all end-effector rot compensation limit [rad]

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -106,6 +106,8 @@ module OpenHRP
       sequence<sequence<double, 3> > eefm_pos_time_const_support;
       /// Sequence of all swing leg rotation spring gain (r,p,y).
       sequence<sequence<double, 3> > eefm_swing_rot_spring_gain;
+      /// Sequence of all swing leg position spring gain (x,y,z).
+      sequence<sequence<double, 3> > eefm_swing_pos_spring_gain;
       /// Sequence of all end-effector position compensation limit [m]
       sequence<double> eefm_pos_compensation_limit;
       /// Sequence of all end-effector rot compensation limit [rad]

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -782,6 +782,7 @@ void Stabilizer::getActualParameters ()
     if (control_mode == MODE_ST) {
       std::vector<hrp::Vector3> ee_pos, cop_pos;
       std::vector<hrp::Matrix33> ee_rot;
+      std::vector<bool> is_contact_list;
       for (size_t i = 0; i < stikp.size(); i++) {
           STIKParam& ikp = stikp[i];
           if (!is_feedback_control_enable[i]) continue;
@@ -789,6 +790,7 @@ void Stabilizer::getActualParameters ()
           ee_pos.push_back(target->p + target->R * ikp.localp);
           cop_pos.push_back(target->p + target->R * ikp.localCOPPos);
           ee_rot.push_back(target->R * ikp.localR);
+          is_contact_list.push_back(isContact(i));
           ee_name.push_back(ikp.ee_name);
           limb_gains.push_back(ikp.swing_support_gain);
           ref_force.push_back(hrp::Vector3(m_ref_wrenches[i].data[0], m_ref_wrenches[i].data[1], m_ref_wrenches[i].data[2]));
@@ -824,7 +826,7 @@ void Stabilizer::getActualParameters ()
                                              new_refzmp, hrp::Vector3(foot_origin_rot * ref_zmp + foot_origin_pos),
                                              eefm_gravitational_acceleration * total_mass, dt,
                                              DEBUGP, std::string(m_profile.instance_name),
-                                             (st_algorithm == OpenHRP::StabilizerService::EEFMQPCOP));
+                                             (st_algorithm == OpenHRP::StabilizerService::EEFMQPCOP), is_contact_list);
       } else if (st_algorithm == OpenHRP::StabilizerService::EEFMQPCOP) {
           szd->distributeZMPToForceMomentsPseudoInverse(ref_force, ref_moment,
                                              ee_pos, cop_pos, ee_rot, ee_name, limb_gains,

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -244,7 +244,7 @@ class Stabilizer
     hrp::Matrix33 localR; // Rotation of ee in end link frame (^{l}R_e = R_l^T R_e)
     // For eefm
     hrp::Vector3 d_foot_pos, d_foot_rpy, ee_d_foot_rpy;
-    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const, eefm_swing_rot_spring_gain;
+    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const, eefm_swing_rot_spring_gain, eefm_swing_pos_spring_gain;
     double eefm_pos_compensation_limit, eefm_rot_compensation_limit;
     hrp::Vector3 ref_force, ref_moment;
     double swing_support_gain, support_time;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -244,7 +244,7 @@ class Stabilizer
     hrp::Matrix33 localR; // Rotation of ee in end link frame (^{l}R_e = R_l^T R_e)
     // For eefm
     hrp::Vector3 d_foot_pos, d_foot_rpy, ee_d_foot_rpy;
-    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const;
+    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const, eefm_swing_rot_spring_gain;
     double eefm_pos_compensation_limit, eefm_rot_compensation_limit;
     hrp::Vector3 ref_force, ref_moment;
     double swing_support_gain, support_time;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -266,7 +266,7 @@ class Stabilizer
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
   std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r, rel_ee_pos;
-  std::vector <hrp::Matrix33> target_ee_R, rel_ee_rot;
+  std::vector <hrp::Matrix33> target_ee_R, rel_ee_rot, act_ee_R;
   std::vector<std::string> rel_ee_name;
   rats::coordinates target_foot_midcoords;
   hrp::Vector3 ref_zmp, ref_cog, ref_cp, ref_cogvel, rel_ref_cp, prev_ref_cog, prev_ref_zmp;

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -16,6 +16,7 @@
 #include "../ImpedanceController/JointPathEx.h"
 #include "../TorqueFilter/IIRFilter.h"
 #include <hrpUtil/MatrixSolvers.h>
+#include <boost/assign.hpp>
 
 #ifdef USE_QPOASES
 #include <qpOASES.hpp>
@@ -565,7 +566,7 @@ public:
                                         const std::vector<double>& limb_gains,
                                         const hrp::Vector3& new_refzmp, const hrp::Vector3& ref_zmp,
                                         const double total_fz, const double dt, const bool printp = true, const std::string& print_str = "",
-                                        const bool use_cop_distribution = false)
+                                        const bool use_cop_distribution = false, const std::vector<bool> is_contact_list = boost::assign::list_of(true)(true)(true)(true))
     {
         size_t ee_num = ee_name.size();
         std::vector<double> alpha_vector(ee_num), fz_alpha_vector(ee_num);
@@ -593,7 +594,7 @@ public:
         double alpha_thre = 1e-20;
         // fz_alpha inversion for weighing matrix
         for (size_t i = 0; i < fz_alpha_vector.size(); i++) {
-            fz_alpha_vector[i] = (fz_alpha_vector[i] < alpha_thre) ? 1/alpha_thre : 1/fz_alpha_vector[i];
+            fz_alpha_vector[i] = (fz_alpha_vector[i] < alpha_thre or is_contact_list.at(i) == false) ? 1/alpha_thre : 1/fz_alpha_vector[i];
         }
         for (size_t j = 0; j < fz_alpha_vector.size(); j++) {
             for (size_t i = 0; i < state_dim_one; i++) {

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -681,7 +681,7 @@ public:
                                         const std::vector<double>& limb_gains,
                                         const hrp::Vector3& new_refzmp, const hrp::Vector3& ref_zmp,
                                         const double total_fz, const double dt, const bool printp = true, const std::string& print_str = "",
-                                        const bool use_cop_distribution = false)
+                                        const bool use_cop_distribution = false, const std::vector<bool> is_contact_list = boost::assign::list_of(true)(true)(true)(true))
     {
         distributeZMPToForceMoments(ref_foot_force, ref_foot_moment,
                                     ee_pos, cop_pos, ee_rot, ee_name, limb_gains,


### PR DESCRIPTION
PLEASE DO NOT MERGE THIS YET

---

以下メモです


A. 空中にある足に力を分配しない（今回のPR）
B. 姿勢制御のダンピングのゲインを0.5から1にする(10でもいいくらい？)

- A無しB無し（現状） ： 遊脚が空中で傾く（new_refzmpが支持脚の外に出て，遊脚に力が分配されるから）

![1x2x](https://cloud.githubusercontent.com/assets/4509039/12004891/fb005586-abc2-11e5-81c4-1b32888c75ce.gif)

- A有りB無し：こけるのは，このPRで支持脚 / 遊脚の切り替えを微妙にしている？

![1o2x](https://cloud.githubusercontent.com/assets/4509039/12004892/1f10d158-abc3-11e5-8592-7ff59a534203.gif)

- A無しB有り： 遊脚が空中で傾く（理由は2つ上と同じ）

![1x2o](https://cloud.githubusercontent.com/assets/4509039/12004894/2dec3cda-abc3-11e5-95ec-df92fbfa5cfc.gif)

- A有りB有り： 遊脚が空中で傾かず，いい感じ

![1o2o](https://cloud.githubusercontent.com/assets/4509039/12004895/34f02df2-abc3-11e5-8097-9cf280a4f428.gif)


テストコード

```lisp
roseus `rospack find hrpsys_ros_bridge`/euslisp/samplerobot-interface.l "(progn                                   
  (setq *robot* (samplerobot-init))                                                                               
  (send *ri* :angle-vector (send *robot* :reset-manip-pose) 200)                                                  
  (send *ri* :wait-interpolation)                                                                                 
  (send *ri* :set-st-param :eefm-body-attitude-control-gain (list 1 1))                                           
  (send *ri* :start-auto-balancer)                                                                                
  (send *ri* :start-st)                                                                                           
  ;;(send *ri* :start-default-unstable-controllers)                                                               
  (send *ri* :set-gait-generator-param :default-step-time 1.0)                                                    
  (send *ri* :go-pos 1.2 0 0)                                                                                     
  )"
```