### PR TITLE
[CMakeLists.txt] Modified to escape CMake warnings

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -173,7 +173,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/hrpsys-base.pc
   DESTINATION lib/pkgconfig)
 
-add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\\"\")
+add_definitions(-DHRPSYS_PACKAGE_VERSION=\"\\\"${CPACK_PACKAGE_VERSION_MAJOR}.${CPACK_PACKAGE_VERSION_MINOR}.${CPACK_PACKAGE_VERSION_PATCH}\"\\\")
 
 option(NO_DIGITAL_INPUT "Disable readDigitalInput and lengthDigitalInput" OFF)
 if(NO_DIGITAL_INPUT)
@@ -207,7 +207,7 @@ if (NOT QNXNTO)
   add_subdirectory(util)
 endif()
 add_subdirectory(sample)
-add_subdirectory(test)
+# add_subdirectory(test)
 
 #if catkin environment
 string(REGEX MATCH "catkin" need_catkin "$ENV{_}")

--- a/ec/hrpEC/CMakeLists.txt
+++ b/ec/hrpEC/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(SET CMP0015 NEW)
 set(common_libs ${OPENRTM_LIBRARIES} hrpIo hrpsysBaseStub)
 find_package(ART REQUIRED)
 

--- a/rtc/RobotHardware/CMakeLists.txt
+++ b/rtc/RobotHardware/CMakeLists.txt
@@ -1,3 +1,4 @@
+cmake_policy(SET CMP0015 NEW)
 set(comp_source  robot.cpp RobotHardware.cpp RobotHardwareService_impl.cpp)
 set(libs hrpIo hrpModel-3.1 hrpCollision-3.1 hrpUtil-3.1 hrpsysBaseStub)
 link_directories(${LIBIO_DIR})


### PR DESCRIPTION
To suppress warnings such that,
```
CMake Warning (dev) at CMakeLists.txt:176 (add_definitions):
  Policy CMP0005 is not set: Preprocessor definition values are now escaped
  automatically.  Run "cmake --help-policy CMP0005" for policy details.  Use
  the cmake_policy command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```

```
CMake Warning (dev) at CMakeLists.txt:210 (add_subdirectory):
  The source directory

    /home/iory/catkin_ws/hrp2/src/hrpsys/test

  does not contain a CMakeLists.txt file.
```

```
CMake Warning (dev) at ec/hrpEC/CMakeLists.txt:4 (link_directories):
  This command specifies the relative path

    io

  as a link directory.

  Policy CMP0015 is not set: link_directories() treats paths relative to the
  source dir.  Run "cmake --help-policy CMP0015" for policy details.  Use the
  cmake_policy command to set the policy and suppress this warning.
This warning is for project developers.  Use -Wno-dev to suppress it.
```