### PR TITLE
add new stride limitation type when goPos and goVelocity

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -132,6 +132,15 @@ module OpenHRP
     };
 
     /**
+     * @enum StrideLimitationType
+     * @brief Type of stride limitation
+     */
+    enum StrideLimitationType {
+      SQUARE,
+      CIRCLE
+    };
+
+    /**
      * @struct FootstepParam
      * @brief Foot step parameters.
      */
@@ -225,6 +234,8 @@ module OpenHRP
       DblArray4 overwritable_stride_limitation;
       /// Use stride limitation or not
       boolean use_stride_limitation;
+      /// Stride limitation type
+      StrideLimitationType stride_limitation_type;
     };
 
     /**

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -236,6 +236,8 @@ module OpenHRP
       boolean use_stride_limitation;
       /// Stride limitation type
       StrideLimitationType stride_limitation_type;
+      /// Leg margin between foot end effector position and foot edge (front, rear, outside, inside) [m]
+      DblArray4 leg_margin;
     };
 
     /**

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -389,7 +389,6 @@ class HrpsysConfigurator:
             if self.es:
                 connectPorts(self.st.port("emergencySignal"), self.es.port("emergencySignal"))
             connectPorts(self.st.port("emergencySignal"), self.abc.port("emergencySignal"))
-            connectPorts(self.st.port("legMargin"), self.abc.port("legMargin"))
 
         # ref force moment connection
         for sen in self.getForceSensorNames():

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -1422,6 +1422,11 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_overwritable_footstep_index_offset(i_param.overwritable_footstep_index_offset);
   gg->set_overwritable_stride_limitation(i_param.overwritable_stride_limitation);
   gg->set_use_stride_limitation(i_param.use_stride_limitation);
+  if (i_param.stride_limitation_type == OpenHRP::AutoBalancerService::SQUARE) {
+    gg->set_stride_limitation_type(SQUARE);
+  } else if (i_param.stride_limitation_type == OpenHRP::AutoBalancerService::CIRCLE) {
+    gg->set_stride_limitation_type(CIRCLE);
+  }
 
   // print
   gg->print_param(std::string(m_profile.instance_name));
@@ -1495,6 +1500,11 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
     i_param.overwritable_stride_limitation[i] = gg->get_overwritable_stride_limitation(i);
   }
   i_param.use_stride_limitation = gg->get_use_stride_limitation();
+  if (gg->get_stride_limitation_type() == SQUARE) {
+    i_param.stride_limitation_type = OpenHRP::AutoBalancerService::SQUARE;
+  } else if (gg->get_stride_limitation_type() == CIRCLE) {
+    i_param.stride_limitation_type = OpenHRP::AutoBalancerService::CIRCLE;
+  }
   return true;
 };
 

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -62,7 +62,6 @@ AutoBalancer::AutoBalancer(RTC::Manager* manager)
       m_AutoBalancerServicePort("AutoBalancerService"),
       m_walkingStatesOut("walkingStates", m_walkingStates),
       m_sbpCogOffsetOut("sbpCogOffset", m_sbpCogOffset),
-      m_legMarginIn("legMargin", m_legMargin),
       // </rtc-template>
       gait_type(BIPED),
       move_base_gain(0.8),
@@ -91,7 +90,6 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     addInPort("zmpIn", m_zmpIn);
     addInPort("optionalData", m_optionalDataIn);
     addInPort("emergencySignal", m_emergencySignalIn);
-    addInPort("legMargin", m_legMarginIn);
 
     // Set OutPort buffer
     addOutPort("q", m_qOut);
@@ -443,12 +441,6 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
         //     is_stop_mode = true;
         //     gg->emergency_stop();
         // }
-    }
-    if (m_legMarginIn.isNew()) {
-      m_legMarginIn.read();
-      for (size_t i = 0; i < 4; i++) {
-        gg->set_leg_margin(m_legMargin.data[i], i);
-      }
     }
 
     Guard guard(m_mutex);
@@ -1420,6 +1412,7 @@ bool AutoBalancer::setGaitGeneratorParam(const OpenHRP::AutoBalancerService::Gai
   gg->set_zmp_weight_map(boost::assign::map_list_of<leg_type, double>(RLEG, i_param.zmp_weight_map[0])(LLEG, i_param.zmp_weight_map[1])(RARM, i_param.zmp_weight_map[2])(LARM, i_param.zmp_weight_map[3]));
   gg->set_optional_go_pos_finalize_footstep_num(i_param.optional_go_pos_finalize_footstep_num);
   gg->set_overwritable_footstep_index_offset(i_param.overwritable_footstep_index_offset);
+  gg->set_leg_margin(i_param.leg_margin);
   gg->set_overwritable_stride_limitation(i_param.overwritable_stride_limitation);
   gg->set_use_stride_limitation(i_param.use_stride_limitation);
   if (i_param.stride_limitation_type == OpenHRP::AutoBalancerService::SQUARE) {
@@ -1496,6 +1489,9 @@ bool AutoBalancer::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGener
   i_param.zmp_weight_map[3] = tmp_zmp_weight_map[LARM];
   i_param.optional_go_pos_finalize_footstep_num = gg->get_optional_go_pos_finalize_footstep_num();
   i_param.overwritable_footstep_index_offset = gg->get_overwritable_footstep_index_offset();
+  for (size_t i=0; i<4; i++) {
+    i_param.leg_margin[i] = gg->get_leg_margin(i);
+  }
   for (size_t i=0; i<4; i++) {
     i_param.overwritable_stride_limitation[i] = gg->get_overwritable_stride_limitation(i);
   }

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -133,8 +133,6 @@ class AutoBalancer
   std::vector<InPort<TimedDoubleSeq> *> m_ref_forceIn;
   TimedLong m_emergencySignal;
   InPort<TimedLong> m_emergencySignalIn;
-  TimedDoubleSeq m_legMargin;
-  InPort<TimedDoubleSeq> m_legMarginIn;
   // for debug
   TimedPoint3D m_cog;
   

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -630,17 +630,18 @@ namespace rats
     return solved;
   };
 
-  void gait_generator::limit_stride (step_node& cur_fs, const step_node& prev_fs)
+  void gait_generator::limit_stride (step_node& cur_fs, const step_node& prev_fs) const
   {
     leg_type cur_leg = cur_fs.l_r;
     // prev_fs frame
     cur_fs.worldcoords.pos = prev_fs.worldcoords.rot.transpose() * (cur_fs.worldcoords.pos - prev_fs.worldcoords.pos);
-    double stride_r = std::pow(cur_fs.worldcoords.pos(0), 2.0) + std::pow(cur_fs.worldcoords.pos(1) + (cur_leg == LLEG ? -1 : 1) * overwritable_stride_limitation[3], 2.0);
+    double stride_r = std::pow(cur_fs.worldcoords.pos(0), 2.0) + std::pow(cur_fs.worldcoords.pos(1) + footstep_param.leg_default_translate_pos[cur_leg == LLEG ? RLEG : LLEG](1) - footstep_param.leg_default_translate_pos[cur_leg](1), 2.0);
     // front, rear, outside limitation
     double stride_r_limit = std::pow(std::max(overwritable_stride_limitation[cur_fs.worldcoords.pos(0) >= 0 ? 0 : 1], overwritable_stride_limitation[2] - overwritable_stride_limitation[3]), 2.0);
     if (stride_r > stride_r_limit) {
-        cur_fs.worldcoords.pos(0) *= sqrt(stride_r_limit / stride_r);
-        cur_fs.worldcoords.pos(1) = (cur_leg == LLEG ? 1 : -1) * overwritable_stride_limitation[3] + sqrt(stride_r_limit / stride_r) * (cur_fs.worldcoords.pos(1) + (cur_leg == LLEG ? -1 : 1) * overwritable_stride_limitation[3]);
+      if ((cur_leg == LLEG ? 1 : -1) * cur_fs.worldcoords.pos(1) < footstep_param.leg_default_translate_pos[LLEG](1) - footstep_param.leg_default_translate_pos[RLEG](1)) cur_fs.worldcoords.pos(0) *= sqrt(stride_r_limit / stride_r);
+      cur_fs.worldcoords.pos(1) = footstep_param.leg_default_translate_pos[cur_leg](1) - footstep_param.leg_default_translate_pos[cur_leg == LLEG ? RLEG : LLEG](1) +
+                                  sqrt(stride_r_limit / stride_r) * (cur_fs.worldcoords.pos(1) + footstep_param.leg_default_translate_pos[cur_leg == LLEG ? RLEG : LLEG](1) - footstep_param.leg_default_translate_pos[cur_leg](1));
     }
     if (cur_fs.worldcoords.pos(0) > overwritable_stride_limitation[0]) cur_fs.worldcoords.pos(0) = overwritable_stride_limitation[0];
     if (cur_fs.worldcoords.pos(0) < -1 * overwritable_stride_limitation[0]) cur_fs.worldcoords.pos(0) = -1 * overwritable_stride_limitation[1];

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -20,6 +20,7 @@ namespace rats
 
     enum orbit_type {SHUFFLING, CYCLOID, RECTANGLE, STAIR, CYCLOIDDELAY, CYCLOIDDELAYKICK, CROSS};
     enum leg_type {RLEG, LLEG, RARM, LARM, BOTH, ALL};
+    enum stride_limitation_type {SQUARE, CIRCLE};
 
     struct step_node
     {
@@ -882,6 +883,7 @@ namespace rats
     bool solved;
     double leg_margin[4], overwritable_stride_limitation[4];
     bool use_stride_limitation;
+    stride_limitation_type default_stride_limitation_type;
 
     /* preview controller parameters */
     //preview_dynamics_filter<preview_control>* preview_controller_ptr;
@@ -928,7 +930,7 @@ namespace rats
         dt(_dt), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0), overwritable_footstep_index_offset(1),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
-        use_inside_step_limitation(true), use_stride_limitation(false),
+        use_inside_step_limitation(true), use_stride_limitation(false), default_stride_limitation_type(SQUARE),
         preview_controller_ptr(NULL) {
         swing_foot_zmp_offsets = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
         prev_que_sfzos = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
@@ -1086,6 +1088,7 @@ namespace rats
       }
     };
     void set_use_stride_limitation (const bool _use_stride_limitation) { use_stride_limitation = _use_stride_limitation; };
+    void set_stride_limitation_type (const stride_limitation_type _tmp) { default_stride_limitation_type = _tmp; };
     /* Get overwritable footstep index. For example, if overwritable_footstep_index_offset = 1, overwrite next footstep. If overwritable_footstep_index_offset = 0, overwrite current swinging footstep. */
     size_t get_overwritable_index () const
     {
@@ -1239,6 +1242,7 @@ namespace rats
     size_t get_overwrite_check_timing () const { return static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1;}; // Almost middle of step time
     double get_overwritable_stride_limitation (const size_t idx) const { return overwritable_stride_limitation[idx]; };
     bool get_use_stride_limitation () const { return use_stride_limitation; };
+    stride_limitation_type get_stride_limitation_type () const { return default_stride_limitation_type; };
     void print_param (const std::string& print_str = "") const
     {
         double stride_fwd_x, stride_y, stride_th, stride_bwd_x;
@@ -1286,6 +1290,12 @@ namespace rats
         for (int i = 0; i < get_NUM_TH_PHASES(); i++) std::cerr << tmp_ratio[i] << " ";
         std::cerr << "]" << std::endl;
         std::cerr << "[" << print_str << "]   optional_go_pos_finalize_footstep_num = " << optional_go_pos_finalize_footstep_num << ", overwritable_footstep_index_offset = " << overwritable_footstep_index_offset << std::endl;
+        std::cerr << "[" << print_str << "]   default_stride_limitation_type = ";
+        if (default_stride_limitation_type == SQUARE) {
+          std::cerr << "SQUARE" << std::endl;
+        } else if (default_stride_limitation_type == CIRCLE) {
+          std::cerr << "CIRCLE" << std::endl;
+        }
     };
   };
 }

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -947,7 +947,7 @@ namespace rats
                                     const std::vector<step_node>& initial_swing_leg_dst_steps,
                                     const double delay = 1.6);
     bool proc_one_tick ();
-    void limit_stride (step_node& cur_fs, const step_node& prev_fs);
+    void limit_stride (step_node& cur_fs, const step_node& prev_fs) const;
     void append_footstep_nodes (const std::vector<std::string>& _legs, const std::vector<coordinates>& _fss)
     {
         std::vector<step_node> tmp_sns;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -1079,8 +1079,10 @@ namespace rats
         append_finalize_footstep(overwrite_footstep_nodes_list);
         print_footstep_nodes_list(overwrite_footstep_nodes_list);
     };
-    void set_leg_margin (const double _leg_margin, const size_t idx) {
-        leg_margin[idx] = _leg_margin;
+    void set_leg_margin (const double _leg_margin[4]) {
+      for (size_t i = 0; i < 4; i++) {
+        leg_margin[i] = _leg_margin[i];
+      }
     };
     void set_overwritable_stride_limitation (const double _overwritable_stride_limitation[4]) {
       for (size_t i = 0; i < 4; i++) {
@@ -1240,6 +1242,7 @@ namespace rats
     size_t get_optional_go_pos_finalize_footstep_num () const { return optional_go_pos_finalize_footstep_num; };
     bool is_finalizing (const double tm) const { return ((preview_controller_ptr->get_delay()*2 - default_step_time/dt)-finalize_count) <= (tm/dt)-1; };
     size_t get_overwrite_check_timing () const { return static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * 0.5) - 1;}; // Almost middle of step time
+    double get_leg_margin (const size_t idx) const { return leg_margin[idx]; };
     double get_overwritable_stride_limitation (const size_t idx) const { return overwritable_stride_limitation[idx]; };
     bool get_use_stride_limitation () const { return use_stride_limitation; };
     stride_limitation_type get_stride_limitation_type () const { return default_stride_limitation_type; };

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -62,7 +62,6 @@ Stabilizer::Stabilizer(RTC::Manager* manager)
     m_actContactStatesOut("actContactStates", m_actContactStates),
     m_COPInfoOut("COPInfo", m_COPInfo),
     m_emergencySignalOut("emergencySignal", m_emergencySignal),
-    m_legMarginOut("legMargin", m_legMargin),
     // for debug output
     m_originRefZmpOut("originRefZmp", m_originRefZmp),
     m_originRefCogOut("originRefCog", m_originRefCog),
@@ -124,7 +123,6 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   addOutPort("actContactStates", m_actContactStatesOut);
   addOutPort("COPInfo", m_COPInfoOut);
   addOutPort("emergencySignal", m_emergencySignalOut);
-  addOutPort("legMargin", m_legMarginOut);
   // for debug output
   addOutPort("originRefZmp", m_originRefZmpOut);
   addOutPort("originRefCog", m_originRefCogOut);
@@ -391,7 +389,6 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   total_mass = m_robot->totalMass();
   ref_zmp_aux = hrp::Vector3::Zero();
   m_actContactStates.data.length(m_contactStates.data.length());
-  m_legMargin.data.length(4);
   for (size_t i = 0; i < m_contactStates.data.length(); i++) {
     contact_states.push_back(true);
     prev_contact_states.push_back(true);
@@ -600,12 +597,6 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
       m_actContactStatesOut.write();
       m_COPInfo.tm = m_qRef.tm;
       m_COPInfoOut.write();
-      m_legMargin.data[0] = szd->get_leg_front_margin();
-      m_legMargin.data[1] = szd->get_leg_rear_margin();
-      m_legMargin.data[2] = szd->get_leg_outside_margin();
-      m_legMargin.data[3] = szd->get_leg_inside_margin();
-      m_legMargin.tm = m_qRef.tm;
-      m_legMarginOut.write();
       //m_tauOut.write();
       // for debug output
       m_originRefZmp.data.x = ref_zmp(0); m_originRefZmp.data.y = ref_zmp(1); m_originRefZmp.data.z = ref_zmp(2);

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -163,7 +163,6 @@ class Stabilizer
   RTC::TimedDoubleSeq m_qRefSeq;
   RTC::TimedBoolean m_walkingStates;
   RTC::TimedPoint3D m_sbpCogOffset;
-  RTC::TimedDoubleSeq m_legMargin;
   // for debug ouput
   RTC::TimedPoint3D m_originRefZmp, m_originRefCog, m_originRefCogVel, m_originNewZmp;
   RTC::TimedPoint3D m_originActZmp, m_originActCog, m_originActCogVel;
@@ -206,7 +205,6 @@ class Stabilizer
   RTC::OutPort<RTC::TimedBooleanSeq> m_actContactStatesOut;
   RTC::OutPort<RTC::TimedDoubleSeq> m_COPInfoOut;
   RTC::OutPort<RTC::TimedLong> m_emergencySignalOut;
-  RTC::OutPort<RTC::TimedDoubleSeq> m_legMarginOut;
   // for debug output
   RTC::OutPort<RTC::TimedPoint3D> m_originRefZmpOut, m_originRefCogOut, m_originRefCogVelOut, m_originNewZmpOut;
   RTC::OutPort<RTC::TimedPoint3D> m_originActZmpOut, m_originActCogOut, m_originActCogVelOut;

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -680,17 +680,18 @@ def demoGaitGeneratorChangeStrideLimitationType():
     # set params
     orig_ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
     ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
-    ggp.stride_limitation_type = OpenHRP.AutoBalancerService.CIRCLE;
-    ggp.overwritable_stride_limitation = [0.15, 0.1, 0.25, 0.1];
+    ggp.stride_limitation_type = OpenHRP.AutoBalancerService.CIRCLE
+    ggp.overwritable_stride_limitation = [0.15, 0.1, 0.25, 0.1]
+    ggp.leg_margin = [182.0*1e-3, 72.0*1e-3, 71.12*1e-3, 71.12*1e-3]
     hcf.abc_svc.setGaitGeneratorParam(ggp)
     # gopos check 1
-    goalx=0.5;goaly=0.5;goalth=20.0
+    goalx=0.3;goaly=0.3;goalth=20.0
     prev_dst_foot_midcoords=hcf.abc_svc.getFootstepParam()[1].dst_foot_midcoords
     hcf.abc_svc.goPos(goalx, goaly, goalth)
     hcf.abc_svc.waitFootSteps()
     checkGoPosParam(goalx, goaly, goalth, prev_dst_foot_midcoords)
     # gopos check 2
-    goalx=-0.5;goaly=-0.5;goalth=-10.0
+    goalx=-0.3;goaly=-0.3;goalth=-10.0
     prev_dst_foot_midcoords=hcf.abc_svc.getFootstepParam()[1].dst_foot_midcoords
     hcf.abc_svc.goPos(goalx, goaly, goalth)
     hcf.abc_svc.waitFootSteps()

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -671,6 +671,35 @@ def demoGaitGeneratorSetFootStepsWithArms():
     hcf.abc_svc.setGaitGeneratorParam(orig_ggp)
     hcf.startAutoBalancer()
 
+def demoGaitGeneratorChangeStrideLimitationType():
+    print >> sys.stderr, "19. Change stride limitation type to CIRCLE"
+    hcf.startAutoBalancer();
+    # initialize dst_foot_midcoords
+    hcf.abc_svc.goPos(0,0,0)
+    hcf.abc_svc.waitFootSteps()
+    # set params
+    orig_ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
+    ggp = hcf.abc_svc.getGaitGeneratorParam()[1]
+    ggp.stride_limitation_type = OpenHRP.AutoBalancerService.CIRCLE;
+    ggp.overwritable_stride_limitation = [0.15, 0.1, 0.25, 0.1];
+    hcf.abc_svc.setGaitGeneratorParam(ggp)
+    # gopos check 1
+    goalx=0.5;goaly=0.5;goalth=20.0
+    prev_dst_foot_midcoords=hcf.abc_svc.getFootstepParam()[1].dst_foot_midcoords
+    hcf.abc_svc.goPos(goalx, goaly, goalth)
+    hcf.abc_svc.waitFootSteps()
+    checkGoPosParam(goalx, goaly, goalth, prev_dst_foot_midcoords)
+    # gopos check 2
+    goalx=-0.5;goaly=-0.5;goalth=-10.0
+    prev_dst_foot_midcoords=hcf.abc_svc.getFootstepParam()[1].dst_foot_midcoords
+    hcf.abc_svc.goPos(goalx, goaly, goalth)
+    hcf.abc_svc.waitFootSteps()
+    checkGoPosParam(goalx, goaly, goalth, prev_dst_foot_midcoords)
+    checkActualBaseAttitude()
+    print >> sys.stderr, "  Change stride limitation type to CIRCLE=>OK"
+    # reset params
+    hcf.abc_svc.setGaitGeneratorParam(orig_ggp)
+
 def demoStandingPosResetting():
     print >> sys.stderr, "demoStandingPosResetting"
     hcf.abc_svc.goPos(0,0,math.degrees(-1*checkParameterFromLog("WAIST")[5])); # Rot yaw
@@ -711,6 +740,7 @@ def demo():
         demoGaitGeneratorGoPosOverwrite()
         demoGaitGeneratorGrasplessManipMode()
         demoGaitGeneratorSetFootStepsWithArms()
+        demoGaitGeneratorChangeStrideLimitationType()
 
 if __name__ == '__main__':
     demo()


### PR DESCRIPTION
goPosやgoVelocityにおいてfootstepを求める際の歩幅の新しい決め方を追加しました．
また，歩幅制約をleg_default_translate_posを使うようにして若干変更しました．
テストも追加しました．
デフォルトの挙動は今までと変わりません．
![stride_limitation](https://cloud.githubusercontent.com/assets/11713954/17729105/72875c60-649d-11e6-9e5e-96aefe7f0a59.jpg)
