### PR TITLE
Add commenttoconnect and build beeper

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -556,7 +556,7 @@ def connectPorts(outP, inPs, subscription="flush", dataflow="Push", bufferlength
         con_prof = RTC.ConnectorProfile("connector0", "", [outP, inP],
                                         [nv1, nv2, nv3, nv4, nv5, nv6, nv7])
         print('[rtm.py]    Connect ' + outP.get_port_profile().name + ' - ' + \
-              inP.get_port_profile().name)
+              inP.get_port_profile().name+' (dataflow_type='+dataflow+', subscription_type='+ subscription+', bufferlength='+str(bufferlength)+', push_rate='+str(rate)+', push_policy='+pushpolicy+')')
         ret, prof = inP.connect(con_prof)
         if ret != RTC.RTC_OK:
             print("failed to connect")

--- a/rtc/CMakeLists.txt
+++ b/rtc/CMakeLists.txt
@@ -51,6 +51,7 @@ if (QHULL_FOUND)
   add_subdirectory(CollisionDetector)
 endif()
 add_subdirectory(PDcontroller)
+add_subdirectory(Beeper)
 
 if (NOT APPLE AND USE_HRPSYSUTIL)
   add_subdirectory(VideoCapture)


### PR DESCRIPTION
2つのコミットをまとめました
- https://github.com/fkanehiro/hrpsys-base/pull/963 でBeeper RTCをビルドするのを忘れてたため、追加しまいsた
- rtm.pyでconnectPortを接続時のsubscription_typeなどの情報をprintするようにしました。

```
[rtm.py]    Connect sh.rfsensorOut - log.sh_rfsensorOut (dataflow_type=Push, subscription_type=flush, bufferlength=1, push_rate=1000, push_policy=new)
```
よろしくお願いいたします。