### PR TITLE
Add quaternion kf test

### DIFF
--- a/rtc/KalmanFilter/EKFilter.h
+++ b/rtc/KalmanFilter/EKFilter.h
@@ -17,7 +17,8 @@ public:
     : P(hrp::Matrix77::Identity() * 0.1),
       Q(Eigen::Matrix3d::Identity() * 0.001),
       R(Eigen::Matrix3d::Identity() * 0.03),
-      g_vec(Eigen::Vector3d(0.0, 0.0, 9.80665))
+      g_vec(Eigen::Vector3d(0.0, 0.0, 9.80665)),
+      z_k(Eigen::Vector3d(0.0, 0.0, 9.80665))
   {
     x << 1, 0, 0, 0, 0, 0, 0;
   }
@@ -119,6 +120,7 @@ public:
   void correction(const Eigen::Vector3d& z) {
     Eigen::Vector4d q_a_priori = x_a_priori.head<4>();
     Eigen::Matrix<double, 3, 7> H;
+    z_k = z;
     Eigen::Vector3d y = calcMeasurementResidual(z, q_a_priori);
     calcH(H, q_a_priori);
     Eigen::Matrix3d S = H * P_a_priori * H.transpose() + R;
@@ -146,11 +148,16 @@ public:
   };
 
   void setdt (const double _dt) { dt = _dt;};
+  void resetKalmanFilterState() {
+    Eigen::Quaternion<double> tmp_q;
+    tmp_q.setFromTwoVectors(z_k, g_vec);
+    x << tmp_q.w(), tmp_q.x(), tmp_q.y(), tmp_q.z(), 0, 0, 0;
+  };
 private:
   hrp::Vector7 x, x_a_priori;
   hrp::Matrix77 P, P_a_priori;
   Eigen::Matrix3d Q, R;
-  Eigen::Vector3d g_vec;
+  Eigen::Vector3d g_vec, z_k;
   double dt;
 };
 

--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -309,6 +309,7 @@ bool KalmanFilter::setKalmanFilterParam(const OpenHRP::KalmanFilterService::Kalm
 bool KalmanFilter::resetKalmanFilterState()
 {
     rpy_kf.resetKalmanFilterState();
+    ekf_filter.resetKalmanFilterState();
 };
 
 bool KalmanFilter::getKalmanFilterParam(OpenHRP::KalmanFilterService::KalmanFilterParam& i_param)

--- a/sample/Sample6dofRobot/Sample6dofRobot.xml.in
+++ b/sample/Sample6dofRobot/Sample6dofRobot.xml.in
@@ -23,9 +23,10 @@
    <property name="outport" value="tau:JOINT_TORQUE"/>
    <property name="outport" value="gyrometer:gyrometer:RATE_GYRO_SENSOR"/>
    <property name="outport" value="gsensor:gsensor:ACCELERATION_SENSOR"/>
+   <property name="outport" value="WAIST:link6:ABS_TRANSFORM"/>
    <property name="WAIST.NumOfAABB" value="1"/>
    <property name="WAIST.translation" value="0  0  0.25"/>
-   <property name="WAIST.rotation" value="1 0 0 0"/>
+   <property name="WAIST.rotation" value="0 1 0 1.4835298641951802"/> <!-- rotate 85 degree around Y-axis -->
    <property name="WAIST.mode" value="Torque"/>
    <property name="controller" value="Sample6dofRobot"/>
    <property name="link1.angle" value="0.0"/>

--- a/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
+++ b/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
@@ -52,7 +52,7 @@ def test_kf_plot (time, av1, av2, av3, optional_out_file_name): # time [s]
     plt.title("KF actual-estimated data (motion time = {0}[s], {1})".format(time,optional_out_file_name))
     plt.legend(("Actual roll", "Estimated roll",
                 "Actual pitch", "Estimated pitch",
-                "Actual yaw", "Estimated yaw"))
+                "Actual yaw", "Estimated yaw"), loc=0)
     plt.savefig("/tmp/test-kf-sample6dofrobot-data-{0}s-{1}.eps".format(time,optional_out_file_name))
 
 def demo():

--- a/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
+++ b/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
@@ -74,9 +74,10 @@ def demo():
         print "setKalmanFilterParam() => OK"
 
     # 3. check log and plot
+    offset = math.radians(85)   # we need this because we rotate waist of this robot in xml file.
     for tm in [4, 1]:
-        test_kf_plot(tm, [0,0,0,0,1,0],   [0,0,0,0,-1,0],    [0,0,0,0,0,0],   "r0-ptest")
-        test_kf_plot(tm, [0,0,0,0,1,0.8], [0,0,0,0,-1,0.8],  [0,0,0,0,0,0.8], "r1-ptest")
-        test_kf_plot(tm, [0,0,0,0,0,0.8], [0,0,0,0,0,-0.8],  [0,0,0,0,0,0],   "p0-rtest")
-        test_kf_plot(tm, [0,0,0,0,1,0.8], [0,0,0,0,1,-0.8],  [0,0,0,0.0,1,0], "p1-rtest")
-        test_kf_plot(tm, [0,0,0,0,1,0.8], [0,0,0,0,-1,-0.8], [0,0,0,0,0,0],   "rptest")
+        test_kf_plot(tm, [0,0,0,0,1-offset,0],   [0,0,0,0,-1-offset,0],    [0,0,0,0,0-offset,0],   "r0-ptest")
+        test_kf_plot(tm, [0,0,0,0,1-offset,0.8], [0,0,0,0,-1-offset,0.8],  [0,0,0,0,0-offset,0.8], "r1-ptest")
+        test_kf_plot(tm, [0,0,0,0,0-offset,0.8], [0,0,0,0,0-offset,-0.8],  [0,0,0,0,0-offset,0],   "p0-rtest")
+        test_kf_plot(tm, [0,0,0,0,1-offset,0.8], [0,0,0,0,1-offset,-0.8],  [0,0,0,0.0,1-offset,0], "p1-rtest")
+        test_kf_plot(tm, [0,0,0,0,1-offset,0.8], [0,0,0,0,-1-offset,-0.8], [0,0,0,0,0-offset,0],   "rptest")

--- a/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
+++ b/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
@@ -37,14 +37,15 @@ def test_kf_plot (time, av1, av2, av3, optional_out_file_name): # time [s]
     kf_ret=[]
     for line in open("/tmp/test-kf-sample6dofrobot-{0}s.kf_rpy".format(time), "r"):
         kf_ret.append(line.split(" ")[0:-1])
-    seq_ret=[]
-    for line in open("/tmp/test-kf-sample6dofrobot-{0}s.sh_qOut".format(time,optional_out_file_name), "r"):
-        seq_ret.append(line.split(" ")[0:-1])
-    initial_sec=int(seq_ret[0][0].split(".")[0])
-    tm_list=map (lambda x : int(x[0].split(".")[0])-initial_sec + float(x[0].split(".")[1]) * 1e-6, seq_ret)
+    #  Actual rpy from simualtor : time, posx, posy, posz, roll, pitch, yaw
+    act_rpy_ret=[]
+    for line in open("/tmp/test-kf-sample6dofrobot-{0}s.Sample6dofRobot(Robot)0_WAIST".format(time), "r"):
+        act_rpy_ret.append(line.split(" ")[0:-1])
+    initial_sec=int(act_rpy_ret[0][0].split(".")[0])
+    tm_list=map (lambda x : int(x[0].split(".")[0])-initial_sec + float(x[0].split(".")[1]) * 1e-6, act_rpy_ret)
     plt.clf()
     for idx in range(3):
-        plt.plot(tm_list, map(lambda x : 180.0 * float(x[4+(2-idx)]) / math.pi, seq_ret))
+        plt.plot(tm_list, map(lambda x : 180.0 * float(x[4+idx]) / math.pi, act_rpy_ret))
         plt.plot(tm_list, map(lambda x : 180.0 * float(x[1+idx]) / math.pi, kf_ret), ":")
     plt.xlabel("Time [s]")
     plt.ylabel("Angle [deg]")

--- a/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
+++ b/sample/Sample6dofRobot/sample6dofrobot_kalman_filter.py.in
@@ -82,3 +82,10 @@ def demo():
         test_kf_plot(tm, [0,0,0,0,0-offset,0.8], [0,0,0,0,0-offset,-0.8],  [0,0,0,0,0-offset,0],   "p0-rtest")
         test_kf_plot(tm, [0,0,0,0,1-offset,0.8], [0,0,0,0,1-offset,-0.8],  [0,0,0,0.0,1-offset,0], "p1-rtest")
         test_kf_plot(tm, [0,0,0,0,1-offset,0.8], [0,0,0,0,-1-offset,-0.8], [0,0,0,0,0-offset,0],   "rptest")
+
+    # 4. check singularity
+    for alg in [OpenHRP.KalmanFilterService.RPYKalmanFilter, OpenHRP.KalmanFilterService.QuaternionExtendedKalmanFilter]:
+        kfp.kf_algorithm = alg
+        hcf.kf_svc.setKalmanFilterParam(kfp)
+        test_kf_plot(3, [0,0,0,0,math.radians(90),0],   [0,0,0,0,math.radians(-90),0],    [0,0,0,0,0,0],   "singularity-test-pitch-"+str(alg))
+        test_kf_plot(3, [0,0,0,math.radians(90),0,0],   [0,0,0,math.radians(-90),0,0],    [0,0,0,0,0,0],   "singularity-test-yaw-"+str(alg))


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/955#issuecomment-187585450 の @k-okada 先生のコメントを受けて，Quaternionを使った姿勢推定のテストコードを加えました．

RPYを使った姿勢推定と比較して特異点付近でも姿勢推定を行えていることを確認できるようになりました．

- test1 : Quaternionバージョン
![1](https://cloud.githubusercontent.com/assets/4509039/13283993/b2fe4d28-db34-11e5-8227-84cc5f5b1927.jpg)

- test1 : RPYバージョン
![2](https://cloud.githubusercontent.com/assets/4509039/13283994/b31d065a-db34-11e5-8194-cf4a53d3d89a.jpg)

- test2 : Quaternionバージョン
![3](https://cloud.githubusercontent.com/assets/4509039/13283995/b3350052-db34-11e5-9468-c8e27510491a.jpg)

- test2 : RPYバージョン
![4](https://cloud.githubusercontent.com/assets/4509039/13283996/b33539d2-db34-11e5-81af-f95a3d1f1bc0.jpg)