### PR TITLE
Use IKLimbParameters instead of each sequence paraemters for IK of AutoBalancer and Stabilizer.

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -224,6 +224,23 @@ module OpenHRP
     };
 
     /**
+     * @enum IKLimbParameters
+     * @brief IKLimbParameters
+     */
+    struct IKLimbParameters {
+        /// Joint weight for Inverse Kinematics calculation.
+        sequence<double> ik_optional_weight_vector;
+        /// SR-inverse gain for inverse kinematics.
+        double sr_gain;
+        /// Avoid joint limit gain for inverse kinematics.
+        double avoid_gain;
+        /// Reference joint angles tracking gain for inverse kinematics.
+        double reference_gain;
+        /// Manipulability limit for inverse kinematics.
+        double manipulability_limit;
+    };
+
+    /**
      * @struct AutoBalancerParam
      * @brief Parameters for AutoBalancer
      */
@@ -257,16 +274,8 @@ module OpenHRP
       sequence<Footstep> end_effector_list;
       /// Default GaitType
       GaitType default_gait_type;
-      /// Sequence of joint weight for Inverse Kinematics calculation. Sequence for all end-effectors.
-      sequence<sequence<double> > ik_optional_weight_vectors;
-      /// Sequence of SR-inverse gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> sr_gains;
-      /// Sequence of avoid joint limit gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> avoid_gains;
-      /// Sequence of reference joint angles tracking gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> reference_gains;
-      /// Sequence of manipulability limit for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> manipulability_limits;
+      /// Sequence for all end-effectors' ik limb parameters
+      sequence<IKLimbParameters> ik_limb_parameters;
     };
 
     /**

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -63,6 +63,23 @@ module OpenHRP
     };
 
     /**
+     * @enum IKLimbParameters
+     * @brief IKLimbParameters
+     */
+    struct IKLimbParameters {
+        /// Joint weight for Inverse Kinematics calculation.
+        sequence<double> ik_optional_weight_vector;
+        /// SR-inverse gain for inverse kinematics.
+        double sr_gain;
+        /// Avoid joint limit gain for inverse kinematics.
+        double avoid_gain;
+        /// Reference joint angles tracking gain for inverse kinematics.
+        double reference_gain;
+        /// Manipulability limit for inverse kinematics.
+        double manipulability_limit;
+    };
+
+    /**
      * @struct stParam
      * @brief Stabilizer Parameters.
      */
@@ -180,16 +197,8 @@ module OpenHRP
       sequence<AutoBalancerService::Footstep> end_effector_list;
       /// whether an emergency stop is used while walking
       boolean is_estop_while_walking;
-      /// Sequence of joint weight for Inverse Kinematics calculation. Sequence for all end-effectors.
-      sequence<sequence<double> > ik_optional_weight_vectors;
-      /// Sequence of SR-inverse gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> sr_gains;
-      /// Sequence of avoid joint limit gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> avoid_gains;
-      /// Sequence of reference joint angles tracking gain for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> reference_gains;
-      /// Sequence of manipulability limit for inverse kinematics. Sequence for all end-effectors.
-      sequence<double> manipulability_limits;
+      /// Sequence for all end-effectors' ik limb parameters
+      sequence<IKLimbParameters> ik_limb_parameters;
     };
 
     /**

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1577,16 +1577,17 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
   }
   for (size_t i = 0; i < ee_vec.size(); i++) {
       ABCIKparam& param = ikp[ee_vec[i]];
+      const OpenHRP::AutoBalancerService::IKLimbParameters& ilp = i_param.ik_limb_parameters[i];
       std::vector<double> ov;
       ov.resize(param.manip->numJoints());
       for (size_t j = 0; j < param.manip->numJoints(); j++) {
-          ov[j] = i_param.ik_optional_weight_vectors[i][j];
+          ov[j] = ilp.ik_optional_weight_vector[j];
       }
       param.manip->setOptionalWeightVector(ov);
-      param.manip->setSRGain(i_param.sr_gains[i]);
-      param.avoid_gain = i_param.avoid_gains[i];
-      param.reference_gain = i_param.reference_gains[i];
-      param.manip->setManipulabilityLimit(i_param.manipulability_limits[i]);
+      param.manip->setSRGain(ilp.sr_gain);
+      param.avoid_gain = ilp.avoid_gain;
+      param.reference_gain = ilp.reference_gain;
+      param.manip->setManipulabilityLimit(ilp.manipulability_limit);
   }
   for (std::map<std::string, ABCIKparam>::iterator it = ikp.begin(); it != ikp.end(); it++) {
       std::cerr << "[" << m_profile.instance_name << "] End Effector [" << it->first << "]" << std::endl;
@@ -1706,24 +1707,21 @@ bool AutoBalancer::getAutoBalancerParam(OpenHRP::AutoBalancerService::AutoBalanc
   case GALLOP: i_param.default_gait_type = OpenHRP::AutoBalancerService::GALLOP; break;
   default: break;
   }
-  i_param.ik_optional_weight_vectors.length(ee_vec.size());
-  i_param.sr_gains.length(ee_vec.size());
-  i_param.avoid_gains.length(ee_vec.size());
-  i_param.reference_gains.length(ee_vec.size());
-  i_param.manipulability_limits.length(ee_vec.size());
+  i_param.ik_limb_parameters.length(ee_vec.size());
   for (size_t i = 0; i < ee_vec.size(); i++) {
       ABCIKparam& param = ikp[ee_vec[i]];
-      i_param.ik_optional_weight_vectors[i].length(param.manip->numJoints());
+      OpenHRP::AutoBalancerService::IKLimbParameters& ilp = i_param.ik_limb_parameters[i];
+      ilp.ik_optional_weight_vector.length(param.manip->numJoints());
       std::vector<double> ov;
       ov.resize(param.manip->numJoints());
       param.manip->getOptionalWeightVector(ov);
       for (size_t j = 0; j < param.manip->numJoints(); j++) {
-          i_param.ik_optional_weight_vectors[i][j] = ov[j];
+          ilp.ik_optional_weight_vector[j] = ov[j];
       }
-      i_param.sr_gains[i] = param.manip->getSRGain();
-      i_param.avoid_gains[i] = param.avoid_gain;
-      i_param.reference_gains[i] = param.reference_gain;
-      i_param.manipulability_limits[i] = param.manip->getManipulabilityLimit();
+      ilp.sr_gain = param.manip->getSRGain();
+      ilp.avoid_gain = param.avoid_gain;
+      ilp.reference_gain = param.reference_gain;
+      ilp.manipulability_limit = param.manip->getManipulabilityLimit();
   }
   return true;
 };


### PR DESCRIPTION
AutoBalancer, StabilzierのIKパラメータを設定している部分を修正しました．
各パラメータをlimbごとにsequenceとしていたのを，すべてのlimbパラメータがまとまったstructを用意してそのsequenceとしました．
整理の目的ですが，これでdownstream（でこれから報告します）のrosbridgeでパラメータがうまくせっとできない問題も回避されます．

よろしくお願いします．