### PR TITLE
[Stabilizer.cpp, Stabilizer.h] fix swing leg modification rule

### DIFF
--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -268,7 +268,7 @@ class Stabilizer
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
-  std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r, rel_ee_pos, d_pos_swing, d_rpy_swing;
+  std::vector <hrp::Vector3> target_ee_p, target_ee_diff_p, target_ee_diff_r, prev_target_ee_diff_r, rel_ee_pos, d_pos_swing, d_rpy_swing, act_ee_p;
   std::vector <hrp::Matrix33> target_ee_R, rel_ee_rot, act_ee_R;
   std::vector<std::string> rel_ee_name;
   rats::coordinates target_foot_midcoords;


### PR DESCRIPTION
式が微妙におかしかったことに気づいたので修正しました．
デフォルトの挙動は変えていないつもりです．

以下メモ

```lisp
(progn
  (load "package://hrpsys_ros_bridge_jvrc/euslisp/jaxon_jvrc-interface.l")
  (setq *robot* (jaxon_jvrc-init))
  (send *ri* :set-gait-generator-param :default-step-height 0.1 :default-step-time 1 :default-orbit-type 2)
  (send *ri* :stop-st)
  (send *ri* :set-st-param :st-algorithm 3)
  (send *ri* :start-st)
  (let ((pos-gain 1.0)
        (rot-gain 1.0)
        (body-gain 10)
        (time-const 0.7))
    (send *ri* :set-st-param
          :eefm-body-attitude-control-gain (list body-gain body-gain)
          :eefm-swing-rot-spring-gain (list (float-vector rot-gain rot-gain 0)
                                            (float-vector rot-gain rot-gain 0)
                                            (float-vector rot-gain rot-gain 0)
                                            (float-vector rot-gain rot-gain 0))
          :eefm-swing-pos-spring-gain (list (float-vector 0 0 pos-gain)
                                            (float-vector 0 0 pos-gain)
                                            (float-vector 0 0 pos-gain)
                                            (float-vector 0 0 pos-gain))
          :eefm-swing-rot-time-const (list (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const))
          :eefm-swing-pos-time-const (list (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const)
                                           (float-vector time-const time-const time-const))
          ))
  (send *ri* :go-velocity 1 0 0)
  (read-line)
  (send *ri* :go-stop))
```