### PR TITLE
Fixed mistake of waitForRTCManagerAndRoboHardware's argument

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -943,9 +943,9 @@ class HrpsysConfigurator:
         print(self.configurator_name + "simulation_mode : %s" % self.simulation_mode)
 
     def waitForRTCManagerAndRoboHardware(self, robotname="Robot", managerhost=nshost):
-        print("\033[93m%s waitForRTCManagerAndRoboHardware has renamed to \
-        waitForRTCManagerAndRoboHardware: Please update your code\033[0m" % self.configurator_name)
-        return self.waitForRTCManagerAndRobotHardware(robotname=robotname, managerhost=nshost)
+        print("\033[93m%s waitForRTCManagerAndRoboHardware has renamed to " % self.configurator_name + \
+              "waitForRTCManagerAndRoboHardware: Please update your code\033[0m")
+        return self.waitForRTCManagerAndRobotHardware(robotname=robotname, managerhost=managerhost)
 
     def waitForRTCManagerAndRobotHardware(self, robotname="Robot", managerhost=nshost):
         '''!@brief


### PR DESCRIPTION
以前のcommitでwaitForRTCManagerAndRoboHardwareの引数が変更されないバグを入れてしまい，
その修正を送ります．
https://github.com/fkanehiro/hrpsys-base/pull/984/files