### PR TITLE
Add refforce weight to eefmqp

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -686,15 +686,15 @@ void AutoBalancer::getTargetParameters()
               ABCIKparam& tmpikp = ikp[leg_names[i]];
               ee_pos.push_back(tmpikp.target_p0 + tmpikp.target_r0 * tmpikp.localPos + tmpikp.target_r0 * tmpikp.localR * default_zmp_offsets[i]);
           }
-          double alpha = (ref_zmp - ee_pos[1]).norm() / (ee_pos[0] - ee_pos[1]).norm();
+          double alpha = (ref_zmp - ee_pos[1]).norm() / ((ee_pos[0] - ref_zmp).norm() + (ee_pos[1] - ref_zmp).norm());
           if (alpha>1.0) alpha = 1.0;
           if (alpha<0.0) alpha = 0.0;
           if (DEBUGP) {
           std::cerr << "[" << m_profile.instance_name << "] alpha:" << alpha << std::endl;
           }
           double mg = m_robot->totalMass() * gg->get_gravitational_acceleration();
-          m_force[0].data[0] = alpha * mg;
-          m_force[1].data[0] = (1-alpha) * mg;
+          m_force[0].data[2] = alpha * mg;
+          m_force[1].data[2] = (1-alpha) * mg;
       }
       // set limbCOPOffset
       {

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -813,6 +813,9 @@ void Stabilizer::getActualParameters ()
           rel_ee_rot.push_back(foot_origin_rot.transpose() * ee_rot.back());
           rel_ee_name.push_back(ee_name.back());
       }
+      //for ABC ref force
+      if ( ref_force[0](2) + ref_force[1](2) == 0 ) ref_force[0](2) = ref_force[1](2) = eefm_gravitational_acceleration * total_mass / 2.0;
+
       // All state variables are foot_origin coords relative
       if (DEBUGP) {
           std::cerr << "[" << m_profile.instance_name << "] ee values" << std::endl;

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -580,6 +580,7 @@ public:
         // QP
         double norm_weight = 1e-7;
         double cop_weight = 1e-3;
+        double ref_force_weight = 0;// 1e-3;
         hrp::dvector total_fm(3);
         total_fm(0) = total_fz;
         total_fm(1) = 0;
@@ -632,7 +633,8 @@ public:
                 for (size_t i = 0; i < state_dim_one; i++) {
                     Kmat(j,i+j*state_dim_one) = 1.0;
                 }
-                reff(j) = total_fz/2.0;
+                reff(j) = ref_foot_force[j](2);// total_fz/2.0;
+                KW(j,j) = ref_force_weight;
             }
             Hmat += Kmat.transpose() * KW * Kmat;
             gvec += -1 * Kmat.transpose() * KW * reff;


### PR DESCRIPTION
StabilizerのZMP分配のEEFMQPモードで
AutoBalancerからのref forceに追従するための評価関数を追加しました.
デフォルトでは評価関数の重みを0としているので挙動は変わりません.