### PR TITLE
Update JointPathEx IK

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -257,6 +257,8 @@ module OpenHRP
       sequence<Footstep> end_effector_list;
       /// Default GaitType
       GaitType default_gait_type;
+      /// Sequence of joint weight for Inverse Kinematics calculation. Sequence for all end-effectors.
+      sequence<sequence<double> > ik_optional_weight_vectors;
     };
 
     /**

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -137,10 +137,6 @@ module OpenHRP
      */
     struct FootstepParam
     {
-      /// Current right foot coords
-      Footstep rleg_coords;
-      /// Current left foot coords
-      Footstep lleg_coords;
       /// Support foot coords
       Footstep support_leg_coords;
       /// Swing foot coords, which is interpolation betwee swing_leg_src_coords and swing_leg_dst_coords

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -180,6 +180,8 @@ module OpenHRP
       sequence<AutoBalancerService::Footstep> end_effector_list;
       /// whether an emergency stop is used while walking
       boolean is_estop_while_walking;
+      /// Sequence of joint weight for Inverse Kinematics calculation. Sequence for all end-effectors.
+      sequence<sequence<double> > ik_optional_weight_vectors;
     };
 
     /**

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -912,13 +912,9 @@ void AutoBalancer::fixLegToCoords (const hrp::Vector3& fix_pos, const hrp::Matri
 
 bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param)
 {
-  hrp::Vector3 vel_p, vel_r;
-  vel_p = param.target_p0 - param.target_link->p;
-  rats::difference_rotation(vel_r, param.target_link->R, param.target_r0);
-  vel_p *= transition_interpolator_ratio * leg_names_interpolator_ratio;
-  vel_r *= transition_interpolator_ratio * leg_names_interpolator_ratio;
-  param.manip->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
+  param.manip->calcInverseKinematics2Loop(param.target_p0, param.target_r0, 1.0, 0.001, 0.01, &qrefv, transition_interpolator_ratio * leg_names_interpolator_ratio);
   // IK check
+  hrp::Vector3 vel_p, vel_r;
   vel_p = param.target_p0 - param.target_link->p;
   rats::difference_rotation(vel_r, param.target_link->R, param.target_r0);
   if (vel_p.norm() > pos_ik_thre && transition_interpolator->isEmpty()) {

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -186,8 +186,8 @@ class AutoBalancer
 
  private:
   struct ABCIKparam {
-    hrp::Vector3 target_p0, current_p0, localPos, adjust_interpolation_target_p0, adjust_interpolation_org_p0;
-    hrp::Matrix33 target_r0, current_r0, localR, adjust_interpolation_target_r0, adjust_interpolation_org_r0;
+    hrp::Vector3 target_p0, localPos, adjust_interpolation_target_p0, adjust_interpolation_org_p0;
+    hrp::Matrix33 target_r0, localR, adjust_interpolation_target_r0, adjust_interpolation_org_r0;
     rats::coordinates target_end_coords;
     hrp::Link* target_link;
     hrp::JointPathExPtr manip;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -227,7 +227,7 @@ class AutoBalancer
   std::map<std::string, ABCIKparam> ikp;
   std::map<std::string, size_t> contact_states_index_map;
   std::map<std::string, hrp::VirtualForceSensorParam> m_vfs;
-  std::vector<std::string> sensor_names, leg_names;
+  std::vector<std::string> sensor_names, leg_names, ee_vec;
   hrp::dvector qorg, qrefv;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R;

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -487,12 +487,10 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
                     hrp::Matrix33 link_frame_rot;
                     link_frame_rot = param.getOutputRot() * ee_map[it->first].localR.transpose();
                     link_frame_pos = param.getOutputPos() - link_frame_rot * ee_map[it->first].localPos;
-                    vel_p = link_frame_pos - target->p;
-                    rats::difference_rotation(vel_r, target->R, link_frame_rot);
                     hrp::JointPathExPtr manip = param.manip;
                     assert(manip);
                     //const int n = manip->numJoints();
-                    manip->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, param.avoid_gain, param.reference_gain, &qrefv);
+                    manip->calcInverseKinematics2Loop(link_frame_pos, link_frame_rot, 1.0, param.avoid_gain, param.reference_gain, &qrefv);
 
                     if ( param.transition_count < 0 ) {
                         param.transition_count++;

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -482,15 +482,11 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
                                              DEBUGP, std::string(m_profile.instance_name), it->first);
 
                     // Solve ik
-                    //   Fix ee frame objective vel => link frame objective vel
-                    hrp::Vector3 link_frame_pos;
-                    hrp::Matrix33 link_frame_rot;
-                    link_frame_rot = param.getOutputRot() * ee_map[it->first].localR.transpose();
-                    link_frame_pos = param.getOutputPos() - link_frame_rot * ee_map[it->first].localPos;
                     hrp::JointPathExPtr manip = param.manip;
                     assert(manip);
                     //const int n = manip->numJoints();
-                    manip->calcInverseKinematics2Loop(link_frame_pos, link_frame_rot, 1.0, param.avoid_gain, param.reference_gain, &qrefv);
+                    manip->calcInverseKinematics2Loop(param.getOutputPos(), param.getOutputRot(), 1.0, param.avoid_gain, param.reference_gain, &qrefv, 1.0,
+                                                      ee_map[it->first].localPos, ee_map[it->first].localR);
 
                     if ( param.transition_count < 0 ) {
                         param.transition_count++;

--- a/rtc/ImpedanceController/JointPathEx.cpp
+++ b/rtc/ImpedanceController/JointPathEx.cpp
@@ -451,10 +451,13 @@ hrp::Vector3 matrix_logEx(const hrp::Matrix33& m) {
     return mlog;
 }
 
-bool JointPathEx::calcInverseKinematics2Loop(const Vector3& target_link_p, const Matrix33& target_link_R,
+bool JointPathEx::calcInverseKinematics2Loop(const Vector3& end_effector_p, const Matrix33& end_effector_R,
                                              const double LAMBDA, const double avoid_gain, const double reference_gain, const hrp::dvector* reference_q,
-                                             const double vel_gain)
+                                             const double vel_gain,
+                                             const hrp::Vector3& localPos, const hrp::Matrix33& localR)
 {
+    hrp::Matrix33 target_link_R(end_effector_R * localR.transpose());
+    hrp::Vector3 target_link_p(end_effector_p - target_link_R * localPos);
     hrp::Vector3 vel_p(target_link_p - endLink()->p);
     // TODO : matrix_logEx should be omegaFromRotEx after checking on real robot testing.
     //hrp::Vector3 vel_r(endLink()->R * omegaFromRotEx(endLink()->R.transpose() * target_link_R));

--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -18,6 +18,9 @@ namespace hrp {
     JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval = true, const std::string& _debug_print_prefix = "");
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
     bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
+    bool calcInverseKinematics2Loop(const Vector3& target_link_p, const Matrix33& target_link_R,
+                                    const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const hrp::dvector* reference_q = NULL,
+                                    const double vel_gain = 1.0);
     bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     double getSRGain() { return sr_gain; }
     bool setSRGain(double g) { sr_gain = g; }

--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -18,9 +18,10 @@ namespace hrp {
     JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval = true, const std::string& _debug_print_prefix = "");
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
     bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
-    bool calcInverseKinematics2Loop(const Vector3& target_link_p, const Matrix33& target_link_R,
+    bool calcInverseKinematics2Loop(const Vector3& end_effector_p, const Matrix33& end_effector_R,
                                     const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const hrp::dvector* reference_q = NULL,
-                                    const double vel_gain = 1.0);
+                                    const double vel_gain = 1.0,
+                                    const hrp::Vector3& localPos = hrp::Vector3::Zero(), const hrp::Matrix33& localR = hrp::Matrix33::Identity());
     bool calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
     double getSRGain() { return sr_gain; }
     bool setSRGain(double g) { sr_gain = g; }

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1652,6 +1652,16 @@ void Stabilizer::getParameter(OpenHRP::StabilizerService::stParam& i_stp)
       // set
       i_stp.end_effector_list[i] = ret_ee;
   }
+  i_stp.ik_optional_weight_vectors.length(jpe_v.size());
+  for (size_t i = 0; i < jpe_v.size(); i++) {
+      i_stp.ik_optional_weight_vectors[i].length(jpe_v[i]->numJoints());
+      std::vector<double> ov;
+      ov.resize(jpe_v[i]->numJoints());
+      jpe_v[i]->getOptionalWeightVector(ov);
+      for (size_t j = 0; j < jpe_v[i]->numJoints(); j++) {
+          i_stp.ik_optional_weight_vectors[i][j] = ov[j];
+      }
+  }
 };
 
 void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
@@ -1772,6 +1782,14 @@ void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
   }
   contact_decision_threshold = i_stp.contact_decision_threshold;
   is_estop_while_walking = i_stp.is_estop_while_walking;
+  for (size_t i = 0; i < jpe_v.size(); i++) {
+      std::vector<double> ov;
+      ov.resize(jpe_v[i]->numJoints());
+      for (size_t j = 0; j < jpe_v[i]->numJoints(); j++) {
+          ov[j] = i_stp.ik_optional_weight_vectors[i][j];
+      }
+      jpe_v[i]->setOptionalWeightVector(ov);
+  }
   if (control_mode == MODE_IDLE) {
       for (size_t i = 0; i < i_stp.end_effector_list.length(); i++) {
           std::vector<STIKParam>::iterator it = std::find_if(stikp.begin(), stikp.end(), (&boost::lambda::_1->* &std::vector<STIKParam>::value_type::ee_name == std::string(i_stp.end_effector_list[i].leg)));
@@ -1850,6 +1868,18 @@ void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
   std::cerr << "[" << m_profile.instance_name << "]  cop_check_margin = " << cop_check_margin << "[m]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]  cp_check_margin = [" << cp_check_margin[0] << ", " << cp_check_margin[1] << ", " << cp_check_margin[2] << ", " << cp_check_margin[3] << "] [m]" << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]  contact_decision_threshold = " << contact_decision_threshold << "[N]" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   ik_optional_weight_vectors = ";
+  for (size_t i = 0; i < jpe_v.size(); i++) {
+      std::vector<double> ov;
+      ov.resize(jpe_v[i]->numJoints());
+      jpe_v[i]->getOptionalWeightVector(ov);
+      std::cerr << "[";
+      for (size_t j = 0; j < jpe_v[i]->numJoints(); j++) {
+          std::cerr << ov[j] << " ";
+      }
+      std::cerr << "]";
+  }
+  std::cerr << std::endl;
 }
 
 std::string Stabilizer::getStabilizerAlgorithmString (OpenHRP::StabilizerService::STAlgorithm _st_algorithm)

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1259,11 +1259,7 @@ void Stabilizer::calcTPCC() {
         m_robot->calcForwardKinematics();
         for (size_t i = 0; i < stikp.size(); i++) {
           if (is_ik_enable[i]) {
-              hrp::Link* target = m_robot->link(stikp[i].target_name);
-              hrp::Vector3 vel_p, vel_r;
-              vel_p = target_link_p[i] - target->p;
-              rats::difference_rotation(vel_r, target->R, target_link_R[i]);
-              jpe_v[i]->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
+              jpe_v[i]->calcInverseKinematics2Loop(target_link_p[i], target_link_R[i], 1.0, 0.001, 0.01, &qrefv, transition_smooth_gain);
           }
         }
       }
@@ -1412,13 +1408,7 @@ void Stabilizer::calcEEForceMomentControl() {
       for (size_t jj = 0; jj < 3; jj++) {
         for (size_t i = 0; i < stikp.size(); i++) {
           if (is_ik_enable[i]) {
-              hrp::Link* target = m_robot->link(stikp[i].target_name);
-              hrp::Vector3 vel_p, vel_r;
-              vel_p = target_link_p[i] - target->p;
-              rats::difference_rotation(vel_r, target->R, target_link_R[i]);
-              vel_p *= transition_smooth_gain;
-              vel_r *= transition_smooth_gain;
-              jpe_v[i]->calcInverseKinematics2Loop(vel_p, vel_r, 1.0, 0.001, 0.01, &qrefv);
+              jpe_v[i]->calcInverseKinematics2Loop(target_link_p[i], target_link_R[i], 1.0, 0.001, 0.01, &qrefv, transition_smooth_gain);
           }
         }
       }


### PR DESCRIPTION
JointPathExのIKまわりを更新しました
- AutoBalancerの不要なcurrent_p, current_rを削除しました
- JointPathExでcalcInverseKinematicsLoop関数で、引数がvelだけでなくposもとれるようにしました。一部matrix_log （omegaFromRot相当）は確認が必要で、残してあります。
- JointPahtExにエンドエフェクタオフセット(move-target)するIKを移しました
- ik weight vectorをAutoBalanc,er Stabilizerでセットできるようにしました

よろしくお願いします。