### PR TITLE
fix bug when overwriting footstep

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -879,6 +879,7 @@ namespace rats
     bool use_inside_step_limitation;
     std::map<leg_type, std::string> leg_type_map;
     coordinates initial_foot_mid_coords;
+    bool solved;
 
     /* preview controller parameters */
     //preview_dynamics_filter<preview_control>* preview_controller_ptr;


### PR DESCRIPTION
footstepを上書くために```overwrite_refzmp_queue``` を呼んだときに，
Autobalancerが出すcogの値が飛ぶバグがあったので，修正しました．

・いままで
![abc_cog_vel_before_x](https://cloud.githubusercontent.com/assets/11713954/12213361/219c3564-b6ba-11e5-83e2-1768397d07ab.jpg)

・このPR
![abc_cog_vel_after_x](https://cloud.githubusercontent.com/assets/11713954/12213364/314545be-b6ba-11e5-87b4-e03ed2f1675f.jpg)

```
(progn
  (load "package://hrpsys_ros_bridge_tutorials/euslisp/samplerobot-interface.l")
  (samplerobot-init)
  (setq *robot* *sr*)
  (send *ri* :angle-vector (send *robot* :angle-vector) 2000)
  (send *ri* :wait-interpolation)
  (send *ri* :start-auto-balancer)
  (send *ri* :start-st)
  (send *ri* :go-velocity 0.1 0 0)
  (unix:sleep 5)
  (send *ri* :go-stop))
```