### PR TITLE
[rtc/Beeper] Update mutex lock and use buffer for communication between beep thread and real-time thread.

### DIFF
--- a/rtc/Beeper/Beeper.h
+++ b/rtc/Beeper/Beeper.h
@@ -129,7 +129,6 @@ class Beeper
   // </rtc-template>
 
  private:
-  double m_dt;
   long long m_loop;
   unsigned int m_debugLevel;
   pthread_t beep_thread;


### PR DESCRIPTION
BeeperRTCでbeepをmutexをかけるのはパラメータの変更だけにし（時間かかってロックしないように）、
また確実にならす or 音を消すためにバッファを用意しました。

よろしくお願いします。