### PR TITLE
Fix collision loop

### DIFF
--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -1,6 +1,7 @@
 # generate .conf and .xml files for two controller period
 set(controller_time_list 0.002 0.005) # [s]
 set(controller_period_list 500 200) # [Hz]
+set(COLLISION_LOOP 1)
 foreach(_idx 0 1)
   list(GET controller_time_list ${_idx} _tmp_controller_time)
   list(GET controller_period_list ${_idx} _tmp_controller_period)
@@ -27,6 +28,8 @@ configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.v
 set(VirtualForceSensorSetting "#virtual_force_sensor") # comment out
 set(JointLimitTableSetting "joint_limit_table")
 configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.el.conf)
+set(COLLISION_LOOP 3)
+configure_file(SampleRobot.conf.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.co_loop.conf)
 
 set(robot_waist_translation "-0.8  0  0" "-4.15  -0.2  0" "-5.83  -0.2  -0.6096")
 set(file_suffix "SlopeUpDown" "StairUp" "StairDown")
@@ -55,6 +58,8 @@ install(FILES
   # for SoftErrorLimiter
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.el.conf
   SampleRobot.PDgain.dat
+  # for collision_loop
+  ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.co_loop.conf
   # TerrainFloor
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.SlopeUpDown.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.TerrainFloor.StairUp.xml

--- a/sample/SampleRobot/SampleRobot.conf.in
+++ b/sample/SampleRobot/SampleRobot.conf.in
@@ -5,6 +5,7 @@ abc_leg_offset: 0,0.09,0
 end_effectors: lleg,LLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, rleg,RLEG_ANKLE_R,WAIST,0.0,0.0,-0.07,0.0,0.0,0.0,0.0, larm,LARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708, rarm,RARM_WRIST_P,CHEST,0.0,0,-0.12,0,1.0,0.0,1.5708,
 
 # CollisionDetector Setting
+collision_loop: @COLLISION_LOOP@
 collision_pair: RARM_WRIST_P:WAIST LARM_WRIST_P:WAIST RARM_WRIST_P:RLEG_HIP_R LARM_WRIST_P:LLEG_HIP_R RARM_WRIST_R:RLEG_HIP_R LARM_WRIST_R:LLEG_HIP_R LLEG_ANKLE_R:RLEG_ANKLE_R
 #   Collision mask not to control legs joints
 #collision_mask: 0,0,0,0,0,0,1,1,1,1,1,1,1,0,0,0,0,0,0,1,1,1,1,1,1,1,1,1,1

--- a/test/test-samplerobot-co_loop.test
+++ b/test/test-samplerobot-co_loop.test
@@ -1,0 +1,10 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot.launch" >
+    <arg name="GUI" value="false" />
+    <arg name="corbaport" value="2809" />
+    <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.co_loop.conf"/>
+  </include>
+
+  <test test-name="samplerobot_co_loop" pkg="hrpsys" type="test-samplerobot-collision.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
+</launch>


### PR DESCRIPTION
collision_loopを設定すると、挙動がおかしくテストが通らない問題を修正しました。

主には、recover時のcollision_check姿勢の更新タイミングがsafe時と違っているのを修正しました。

collision_loopを使うと、lastsafe_jointdataと出力されている関節角度が違ってしまう
(collision_loopの回数前のデータがlastsafe_jointdata)のをcollision判定されたら戻すようにしました。