### PR TITLE
get out from initial collision state

### DIFF
--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -452,6 +452,14 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
                 }
             }
             if ( m_safe_posture ) {
+                if (! m_have_safe_posture ) {
+                    // first transition collision -> safe
+                    std::cerr << "[" << m_profile.instance_name << "] set safe posture" << std::endl;
+                    for ( int i = 0; i < m_q.data.length(); i++ ) {
+                        m_lastsafe_jointdata[i] = m_robot->joint(i)->q;
+                    }
+                    m_interpolator->set(m_lastsafe_jointdata); // Set current angles as initial angle for recover
+                }
                 m_have_safe_posture = true;
                 if (m_recover_time != default_recover_time) {
                     // sefe or recover

--- a/sample/SampleRobot/CMakeLists.txt
+++ b/sample/SampleRobot/CMakeLists.txt
@@ -2,6 +2,7 @@
 set(controller_time_list 0.002 0.005) # [s]
 set(controller_period_list 500 200) # [Hz]
 set(COLLISION_LOOP 1)
+set(L_SHOULDER_R_INITIAL 0.0)
 foreach(_idx 0 1)
   list(GET controller_time_list ${_idx} _tmp_controller_time)
   list(GET controller_period_list ${_idx} _tmp_controller_period)
@@ -19,6 +20,13 @@ foreach(_idx 0 1)
 endforeach()
 configure_file(SampleRobot.kinematicsonly.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.kinematicsonly.xml)
 configure_file(SampleRobot.carryobject.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.carryobject.xml)
+
+##
+set(CONTROLLER_TIME 0.002)
+set(CONTROLLER_PERIOD 500)
+set(L_SHOULDER_R_INITIAL -0.15) ##
+configure_file(SampleRobot.xml.in ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500_init_col.xml)
+set(L_SHOULDER_R_INITIAL 0.0)  ## revert initial angle
 
 # for virtual force sensor testing
 set(CONTROLLER_TIME 0.002)
@@ -45,6 +53,7 @@ install(FILES
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.conf
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.log.conf
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.xml
+  ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500_init_col.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.500.torque.xml
   ${CMAKE_CURRENT_BINARY_DIR}/SampleRobot.RobotHardware.500.conf
   # files for 200[Hz]  = 0.005[s]

--- a/sample/SampleRobot/SampleRobot.xml.in
+++ b/sample/SampleRobot/SampleRobot.xml.in
@@ -93,7 +93,7 @@
    <property name="LARM_SHOULDER_P.angle" value="0.0"/>
    <property name="LARM_SHOULDER_P.mode" value="HighGain"/>
    <property name="LARM_SHOULDER_P.NumOfAABB" value="1"/>
-   <property name="LARM_SHOULDER_R.angle" value="0.0"/>
+   <property name="LARM_SHOULDER_R.angle" value="@L_SHOULDER_R_INITIAL@"/>
    <property name="LARM_SHOULDER_R.mode" value="HighGain"/>
    <property name="LARM_SHOULDER_R.NumOfAABB" value="1"/>
    <property name="LARM_SHOULDER_Y.angle" value="0.0"/>

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -27,7 +27,7 @@ def init ():
 # demo functions
 def demoCollisionCheckSafe ():
     print >> sys.stderr, "1. CollisionCheck in safe pose"
-    hcf.seq_svc.setJointAngles(col_safe_pose, 1.0);
+    hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -13,6 +13,15 @@ except:
     import socket
     import time
 
+def vector_equal_eps (vec1, vec2, eps=1e-5):
+    if len(vec1) == len(vec2):
+        for e1, e2 in zip(vec1, vec2):
+            if abs(e1 - e2) > eps:
+                return False
+        return True
+    else:
+        return False
+
 def init ():
     global hcf, init_pose, col_safe_pose, col_fail_pose, hrpsys_version
     hcf = HrpsysConfigurator()
@@ -29,6 +38,11 @@ def demoCollisionCheckSafe ():
     print >> sys.stderr, "1. CollisionCheck in safe pose"
     hcf.seq_svc.setJointAngles(col_safe_pose, 3.0);
     hcf.waitInterpolation();
+    counter = 0
+    while (counter < 20) and (not vector_equal_eps([x / 180 * math.pi  for x in hcf.getJointAngles()], col_safe_pose)):
+        time.sleep(0.2)
+        counter = counter + 1
+    assert(counter != 20)
     cs=hcf.co_svc.getCollisionStatus()[1]
     if cs.safe_posture:
         print >> sys.stderr, "  => Safe pose"
@@ -36,7 +50,7 @@ def demoCollisionCheckSafe ():
 
 def demoCollisionCheckFail ():
     print >> sys.stderr, "2. CollisionCheck in fail pose"
-    hcf.seq_svc.setJointAngles(col_fail_pose, 1.0);
+    hcf.seq_svc.setJointAngles(col_fail_pose, 3.0);
     hcf.waitInterpolation();
     cs=hcf.co_svc.getCollisionStatus()[1]
     if not cs.safe_posture:

--- a/test/test-samplerobot-co-init_collision.test
+++ b/test/test-samplerobot-co-init_collision.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot.launch" >
+    <arg name="GUI" value="false" />
+    <arg name="corbaport" value="2809" />
+    <arg name="PROJECT_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500_init_col.xml"/>
+    <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.conf"/>
+  </include>
+
+  <test test-name="samplerobot_init_collision" pkg="hrpsys" type="test-samplerobot-collision.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
+</launch>

--- a/test/test-samplerobot-co_loop-init_collision.test
+++ b/test/test-samplerobot-co_loop-init_collision.test
@@ -1,0 +1,11 @@
+<launch>
+  <include file="$(find hrpsys)/launch/samplerobot.launch" >
+    <arg name="GUI" value="false" />
+    <arg name="corbaport" value="2809" />
+    <arg name="PROJECT_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500_init_col.xml"/>
+    <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.co_loop.conf"/>
+  </include>
+
+  <test test-name="samplerobot_co_loop" pkg="hrpsys" type="test-samplerobot-collision.py"
+        args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
+</launch>

--- a/test/test-samplerobot-co_loop-init_collision.test
+++ b/test/test-samplerobot-co_loop-init_collision.test
@@ -6,6 +6,6 @@
     <arg name="CONF_FILE" value="$(find hrpsys)/samples/SampleRobot/SampleRobot.500.co_loop.conf"/>
   </include>
 
-  <test test-name="samplerobot_co_loop" pkg="hrpsys" type="test-samplerobot-collision.py"
+  <test test-name="samplerobot_co_loop_init-collision" pkg="hrpsys" type="test-samplerobot-collision.py"
         args="-ORBInitRef NameService=corbaloc:iiop:localhost:2809/NameService" retry="2"/>
 </launch>

--- a/test/test-samplerobot-collision.py
+++ b/test/test-samplerobot-collision.py
@@ -9,7 +9,7 @@ sys.path.append(os.path.join(check_output(['pkg-config', 'hrpsys-base', '--varia
 import samplerobot_collision_detector
 import unittest, rostest
 
-if '__name:=samplerobot_co_loop' in sys.argv:
+if [s for s in sys.argv if '__name:=samplerobot_co_loop' in s]:
     class TestSampleRobotCollisionDetector(unittest.TestCase):
         def test_demo (self):
             samplerobot_collision_detector.demo_co_loop()


### PR DESCRIPTION
初期状態でコリジョンしている時に、SAFEモードに移行しない問題の修正です。
(https://github.com/fkanehiro/hrpsys-base/pull/993 でエンバグした）
テストも通るはずです。
https://github.com/fkanehiro/hrpsys-base/pull/1014

```
[ROSTEST]-----------------------------------------------------------------------

[hrpsys.rosunit-samplerobot_init_collision/test_demo][FAILURE]------------------
File "/usr/lib/python2.7/unittest/case.py", line 327, in run
    testMethod()
  File "/home/travis/catkin_ws/install_isolated/share/hrpsys/test/test-samplerobot-collision.py", line 19, in test_demo
    samplerobot_collision_detector.demo()
  File "/home/travis/catkin_ws/install_isolated/share/hrpsys/samples/SampleRobot/samplerobot_collision_detector.py", line 129, in demo
    demoCollisionCheckFail()
  File "/home/travis/catkin_ws/install_isolated/share/hrpsys/samples/SampleRobot/samplerobot_collision_detector.py", line 50, in demoCollisionCheckFail
    assert(cs.safe_posture is True)
--------------------------------------------------------------------------------


SUMMARY
[1;31m * RESULT: FAIL[0m
 * TESTS: 1
 * ERRORS: 0
[1;31m * FAILURES: 1[0m
```