### PR TITLE
check version in CMakeLists.txt against package.xml

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -105,7 +105,7 @@ set(CPACK_PACKAGE_NAME hrpsys-base)
 set(CPACK_PACKAGE_VENDOR "AIST")
 set(CPACK_PACKAGE_CONTACT "Fumio Kanehiro <f-kanehiro@aist.go.jp>")
 set(CPACK_PACKAGE_VERSION_MAJOR 315)
-set(CPACK_PACKAGE_VERSION_MINOR 7)
+set(CPACK_PACKAGE_VERSION_MINOR 9)
 set(CPACK_PACKAGE_VERSION_PATCH 0)
 execute_process(
   COMMAND date +%Y%m%d%H%M
@@ -212,6 +212,13 @@ add_subdirectory(test)
 #if catkin environment
 string(REGEX MATCH "catkin" need_catkin "$ENV{_}")
 if(need_catkin OR "${CATKIN_BUILD_BINARY_PACKAGE}")
+  find_package(catkin)
+  if(catkin_FOUND)
+    catkin_package_xml()
+    if(NOT hrpsys_VERSION VERSION_EQUAL CPACK_PACKAGE_VERSION)
+      message( FATAL_ERROR "hrpsys_version (from package.xml): ${hrpsys_VERSION} is not equal CPACK_PACKAGE_VERSION: ${CPACK_PACKAGE_VERSION}" )
+    endif()
+  endif()
   install(CODE "file(WRITE \$ENV{DESTDIR}\${CMAKE_INSTALL_PREFIX}/share/doc/hrpsys/rospack_nosubdirs)")
   install(FILES package.xml DESTINATION share/hrpsys/)
   install(CODE "


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/990
と直接は関係ないのですが、バージョン番号が正しくrtcに反映されていないように思います。

ここのdefineでバージョン番号を設定しているのですが、それが、package.xmlのものとと違っています。
https://github.com/fkanehiro/hrpsys-base/blob/master/CMakeLists.txt#L176

このPRでは、違う場合に落ちるようになっています。

値を直接設定するために、find_package(catkin)をすると、問題がありました。
- docディレクトリでのtargetが重複する (catkinでロードしたときに先に設定されると思われる）
- subdirectoryにCMakeLists.txtがないとエラーになる (find_package(catkin)の有無で違いがある）
　　こちらは、空のCMakeLists.txtを置けば解決するとは思う。


バージョン番号の付け方について、理解が足りていないのですが、現在は315.9.0がリリースされていますが、
それ以降にPRがあってソースコードに変更があってもバージョン番号は315.9.0に固定でしょうか？
リリース(deb)のあとに追加したソースコードの機能をテストしたい場合は、バージョンが上がっていてほしいと思うのですが、どうでしょうか？
