### PR TITLE
Add moment limit and test for turnwalk

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -108,6 +108,8 @@ module OpenHRP
       sequence<sequence<double, 3> > eefm_swing_rot_spring_gain;
       /// Sequence of all swing leg end-effector position spring gain (x,y,z).
       sequence<sequence<double, 3> > eefm_swing_pos_spring_gain;
+      /// Sequence of all end-effector end-effector-frame moment limit [Nm]
+      sequence<sequence<double, 3> > eefm_ee_moment_limit;
       /// Sequence of all end-effector position compensation limit [m]
       sequence<double> eefm_pos_compensation_limit;
       /// Sequence of all end-effector rot compensation limit [rad]

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -132,6 +132,7 @@ class Stabilizer
                                    const hrp::Vector3& DD, const hrp::Vector3& TT);
   double vlimit(double value, double llimit_value, double ulimit_value);
   hrp::Vector3 vlimit(const hrp::Vector3& value, double llimit_value, double ulimit_value);
+  hrp::Vector3 vlimit(const hrp::Vector3& value, const hrp::Vector3& limit_value);
 
   inline bool isContact (const size_t idx) // 0 = right, 1 = left
   {
@@ -244,7 +245,7 @@ class Stabilizer
     hrp::Matrix33 localR; // Rotation of ee in end link frame (^{l}R_e = R_l^T R_e)
     // For eefm
     hrp::Vector3 d_foot_pos, d_foot_rpy, ee_d_foot_rpy;
-    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const, eefm_swing_rot_spring_gain, eefm_swing_pos_spring_gain;
+    hrp::Vector3 eefm_pos_damping_gain, eefm_pos_time_const_support, eefm_rot_damping_gain, eefm_rot_time_const, eefm_swing_rot_spring_gain, eefm_swing_pos_spring_gain, eefm_ee_moment_limit;
     double eefm_pos_compensation_limit, eefm_rot_compensation_limit;
     hrp::Vector3 ref_force, ref_moment;
     double swing_support_gain, support_time;

--- a/sample/SampleRobot/samplerobot_stabilizer.py
+++ b/sample/SampleRobot/samplerobot_stabilizer.py
@@ -170,6 +170,34 @@ def demoSTLoadPattern ():
     else:
         print >> sys.stderr, "  This sample is neglected in High-gain mode simulation"
 
+def demoSTTurnWalk ():
+    print >> sys.stderr, "6. EEFMQP st + Turn walk"
+    if hcf.pdc:
+        stp = hcf.st_svc.getParameter()
+        stp.st_algorithm=OpenHRP.StabilizerService.EEFMQP
+        hcf.st_svc.setParameter(stp)
+        hcf.startAutoBalancer()
+        ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
+        org_ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
+        ggp.stride_parameter=[0.15, 0.15, 90.0, 0.05]
+        hcf.abc_svc.setGaitGeneratorParam(ggp)
+        hcf.co_svc.disableCollisionDetection()
+        hcf.startStabilizer ()
+        hcf.abc_svc.goPos(0,0,175);
+        hcf.abc_svc.waitFootSteps();
+        hcf.abc_svc.goPos(0.4,0.15,40);
+        hcf.abc_svc.waitFootSteps();
+        hcf.stopStabilizer ()
+        # Wait for non-st osscilation being samalpl
+        hcf.abc_svc.setGaitGeneratorParam(org_ggp)
+        hcf.co_svc.enableCollisionDetection()
+        ret = checkActualBaseAttitude()
+        if ret:
+            print >> sys.stderr, "  ST + Turnwalk => OK"
+        assert(ret)
+    else:
+        print >> sys.stderr, "  This sample is neglected in High-gain mode simulation"
+
 def demo():
     OPENHRP3_DIR=check_output(['pkg-config', 'openhrp3.1', '--variable=prefix']).rstrip()
     if os.path.exists(OPENHRP3_DIR+"/share/OpenHRP-3.1/sample/model/sample1_bush.wrl"):
@@ -180,6 +208,7 @@ def demo():
             demoStartStopTPCCST()
             demoStartStopEEFMQPST()
             demoSTLoadPattern()
+            demoSTTurnWalk()
     else:
         print >> sys.stderr, "Skip st test because of missing sample1_bush.wrl"
 


### PR DESCRIPTION
STでかく足先のeeローカルのモーメントのリミット値をセットできるようにしました。
デフォルトは1e4Nmで大きい値なため、limitなしと同じだと思います。

また、https://github.com/fkanehiro/hrpsys-base/pull/935 に関連して
ターン歩行を含めたテストも追加しました。

よろしくお願いします。