### PR TITLE
add method for setInterpolationMode

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -1130,6 +1130,14 @@ class HrpsysConfigurator:
         '''
         self.seq_svc.waitInterpolationOfGroup(gname)
 
+    def setInterpolationMode(self, mode):
+        '''!@brief
+        set interpolation mode.
+        @param i_mode_ new interpolation mode
+        @return true if set successfully, false otherwise
+        '''
+        return self.seq_svc.setInterpolationMode(mode)
+
     def getJointAngles(self):
         '''!@brief
         Returns the commanded joint angle values.


### PR DESCRIPTION
you can change interpolation mode by
```
hcf.setInterpolationMode(OpenHRP.SequencePlayerService.LINEAR)                                     
hcf.setInterpolationMode(OpenHRP.SequencePlayerService.HOFFARBIB)  
```

for full test
```
roslaunch hrpsys samplerobot.launch
```
and run 
```
from hrpsys.hrpsys_config import *
import OpenHRP
hcf = HrpsysConfigurator()
hcf.init ("SampleRobot(Robot)0")
for fname, mode in zip(['/tmp/default', '/tmp/linear', '/tmp/hoffarbib'], [False, OpenHRP.SequencePl\
ayerService.LINEAR, OpenHRP.SequencePlayerService.HOFFARBIB]):
    print('fname ', fname, ', mode : ', mode)
    if mode:
	hcf.setInterpolationMode(mode)
    hcf.clearLog()
    hcf.setJointAngle('LARM_ELBOW', -90, 1)
    hcf.waitInterpolation()
    hcf.setJointAngle('LARM_ELBOW',   0, 1)
    hcf.waitInterpolation()
    hcf.saveLog(fname)
```
and you can get
![default](https://cloud.githubusercontent.com/assets/493276/16139540/7ba4612a-3483-11e6-89bb-764bcaa7d32c.png)
![linear](https://cloud.githubusercontent.com/assets/493276/16139545/862342a6-3483-11e6-90d5-94eaa604dae5.png)
![hoffarbib](https://cloud.githubusercontent.com/assets/493276/16139718/487e2f2c-3485-11e6-8804-bbea0d15a71e.png)

with a command like
```
gnuplot -e 'set terminal png; set output 'default.png'; plot "/tmp/default.sh_qOut" using 1:24; '
```
