### PR TITLE
save ReferenceForceUpdater output with DataLogger

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -874,6 +874,9 @@ class HrpsysConfigurator:
         if self.rmfo != None:
             for sen in filter(lambda x: x.type == "Force", self.sensors):
                 self.connectLoggerPort(self.rmfo, "off_"+sen.name)
+        if self.rfu != None:
+            for sen in filter(lambda x: x.type == "Force", self.sensors):
+                self.connectLoggerPort(self.rfu, "ref_"+sen.name+"Out")
         self.log_svc.clear()
         ## parallel running log process (outside from rtcd) for saving logs by emergency signal
         if self.log and (self.log_use_owned_ec or not isinstance(self.log.owned_ecs[0], OpenRTM._objref_ExtTrigExecutionContextService)):


### PR DESCRIPTION
@snozawa さん、デバッグのためにReferenceForceUpdaterの出力を
デフォルトでDataLoggerで保存するようにしましたので
ご確認いただけますでしょうか。
HRP2実機で正常にログをとれることを確認済みです。