### PR TITLE
Add fall direction

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -43,7 +43,8 @@ module OpenHRP
     enum EmergencyCheckMode {
       NO_CHECK,
       COP,
-      CP
+      CP,
+      TILT
     };
 
     /**

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -189,6 +189,8 @@ module OpenHRP
       double cop_check_margin;
       /// CP margin [m] (front, rear, inside, outside)
       DblArray4 cp_check_margin;
+      /// tilt margin [rad] (single support phase, double support phase) from reference floor
+      DblArray2 tilt_margin;
       /// ref_CP [m] (x,y) (foot_origin relative coordinate)
       DblArray2 ref_capture_point;
       /// act_CP [m] (x,y) (foot_origin relative coordinate)

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -439,6 +439,7 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
         // if (!is_stop_mode) {
         //     std::cerr << "[" << m_profile.instance_name << "] emergencySignal is set!" << std::endl;
         //     is_stop_mode = true;
+        //     gg->emergency_stop();
         // }
     }
 

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1182,11 +1182,14 @@ void Stabilizer::calcStateForEmergencySignal()
       double total_force = 0.0;
       for (size_t i = 0; i < stikp.size(); i++) {
           if (is_zmp_calc_enable[i]) {
-              if (projected_normal.at(i).norm() > sin(tilt_margin[0])) {
-                  will_fall = true;
-                  if (loop % static_cast <int>(1.0/dt) == 0 ) { // once per 1.0[s]
-                      std::cerr << "[" << m_profile.instance_name << "] " << stikp[i].ee_name << " cannot support total weight, "
-                                << "otherwise robot will fall down toward " << "(" << projected_normal.at(i)(0) << "," << projected_normal.at(i)(1) << ") direction" << std::endl;
+              if (is_walking) {
+                  if (projected_normal.at(i).norm() > sin(tilt_margin[0])) {
+                      will_fall = true;
+                      std::cerr << "swgsuptime : " << m_controlSwingSupportTime.data[i] << ", state : " << contact_states[i] << std::endl;
+                      if (loop % static_cast <int>(1.0/dt) == 0 ) { // once per 1.0[s]
+                          std::cerr << "[" << m_profile.instance_name << "] " << stikp[i].ee_name << " cannot support total weight, "
+                                    << "otherwise robot will fall down toward " << "(" << projected_normal.at(i)(0) << "," << projected_normal.at(i)(1) << ") direction" << std::endl;
+                      }
                   }
               }
               fall_direction += projected_normal.at(i) * act_force.at(i).norm();

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -268,7 +268,7 @@ class Stabilizer
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
-  std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r, rel_ee_pos, d_pos_swing, d_rpy_swing;
+  std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r, rel_ee_pos, d_pos_swing, d_rpy_swing, projected_normal, act_force;
   std::vector <hrp::Matrix33> target_ee_R, rel_ee_rot, act_ee_R;
   std::vector<std::string> rel_ee_name;
   rats::coordinates target_foot_midcoords;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -296,7 +296,7 @@ class Stabilizer
   hrp::Vector3 new_refzmp, rel_cog, ref_zmp_aux;
   hrp::Vector3 pos_ctrl;
   double total_mass, transition_time, cop_check_margin, contact_decision_threshold;
-  std::vector<double> cp_check_margin;
+  std::vector<double> cp_check_margin, tilt_margin;
   OpenHRP::StabilizerService::EmergencyCheckMode emergency_check_mode;
 };
 


### PR DESCRIPTION
@snozawa さん，歩行中に転倒しそうになったときに歩行を止めたくて，
（判定方法・回避方法などなどいろいろありそうで，難しい問題なのかもしれませんが）
その一例としてこのPRのように足平の傾きを見るのはダメでしょうか？

歩いていて何か踏んづけたときは

1. 「double support phaseだろうが耐えられない」
2. 「double support phaseなら耐えられるけどsingle support phaseなら耐えられない」
3. 「single support phaseでも耐えられる」

の3段階に分けられると思っていて，
このPRは2に相当するケースでabcに緊急停止シグナルを送って止める，ということを狙って，
その閾値をパラチュンできるようにしています．

以下がまっすぐ歩く司令を送っている際に途中で止まる様子です．

![b](https://cloud.githubusercontent.com/assets/4509039/12507912/0df9d39a-c13c-11e5-9444-cc15bd5a102e.gif)

今回は傾きのみの判定ですが，反力の有無とかも試したいと思っています．

ご確認よろしくお願いします．