### PR TITLE
Use robothardware with simulation

### DIFF
--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -219,10 +219,8 @@ RTC::ReturnCode_t RobotHardware::onDeactivated(RTC::UniqueId ec_id)
 RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
 {
     //std::cout << "RobotHardware:onExecute(" << ec_id << ")" << std::endl;
-  coil::TimeValue coiltm(coil::gettimeofday());
-  Time tm; 
-  tm.sec  = coiltm.sec();
-  tm.nsec = coiltm.usec() * 1000;
+  Time tm;
+  this->getTimeNow(tm);
 
   if (!m_isDemoMode){
       robot::emg_reason reason;

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -101,6 +101,11 @@ class RobotHardware
   // no corresponding operation exists in OpenRTm-aist-0.2.0
   // virtual RTC::ReturnCode_t onRateChanged(RTC::UniqueId ec_id);
 
+  virtual inline void getTimeNow(Time &tm) {
+      coil::TimeValue coiltm(coil::gettimeofday());
+      tm.sec  = coiltm.sec();
+      tm.nsec = coiltm.usec() * 1000;
+  };
 
  protected:
   // Configuration variable declaration

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -198,6 +198,7 @@ class RobotHardware
   
   // </rtc-template>
 
+  robot *robot_ptr(void) { return m_robot.get(); };
  private:
   int dummy;
   boost::shared_ptr<robot> m_robot;


### PR DESCRIPTION
シミュレータでRobotHardwareを使いたいと思っていまして、
そのときにRobotHardwareの時間取得が現実時間のみであると使いにくいので、
時間取得のメソッドを追加し、継承時にオーバーライドできるようにしました。
RobotHardwareクラス自体の動作に変化はありません。