### PR TITLE
Fix to use round to convert double time parameter to size_t time count.

### DIFF
--- a/rtc/ImpedanceController/ObjectTurnaroundDetector.h
+++ b/rtc/ImpedanceController/ObjectTurnaroundDetector.h
@@ -5,6 +5,7 @@
 #include "../TorqueFilter/IIRFilter.h"
 #include <boost/shared_ptr.hpp>
 #include <iostream>
+#include <cmath>
 
 class ObjectTurnaroundDetector
 {
@@ -139,8 +140,8 @@ class ObjectTurnaroundDetector
     void setDwrenchCutoffFreq (const double a) { dwrench_filter->setCutOffFreq(a); };
     void setDetectRatioThre (const double a) { detect_ratio_thre = a; };
     void setStartRatioThre (const double a) { start_ratio_thre = a; };
-    void setDetectTimeThre (const double a) { detect_count_thre = static_cast<size_t>(a/dt); };
-    void setStartTimeThre (const double a) { start_count_thre = static_cast<size_t>(a/dt); };
+    void setDetectTimeThre (const double a) { detect_count_thre = round(a/dt); };
+    void setStartTimeThre (const double a) { start_count_thre = round(a/dt); };
     void setAxis (const hrp::Vector3& a) { axis = a; };
     void setMomentCenter (const hrp::Vector3& a) { moment_center = a; };
     void setDetectorTotalWrench (const detector_total_wrench _dtw)

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -148,6 +148,21 @@ def demo():
         hcf.seq_svc.waitInterpolation();
     else:
         print >> sys.stderr, "8. World frame ref-force check is not executed in non-kinematics-only-mode"
+    # 9. Object Turnaround Detector set param check
+    print >> sys.stderr, "9. Object Turnaround Detector set param check"
+    ret9 = True
+    detect_time_thre = 0.3
+    start_time_thre=0.3
+    for number_disturbance in [0, 1e-5, -1e-5]: # 1e-5 is smaller than dt
+        otdp=hcf.ic_svc.getObjectTurnaroundDetectorParam()[1];
+        otdp.detect_time_thre = detect_time_thre + number_disturbance
+        otdp.start_time_thre = start_time_thre + number_disturbance
+        hcf.ic_svc.setObjectTurnaroundDetectorParam(otdp);
+        otdp2=hcf.ic_svc.getObjectTurnaroundDetectorParam()[1];
+        print >> sys.stderr, "  ", otdp2
+        ret9 = ret9 and (otdp2.detect_time_thre == detect_time_thre and otdp2.start_time_thre == start_time_thre)
+    assert(ret9)
+    print >> sys.stderr, "  => OK"
 
 if __name__ == '__main__':
     demo()


### PR DESCRIPTION
Object Tounraround Detector計算の中で、時間パラメータを離散時間カウントになおすときに
誤ってキャストしてたので直しました。

よろしくおおねがいします。