### PR TITLE
Update stabilizer sbp_cog_offset and add RobotHardware comment

### DIFF
--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -93,7 +93,9 @@ bool robot::init()
 
 void robot::removeForceSensorOffset()
 {
+    std::cerr << "[RobotHardware] removeForceSensorOffset..." << std::endl;
     startForceSensorCalibration();
+    std::cerr << "[RobotHardware] removeForceSensorOffset...done." << std::endl;
 }
 
 bool robot::loadGain()
@@ -116,6 +118,7 @@ bool robot::loadGain()
 
 void robot::startInertiaSensorCalibration()
 {
+    std::cerr << "[RobotHardware] startInertiaSensorCalibration..." << std::endl;
     if (numSensors(Sensor::ACCELERATION)==0 
         && numSensors(Sensor::RATE_GYRO)==0)  return;
 
@@ -147,6 +150,7 @@ void robot::startInertiaSensorCalibration()
     inertia_calib_counter=CALIB_COUNT;
 
     sem_wait(&wait_sem);
+    std::cerr << "[RobotHardware] startInertiaSensorCalibration...done." << std::endl;
 }
 
 void robot::startForceSensorCalibration()

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1088,6 +1088,7 @@ void Stabilizer::getTargetParameters ()
     ref_cp = ref_cog + ref_cogvel / std::sqrt(eefm_gravitational_acceleration / (ref_cog - ref_zmp)(2));
     rel_ref_cp = hrp::Vector3(ref_cp(0), ref_cp(1), ref_zmp(2));
     rel_ref_cp = m_robot->rootLink()->R.transpose() * ((foot_origin_pos + foot_origin_rot * rel_ref_cp) - m_robot->rootLink()->p);
+    sbp_cog_offset = foot_origin_rot.transpose() * sbp_cog_offset;
     // <= Reference foot_origin frame
   } else {
     ref_cogvel = (ref_cog - prev_ref_cog)/dt;
@@ -1189,7 +1190,10 @@ void Stabilizer::calcStateForEmergencySignal()
     else if (isContact(contact_states_index_map["lleg"])) support_leg = SimpleZMPDistributor::LLEG;
     if (!is_walking || is_estop_while_walking) is_cp_outside = !szd->is_inside_support_polygon(tmp_cp, rel_ee_pos, rel_ee_rot, rel_ee_name, support_leg, cp_check_margin, - sbp_cog_offset);
     if (DEBUGP) {
-      std::cerr << "[" << m_profile.instance_name << "] CP value " << "[" << act_cp(0) << "," << act_cp(1) << "] [m]" << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "] CP value " << "[" << act_cp(0) << "," << act_cp(1) << "] [m], "
+                << "sbp cog offset [" << sbp_cog_offset(0) << " " << sbp_cog_offset(1) << "], outside ? "
+                << (is_cp_outside?"Outside":"Inside")
+                << std::endl;
     }
     if (is_cp_outside) {
       if (initial_cp_too_large_error || loop % static_cast <int>(0.2/dt) == 0 ) { // once per 0.2[s]


### PR DESCRIPTION
Stabilizer の estop判定でつかっているsbp_cog_offsetの座標系がおかしかったのを直しました
（reference world frameをfoot origin frameになおした）
また、RobotHardware のremoveForceSensorなどの関数の呼び出し次にprint分をだすようにしました。

よろしくお願いします。