### PR TITLE
Update semaphore and EcexutionContext.

### DIFF
--- a/ec/hrpEC/hrpEC.h
+++ b/ec/hrpEC/hrpEC.h
@@ -13,6 +13,10 @@
 
 #include "hrpsys/idl/ExecutionProfileService.hh"
 
+#ifdef __QNX__
+using std::fprintf;
+#endif
+
 namespace RTC
 {
   class hrpExecutionContext
@@ -52,6 +56,14 @@ namespace RTC
           }
       }
     }
+    void printRTCProcessingTime (std::vector<double>& processes)
+    {
+      fprintf(stderr, "[hrpEC] ");
+      for (unsigned int i=0; i< processes.size(); i++){
+        fprintf(stderr, "%s(%4.2f), ", rtc_names[i].c_str(),processes[i]*1e3);
+      }
+      fprintf(stderr, "[ms]\n");
+    };
     OpenHRP::ExecutionProfileService::Profile m_profile;
     struct timeval m_tv;
     int m_priority;

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -2,7 +2,7 @@
 #define __ROBOT_H__
 
 #include <boost/array.hpp>
-#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+#include <semaphore.h>
 #include <hrpModel/Body.h>
 
 /**
@@ -335,7 +335,7 @@ private:
     std::string m_calibJointName, m_calibOptions;
     std::string m_pdgainsFilename;
     bool m_reportedEmergency;
-    boost::interprocess::interprocess_semaphore wait_sem;
+    sem_t wait_sem;
     double m_dt;
     std::vector<double> m_commandOld, m_velocityOld;
     hrp::Vector3 G;

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -10,7 +10,7 @@
 #ifndef SEQUENCEPLAYER_H
 #define SEQUENCEPLAYER_H
 
-#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+#include <semaphore.h>
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -181,7 +181,7 @@ class SequencePlayer
  private:
   seqplay *m_seq;
   bool m_clearFlag, m_waitFlag;
-  boost::interprocess::interprocess_semaphore m_waitSem;
+  sem_t m_waitSem;
   hrp::BodyPtr m_robot;
   std::string m_gname;
   unsigned int m_debugLevel;

--- a/rtc/StateHolder/StateHolder.h
+++ b/rtc/StateHolder/StateHolder.h
@@ -10,7 +10,7 @@
 #ifndef NULL_COMPONENT_H
 #define NULL_COMPONENT_H
 
-#include <boost/interprocess/sync/interprocess_semaphore.hpp>
+#include <semaphore.h>
 #include <rtm/Manager.h>
 #include <rtm/DataFlowComponentBase.h>
 #include <rtm/CorbaPort.h>
@@ -165,7 +165,7 @@ class StateHolder
 
  private:
   int m_timeCount;
-  boost::interprocess::interprocess_semaphore m_waitSem, m_timeSem;
+  sem_t m_waitSem, m_timeSem;
   bool m_requestGoActual;
   double m_dt;
   int dummy;


### PR DESCRIPTION
２つのコミットをまとめました。
- semaphore.h

    https://github.com/fkanehiro/hrpsys-base/issues/969 に基づき、interprocess_semaphoreをsemaphore.hにしました。
    対象となるRTCはseq, rh, shです。
    初期化時のぱらめtーあ(https://linuxjm.osdn.jp/html/LDP_man-pages/man3/sem_init.3.html) は、
    pthreadが0(プロセス内のスレッド間共有)にして、
    初期カウントであるvauleは０にしました(interprocess_semaphoreの引数http://www.boost.org/doc/libs/1_35_0/doc/html/boost/interprocess/interprocess_semaphore.html の初期カウントも0としていたため)
- hrpEC

    hrpECで、time overなタイミング以外にも`ENABLE_DEBUG_PRINT`のdefineをtrueにしてビルドしたら実行時間内訳、各RTCの時間のリストを常時（5秒に一回くらい）表示します。
    デフォルトはfalseにしてあり、今までと挙動はほぼかわらないと思います（print表示に`[hrpEC]`と追加されるようにした）

以上よろしくお願いいたします。