### PR TITLE
Add Beeper RTC

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -247,6 +247,11 @@ class HrpsysConfigurator:
     log_version = None
     log_use_owned_ec = False
 
+    # Beeper
+    bp = None
+    bp_svc = None
+    bp_version = None
+
     # rtm manager
     ms = None
 
@@ -496,6 +501,16 @@ class HrpsysConfigurator:
         if self.es:
             connectPorts(self.rh.port("servoState"), self.es.port("servoStateIn"))
 
+        if self.bp:
+            if self.tl:
+                connectPorts(self.tl.port("beepCommand"), self.bp.port("beepCommand"))
+            if self.es:
+                connectPorts(self.es.port("beepCommand"), self.bp.port("beepCommand"))
+            if self.el:
+                connectPorts(self.el.port("beepCommand"), self.bp.port("beepCommand"))
+            if self.co:
+                connectPorts(self.co.port("beepCommand"), self.bp.port("beepCommand"))
+
     def activateComps(self):
         '''!@brief
         Activate components(plugins)
@@ -676,9 +691,10 @@ class HrpsysConfigurator:
             ['co', "CollisionDetector"],
             ['tc', "TorqueController"],
             ['te', "ThermoEstimator"],
-            ['tl', "ThermoLimiter"],
             ['hes', "EmergencyStopper"],
             ['el', "SoftErrorLimiter"],
+            ['tl', "ThermoLimiter"],
+            ['bp', "Beeper"],
             ['log', "DataLogger"]
             ]
 

--- a/rtc/Beeper/Beeper.cpp
+++ b/rtc/Beeper/Beeper.cpp
@@ -1,0 +1,208 @@
+// -*- C++ -*-
+/*!
+ * @file  Beeper.cpp
+ * @brief Beeper component
+ * $Date$
+ *
+ * $Id$
+ */
+
+#include "Beeper.h"
+#include <rtm/CorbaNaming.h>
+
+// Variables for beep_thread
+int beep_length = 0;
+int beep_freq = 1000;
+bool beep_start = false;
+pthread_mutex_t beep_mutex;  // Mutex
+
+// Module specification
+// <rtc-template block="module_spec">
+static const char* beeper_spec[] =
+  {
+    "implementation_id", "Beeper",
+    "type_name",         "Beeper",
+    "description",       "beeper",
+    "version",           HRPSYS_PACKAGE_VERSION,
+    "vendor",            "AIST",
+    "category",          "example",
+    "activity_type",     "DataFlowComponent",
+    "max_instance",      "10",
+    "language",          "C++",
+    "lang_type",         "compile",
+    // Configuration variables
+    "conf.default.debugLevel", "0",
+    ""
+  };
+// </rtc-template>
+
+void* call_beep (void* args)
+{
+  init_beep();
+  while (1) {
+    usleep(1000);
+    pthread_mutex_lock( &beep_mutex );
+    if (beep_start) {
+      start_beep(beep_freq, beep_length);
+    } else {
+      stop_beep();
+    }
+    pthread_mutex_unlock( &beep_mutex );
+  }
+  quit_beep();
+}
+
+Beeper::Beeper(RTC::Manager* manager)
+  : RTC::DataFlowComponentBase(manager),
+    // <rtc-template block="initializer">
+    m_dt(0.002),
+    m_beepCommandIn("beepCommand", m_beepCommand),
+    m_debugLevel(0)
+{
+  pthread_create(&beep_thread, NULL, call_beep, (void*)NULL);
+  pthread_mutex_init( &beep_mutex, NULL );
+}
+
+Beeper::~Beeper()
+{
+  pthread_join(beep_thread, NULL );
+}
+
+RTC::ReturnCode_t Beeper::onInitialize()
+{
+  std::cerr << "[" << m_profile.instance_name << "] : onInitialize()" << std::endl;
+  // <rtc-template block="bind_config">
+  // Bind variables and configuration variable
+  bindParameter("debugLevel", m_debugLevel, "0");
+  
+  // </rtc-template>
+
+  // Registration: InPort/OutPort/Service
+  // <rtc-template block="registration">
+  // Set InPort buffers
+  addInPort("beepCommand", m_beepCommandIn);
+
+  // Set OutPort buffer
+
+  // Set service consumers to Ports
+
+  // Set CORBA Service Ports
+
+  // </rtc-template>
+
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t Beeper::onFinalize()
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onStartup(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onShutdown(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+RTC::ReturnCode_t Beeper::onActivated(RTC::UniqueId ec_id)
+{
+  std::cerr << "[" << m_profile.instance_name << "] : onActivated(" << ec_id << ")" << std::endl;
+  return RTC::RTC_OK;
+}
+
+RTC::ReturnCode_t Beeper::onDeactivated(RTC::UniqueId ec_id)
+{
+  std::cerr << "[" << m_profile.instance_name << "] : onDeactivated(" << ec_id << ")" << std::endl;
+  return RTC::RTC_OK;
+}
+
+#define DEBUGP ((m_debugLevel==1 && m_loop%200==0) || m_debugLevel > 1 )
+RTC::ReturnCode_t Beeper::onExecute(RTC::UniqueId ec_id)
+{
+  // std::cout << m_profile.instance_name<< ": onExecute(" << ec_id << "), data = " << m_data.data << std::endl;
+  m_loop++;
+
+  if (m_beepCommandIn.isNew()) {
+    m_beepCommandIn.read();
+    pthread_mutex_lock( &beep_mutex );
+    beep_start = (m_beepCommand.data[BEEP_INFO_START] == 1);
+    beep_freq = m_beepCommand.data[BEEP_INFO_FREQ];
+    beep_length = m_beepCommand.data[BEEP_INFO_LENGTH];
+    pthread_mutex_unlock( &beep_mutex );
+  } else {
+    pthread_mutex_lock( &beep_mutex );
+    beep_start = false;
+    pthread_mutex_unlock( &beep_mutex );
+  }
+  if (DEBUGP) {
+    std::cerr << "[" << m_profile.instance_name<< "] start " << beep_start << " freq " << beep_freq << " length " << beep_length << std::endl;
+  }
+//   if (beep_start) {
+//     start_beep(beep_freq, beep_length, true);
+//   } else {
+//     stop_beep(true);
+//   }
+
+  return RTC::RTC_OK;
+}
+
+/*
+RTC::ReturnCode_t Beeper::onAborting(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onError(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onReset(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onStateUpdate(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+/*
+RTC::ReturnCode_t Beeper::onRateChanged(RTC::UniqueId ec_id)
+{
+  return RTC::RTC_OK;
+}
+*/
+
+
+extern "C"
+{
+
+  void BeeperInit(RTC::Manager* manager)
+  {
+    RTC::Properties profile(beeper_spec);
+    manager->registerFactory(profile,
+                             RTC::Create<Beeper>,
+                             RTC::Delete<Beeper>);
+  }
+
+};
+
+

--- a/rtc/Beeper/Beeper.h
+++ b/rtc/Beeper/Beeper.h
@@ -1,0 +1,144 @@
+// -*- C++ -*-
+/*!
+ * @file  Beeper.h
+ * @brief Beeper component
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+#ifndef BEEPER_H
+#define BEEPER_H
+
+#include <rtm/Manager.h>
+#include <rtm/DataFlowComponentBase.h>
+#include <rtm/CorbaPort.h>
+#include <rtm/DataInPort.h>
+#include <rtm/DataOutPort.h>
+#include <rtm/idl/BasicDataTypeSkel.h>
+#include "../SoftErrorLimiter/beep.h"
+
+// Service implementation headers
+// <rtc-template block="service_impl_h">
+
+// </rtc-template>
+
+// Service Consumer stub headers
+// <rtc-template block="consumer_stub_h">
+
+// </rtc-template>
+
+using namespace RTC;
+
+/**
+   \brief sample RT component which has one data input port and one data output port
+ */
+class Beeper
+  : public RTC::DataFlowComponentBase
+{
+ public:
+  /**
+     \brief Constructor
+     \param manager pointer to the Manager
+  */
+  Beeper(RTC::Manager* manager);
+  /**
+     \brief Destructor
+  */
+  virtual ~Beeper();
+
+  // The initialize action (on CREATED->ALIVE transition)
+  // formaer rtc_init_entry()
+  virtual RTC::ReturnCode_t onInitialize();
+
+  // The finalize action (on ALIVE->END transition)
+  // formaer rtc_exiting_entry()
+  // virtual RTC::ReturnCode_t onFinalize();
+
+  // The startup action when ExecutionContext startup
+  // former rtc_starting_entry()
+  // virtual RTC::ReturnCode_t onStartup(RTC::UniqueId ec_id);
+
+  // The shutdown action when ExecutionContext stop
+  // former rtc_stopping_entry()
+  // virtual RTC::ReturnCode_t onShutdown(RTC::UniqueId ec_id);
+
+  // The activated action (Active state entry action)
+  // former rtc_active_entry()
+  virtual RTC::ReturnCode_t onActivated(RTC::UniqueId ec_id);
+
+  // The deactivated action (Active state exit action)
+  // former rtc_active_exit()
+  virtual RTC::ReturnCode_t onDeactivated(RTC::UniqueId ec_id);
+
+  // The execution action that is invoked periodically
+  // former rtc_active_do()
+  virtual RTC::ReturnCode_t onExecute(RTC::UniqueId ec_id);
+
+  // The aborting action when main logic error occurred.
+  // former rtc_aborting_entry()
+  // virtual RTC::ReturnCode_t onAborting(RTC::UniqueId ec_id);
+
+  // The error action in ERROR state
+  // former rtc_error_do()
+  // virtual RTC::ReturnCode_t onError(RTC::UniqueId ec_id);
+
+  // The reset action that is invoked resetting
+  // This is same but different the former rtc_init_entry()
+  // virtual RTC::ReturnCode_t onReset(RTC::UniqueId ec_id);
+
+  // The state update action that is invoked after onExecute() action
+  // no corresponding operation exists in OpenRTm-aist-0.2.0
+  // virtual RTC::ReturnCode_t onStateUpdate(RTC::UniqueId ec_id);
+
+  // The action that is invoked when execution context's rate is changed
+  // no corresponding operation exists in OpenRTm-aist-0.2.0
+  // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
+
+ protected:
+  // Configuration variable declaration
+  // <rtc-template block="config_declare">
+  
+  // </rtc-template>
+  TimedLongSeq m_beepCommand;
+
+  // DataInPort declaration
+  // <rtc-template block="inport_declare">
+  InPort<TimedLongSeq> m_beepCommandIn;
+  
+  // </rtc-template>
+
+  // DataOutPort declaration
+  // <rtc-template block="outport_declare">
+  
+  // </rtc-template>
+
+  // CORBA Port declaration
+  // <rtc-template block="corbaport_declare">
+  
+  // </rtc-template>
+
+  // Service declaration
+  // <rtc-template block="service_declare">
+  
+  // </rtc-template>
+
+  // Consumer declaration
+  // <rtc-template block="consumer_declare">
+  
+  // </rtc-template>
+
+ private:
+  double m_dt;
+  long long m_loop;
+  unsigned int m_debugLevel;
+  pthread_t beep_thread;
+};
+
+
+extern "C"
+{
+  void BeeperInit(RTC::Manager* manager);
+};
+
+#endif // BEEPER_H

--- a/rtc/Beeper/Beeper.txt
+++ b/rtc/Beeper/Beeper.txt
@@ -1,0 +1,53 @@
+/**
+
+\page Beeper
+
+\section introduction Overview
+
+This component is a RT component to beep sound using /dev/console.
+Because we use non-real-time-thread for beeping, beeping is not real time.
+Beep commands come from several RTCs and the latter RTC has high priority.
+
+<table>
+<tr><th>implementation_id</th><td>Beeper</td></tr>
+<tr><th>category</th><td>example</td></tr>
+</table>
+
+\section dataports Data Ports
+
+\subsection inports Input Ports
+
+<table>
+<tr><th>port name</th><th>data type</th><th>unit</th><th>description</th></tr>
+<tr><td>beepCommand</td><td>RTC::TimedLongSeq</td><td></td><td>Beep Command (please see beep.h) </td></tr>
+</table>
+
+\subsection outports Output Ports
+
+<table>
+<tr><th>port name</th><th>data type</th><th>unit</th><th>description</th></tr>
+</table>
+
+\section serviceports Service Ports
+
+\subsection provider Service Providers
+
+<table>
+<tr><th>port name</th><th>interface name</th><th>service type</th><th>IDL</th><th>description</th></tr>
+</table>
+
+\subsection consumer Service Consumers
+
+N/A
+
+\section configuration Configuration Variables
+
+<table>
+<tr><th>name</th><th>type</th><th>unit</th><th>default value</th><th>description</th></tr>
+</table>
+
+\section conf Configuration File
+
+N/A
+
+ */

--- a/rtc/Beeper/BeeperComp.cpp
+++ b/rtc/Beeper/BeeperComp.cpp
@@ -1,0 +1,91 @@
+// -*- C++ -*-
+/*!
+ * @file BeeperComp.cpp
+ * @brief Standalone component
+ * @date $Date$
+ *
+ * $Id$
+ */
+
+#include <rtm/Manager.h>
+#include <iostream>
+#include <string>
+#include "Beeper.h"
+
+
+void MyModuleInit(RTC::Manager* manager)
+{
+  BeeperInit(manager);
+  RTC::RtcBase* comp;
+
+  // Create a component
+  comp = manager->createComponent("Beeper");
+
+
+  // Example
+  // The following procedure is examples how handle RT-Components.
+  // These should not be in this function.
+
+  // Get the component's object reference
+ RTC::RTObject_var rtobj;
+ rtobj = RTC::RTObject::_narrow(manager->getPOA()->servant_to_reference(comp));
+
+  // Get the port list of the component
+ PortServiceList* portlist;
+ portlist = rtobj->get_ports();
+
+  // getting port profiles
+ std::cout << "Number of Ports: ";
+ std::cout << portlist->length() << std::endl << std::endl; 
+ for (CORBA::ULong i(0), n(portlist->length()); i < n; ++i)
+ {
+   PortService_ptr port;
+   port = (*portlist)[i];
+   std::cout << "Port" << i << " (name): ";
+   std::cout << port->get_port_profile()->name << std::endl;
+   
+   RTC::PortInterfaceProfileList iflist;
+   iflist = port->get_port_profile()->interfaces;
+   std::cout << "---interfaces---" << std::endl;
+   for (CORBA::ULong i(0), n(iflist.length()); i < n; ++i)
+   {
+     std::cout << "I/F name: ";
+     std::cout << iflist[i].instance_name << std::endl;
+     std::cout << "I/F type: ";
+     std::cout << iflist[i].type_name << std::endl;
+     const char* pol;
+     pol = iflist[i].polarity == 0 ? "PROVIDED" : "REQUIRED";
+     std::cout << "Polarity: " << pol << std::endl;
+   }
+   std::cout << "---properties---" << std::endl;
+   NVUtil::dump(port->get_port_profile()->properties);
+   std::cout << "----------------" << std::endl << std::endl;
+ }
+
+  return;
+}
+
+int main (int argc, char** argv)
+{
+  RTC::Manager* manager;
+  manager = RTC::Manager::init(argc, argv);
+
+  // Initialize manager
+  manager->init(argc, argv);
+
+  // Set module initialization proceduer
+  // This procedure will be invoked in activateManager() function.
+  manager->setModuleInitProc(MyModuleInit);
+
+  // Activate manager and register to naming service
+  manager->activateManager();
+
+  // run the manager in blocking mode
+  // runManager(false) is the default.
+  manager->runManager();
+
+  // If you want to run the manager in non-blocking mode, do like this
+  // manager->runManager(true);
+
+  return 0;
+}

--- a/rtc/Beeper/CMakeLists.txt
+++ b/rtc/Beeper/CMakeLists.txt
@@ -1,0 +1,16 @@
+#set(comp_sources Beeper.cpp BeeperService_impl.cpp ../SoftErrorLimiter/beep.cpp)
+set(comp_sources Beeper.cpp ../SoftErrorLimiter/beep.cpp)
+set(libs hrpModel-3.1 hrpUtil-3.1 hrpsysBaseStub)
+add_library(Beeper SHARED ${comp_sources})
+target_link_libraries(Beeper ${libs})
+set_target_properties(Beeper PROPERTIES PREFIX "")
+
+add_executable(BeeperComp BeeperComp.cpp ${comp_sources})
+target_link_libraries(BeeperComp ${libs})
+
+set(target Beeper BeeperComp)
+
+install(TARGETS ${target}
+  RUNTIME DESTINATION bin CONFIGURATIONS Release Debug
+  LIBRARY DESTINATION lib CONFIGURATIONS Release Debug
+)

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -30,6 +30,7 @@
 
 #include "VclipLinkPair.h"
 #include "CollisionDetectorService_impl.h"
+#include "../SoftErrorLimiter/beep.h"
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
@@ -136,6 +137,8 @@ class CollisionDetector
   // <rtc-template block="outport_declare">
   TimedDoubleSeq m_q;
   OutPort<TimedDoubleSeq> m_qOut;
+  TimedLongSeq m_beepCommand;
+  OutPort<TimedLongSeq> m_beepCommandOut;
   
   // </rtc-template>
 
@@ -197,6 +200,10 @@ class CollisionDetector
   int collision_beep_freq, collision_beep_count;
   bool m_have_safe_posture;
   OpenHRP::CollisionDetectorService::CollisionState m_state;
+  BeepClient bc;
+  // Since this RTC is stable RTC, we support both direct beeping from this RTC and beepring through BeeperRTC.
+  // If m_beepCommand is connected to BeeperRTC, is_beep_port_connected is true.
+  bool is_beep_port_connected;
 };
 
 #ifndef USE_HRPSYSUTIL

--- a/rtc/CollisionDetector/CollisionDetector.txt
+++ b/rtc/CollisionDetector/CollisionDetector.txt
@@ -24,6 +24,10 @@ Transition from overwrite mode to non-overwrite mode
 is implemented as min-jerk interplation by default. 
 Transition time is 1.0[s] by default.
 
+In collision, this component makes beep sound.
+If the cause of errors are removed, error flags and beep sound are removed.
+Since this RTC is stable RTC, we support both direct beeping from this RTC and beepring through BeeperRTC.
+
 \section dataports Data Ports
 
 \subsection inports Input Ports

--- a/rtc/EmergencyStopper/EmergencyStopper.h
+++ b/rtc/EmergencyStopper/EmergencyStopper.h
@@ -25,6 +25,7 @@
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "EmergencyStopperService_impl.h"
+#include "../SoftErrorLimiter/beep.h"
 
 // </rtc-template>
 
@@ -117,6 +118,7 @@ protected:
     OpenHRP::TimedLongSeqSeq m_servoState;
     std::vector<TimedDoubleSeq> m_wrenchesRef;
     std::vector<TimedDoubleSeq> m_wrenches;
+    TimedLongSeq m_beepCommand;
 
     // DataInPort declaration
     // <rtc-template block="inport_declare">
@@ -132,6 +134,7 @@ protected:
     OutPort<TimedDoubleSeq> m_qOut;
     OutPort<TimedLong> m_emergencyModeOut;
     std::vector<OutPort<TimedDoubleSeq> *> m_wrenchesOut;
+    OutPort<TimedLongSeq> m_beepCommandOut;
   
     // </rtc-template>
 
@@ -187,6 +190,7 @@ private:
     std::queue<std::vector<double> > m_input_wrenches_queue;
     int emergency_stopper_beep_count, emergency_stopper_beep_freq;
     coil::Mutex m_mutex;
+    BeepClient bc;
 };
 
 

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.h
@@ -22,6 +22,7 @@
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "SoftErrorLimiterService_impl.h"
+#include "beep.h"
 
 // </rtc-template>
 
@@ -107,6 +108,7 @@ class SoftErrorLimiter
   TimedDoubleSeq m_qRef;
   TimedDoubleSeq m_qCurrent;
   OpenHRP::TimedLongSeqSeq m_servoState;
+  TimedLongSeq m_beepCommand;
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
@@ -120,6 +122,7 @@ class SoftErrorLimiter
   // <rtc-template block="outport_declare">
   OutPort<TimedDoubleSeq> m_qOut;
   OutPort<OpenHRP::TimedLongSeqSeq> m_servoStateOut;
+  OutPort<TimedLongSeq> m_beepCommandOut;
   
   // </rtc-template>
 
@@ -146,6 +149,10 @@ class SoftErrorLimiter
   unsigned int m_debugLevel;
   int dummy, position_limit_error_beep_freq, soft_limit_error_beep_freq, debug_print_freq;
   double dt;
+  BeepClient bc;
+  // Since this RTC is stable RTC, we support both direct beeping from this RTC and beepring through BeeperRTC.
+  // If m_beepCommand is connected to BeeperRTC, is_beep_port_connected is true.
+  bool is_beep_port_connected;
 };
 
 

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.txt
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.txt
@@ -31,6 +31,8 @@ At the same time, this component makes beep sound 2 times per 1[s].
 
 If the cause of errors are removed, error flags and beep sound are removed.
 
+Since this RTC is stable RTC, we support both direct beeping from this RTC and beepring through BeeperRTC.
+
 <table>
 <tr><th>implementation_id</th><td>NullComponent</td></tr>
 <tr><th>category</th><td>example</td></tr>

--- a/rtc/SoftErrorLimiter/beep.h
+++ b/rtc/SoftErrorLimiter/beep.h
@@ -1,4 +1,50 @@
+#ifndef BEEP_H
+#define BEEP_H
+
 void init_beep();
 void start_beep(int freq, int length=50);
 void stop_beep();
 void quit_beep();
+
+typedef enum {BEEP_INFO_START, BEEP_INFO_FREQ, BEEP_INFO_LENGTH, NUM_BEEP_INFO} beep_info;
+
+// Beep client to send command to BeeperRTC
+#include <rtm/idl/BasicDataTypeSkel.h>
+class BeepClient
+{
+ private:
+  bool is_start_beep, prev_is_start_beep;
+  int freq, length;
+ public:
+  BeepClient () : is_start_beep(false), prev_is_start_beep(false) {};
+  ~BeepClient () {};
+  int get_num_beep_info () const { return NUM_BEEP_INFO; };
+  void startBeep (const int _freq, const int _length = 50)
+  {
+    prev_is_start_beep = is_start_beep;
+    is_start_beep = true;
+    freq = _freq;
+    length = _length;
+  };
+  void stopBeep ()
+  {
+    prev_is_start_beep = is_start_beep;
+    is_start_beep = false;
+    freq = 1; // dummy
+    length = 0; // dummy
+  };
+  bool isWritable () const
+  {
+    // Write data port to overwrite and pass through between client RTCs.
+    // If currently "start" or changed to "stop", write data port.
+    // If keep "stop", do not write data port.
+    return (is_start_beep || prev_is_start_beep);
+  };
+  void setDataPort (RTC::TimedLongSeq& out_data)
+  {
+    out_data.data[BEEP_INFO_START] = (is_start_beep?1:0);
+    out_data.data[BEEP_INFO_FREQ] = freq;
+    out_data.data[BEEP_INFO_LENGTH] = length;
+  };
+};
+#endif // BEEP_H

--- a/rtc/ThermoLimiter/ThermoLimiter.h
+++ b/rtc/ThermoLimiter/ThermoLimiter.h
@@ -26,6 +26,7 @@
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "ThermoLimiterService_impl.h"
+#include "../SoftErrorLimiter/beep.h"
 
 // </rtc-template>
 
@@ -111,6 +112,7 @@ class ThermoLimiter
   // </rtc-template>
   TimedDoubleSeq m_tempIn;
   TimedDoubleSeq m_tauMaxOut;
+  TimedLongSeq m_beepCommandOut;
   
   // DataInPort declaration
   // <rtc-template block="inport_declare">
@@ -121,6 +123,7 @@ class ThermoLimiter
   // DataOutPort declaration
   // <rtc-template block="outport_declare">
   OutPort<TimedDoubleSeq> m_tauMaxOutOut;
+  OutPort<TimedLongSeq> m_beepCommandOutOut;
   
   // </rtc-template>
 
@@ -150,6 +153,7 @@ class ThermoLimiter
   hrp::BodyPtr m_robot;
   std::vector<MotorHeatParam> m_motorHeatParams;
   coil::Mutex m_mutex;
+  BeepClient bc;
 
   void calcMaxTorqueFromTemperature(hrp::dvector &tauMax);
   double calcEmergencyRatio(RTC::TimedDoubleSeq &current, hrp::dvector &max, double alarmRatio, std::string &prefix);


### PR DESCRIPTION
Beep音を鳴らす部分を別RTCとして取り出しました(BeeperRTC)。

今まではCollisionDetector, SoftErrorlimiter, ThermoLimiter, EmergencyStopperなどで
ビープ音をそれぞれ独立に/dev/consoleを叩いていましたが、
実時間が守られないことがあるので一ヶ所にまとめるべく別RTCとしました。
また、/dev/consoleにアクセスするものはBeeperRTCのメインスレッドと別スレッドにしました。

さらに、ColisionDetector, SoftErrorLimiteはStableRTCなので、BeeperRTCにつながってなければ(connectorsが０)
今までどおり各RTCの中でビープ音をならすようにして、互換性を保つようにしました。

デフォルトのgetUnstableRTCListの中にBeeperを追加しました。
RTCの実行順序が後のRTCの方が優先度が高い（後の方のRTCの音がなる）ようにしていて、
関節負荷は優先度高めとおもいelよりtlがあとにくるように、この２つのRTCの順番をかえました。

よろしくお願いします。