### PR TITLE
[rtc/ReferenceForceUpdater/,idl/ReferenceForceUpdaterService.idl] add frame parameter to set move_dir in world coordinates

### DIFF
--- a/idl/ReferenceForceUpdaterService.idl
+++ b/idl/ReferenceForceUpdaterService.idl
@@ -16,6 +16,9 @@ module OpenHRP
       {
           /// Motion direction to update reference force
           DblSequence3 motion_dir;
+          /// frame of motion_dir ("local" or "world").
+          /// "local" is coordinate at end effector, and "world" is the coordinate between the feet.
+          string frame;
           /// Update frequency [Hz]
           double update_freq;
           /// Update time ratio \in [0,1]

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -172,11 +172,13 @@ class ReferenceForceUpdater
     double i_gain;
     // Motion direction to update reference force
     hrp::Vector3 motion_dir;
+    std::string frame;
     int update_count;
     bool is_active, is_stopping;
     ReferenceForceUpdaterParam () {
       //params defined in idl
       motion_dir = hrp::Vector3::UnitZ();
+      frame="local";
       update_freq = 50; // Hz
       update_time_ratio = 0.5;
       p_gain = 0.02;


### PR DESCRIPTION
ReferenceForceUpdaterでmotion_dirのベクトルを渡す際に、
今までend effectorの座標で与えていましたが、
両足の間にある座標(foot-mid-coords)でも渡せるように,frame パラメータを追加しました。

```
p=hcf.rfu_svc.getReferenceForceUpdaterParam("larm")[1]
p.frame="local" # motion_dirの座標系はend effector の座標系 (default)
p.frame="world" # motion_dirの座標系は両足の真ん中(foot-mid-coords)
hcf.rfu_svc.setReferenceForceUpdaterParam("larm",p)
```
シミュレータで挙動を確認しました。