### PR TITLE
add test for CollisionDetector on initial collision state

### DIFF
--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(controller_time_list 0.002 0.005) # [s]
 set(controller_period_list 500 200) # [Hz]
 set(COLLISION_LOOP 1)
+set(L_SHOULDER_R_INITIAL 0.0)
 foreach(_idx 0 1)
   list(GET controller_time_list ${_idx} _tmp_controller_time)
   list(GET controller_period_list ${_idx} _tmp_controller_period)
@@ -19,6 +20,13 @@ foreach(_idx 0 1)
 endforeach()
 configure_file(SampleRobot.kinematicsonly.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.kinematicsonly.xml)
 configure_file(SampleRobot.carryobject.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.carryobject.xml)
+
+##
+set(CONTROLLER_TIME 0.002)
+set(CONTROLLER_PERIOD 500)
+set(L_SHOULDER_R_INITIAL -0.15) ##
+configure_file(SampleRobot.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500_init_col.xml)
+set(L_SHOULDER_R_INITIAL 0.0)  ## revert initial angle
 
 # for virtual force sensor testing
 set(CONTROLLER_TIME 0.002)
@@ -45,6 +53,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.conf
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.log.conf
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.xml
+  ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500_init_col.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.torque.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.RobotHardware.500.conf
   # files for 200[Hz]  = 0.005[s]

--- a/sample/SampleRobot/SampleRobot.xml.in
+++ b/sample/SampleRobot/SampleRobot.xml.in
@@ -93,7 +93,7 @@
    <property name="LARM_SHOULDER_P.angle" value="0.0"/>
    <property name="LARM_SHOULDER_P.mode" value="HighGain"/>
    <property name="LARM_SHOULDER_P.NumOfAABB" value="1"/>
-   <property name="LARM_SHOULDER_R.angle" value="0.0"/>
+   <property name="LARM_SHOULDER_R.angle" value="@L_SHOULDER_R_INITIAL@"/>
    <property name="LARM_SHOULDER_R.mode" value="HighGain"/>
    <property name="LARM_SHOULDER_R.NumOfAABB" value="1"/>
    <property name="LARM_SHOULDER_Y.angle" value="0.0"/>

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -27,7 +27,7 @@ def init ():
 # demo functions
 def demoCollisionCheckSafe ():
     print >> sys.stderr, "1. CollisionCheck in safe pose"
-    hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
+    hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:

--- a/test/test-samplerobot-co-init_collision.test
+++ b/test/test-samplerobot-co-init_collision.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot.launch" >
+    <arg name="GUI" value="false" />
+    <arg name="corbaport" value="2809" />
+    <arg name="PROJECT_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500_init_col.xml"/>
+    <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.conf"/>
+  </include>
+
+  <test test-name="samplerobot_init_collision" pkg="hrpsys" type="test-samplerobot-collision.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
+</launch>

--- a/test/test-samplerobot-co_loop-init_collision.test
+++ b/test/test-samplerobot-co_loop-init_collision.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot.launch" >
+    <arg name="GUI" value="false" />
+    <arg name="corbaport" value="2809" />
+    <arg name="PROJECT_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500_init_col.xml"/>
+    <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.co_loop.conf"/>
+  </include>
+
+  <test test-name="samplerobot_co_loop" pkg="hrpsys" type="test-samplerobot-collision.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
+</launch>


### PR DESCRIPTION
collisionDetectorがinitialize時にcollision状態の時の挙動のテストを加えました。
現状では、failします。 （initialize時にcollision状態だと、collision freeの状態に移行できない）
修正PRは、この後行います。