### PR TITLE
[rtc/TorqueFilter/IIRFilter.h] Fix type of getCurrentValue

### DIFF
--- a/rtc/TorqueFilter/IIRFilter.h
+++ b/rtc/TorqueFilter/IIRFilter.h
@@ -79,7 +79,7 @@ public:
         const_param = 2 * M_PI * cutoff_freq * dt;
     };
     double getCutOffFreq () const { return cutoff_freq; };
-    double getCurrentValue () const { return prev_value; };
+    T getCurrentValue () const { return prev_value; };
 };
 
 #endif // IIRFilter_H


### PR DESCRIPTION
[rtc/TorqueFilter/IIRFilter.h] Fix type of getCurrentValue
型がちがってたきがするので直しました。
よろしくお願いします。