### PR TITLE
Check read_power_state flags to servo off

### DIFF
--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -229,7 +229,7 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
       robot::emg_reason reason;
       int id;
       if (m_robot->checkEmergency(reason, id)){
-          if (reason == robot::EMG_SERVO_ERROR){
+          if (reason == robot::EMG_SERVO_ERROR || reason == robot::EMG_POWER_OFF){
               m_robot->servo("all", false);
               m_emergencySignal.data = reason;
               m_emergencySignalOut.write();

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -237,7 +237,7 @@ public:
     /**
        \brief reasons of emergency
      */
-    typedef enum {EMG_SERVO_ERROR, EMG_FZ, EMG_SERVO_ALARM} emg_reason;
+    typedef enum {EMG_SERVO_ERROR, EMG_FZ, EMG_SERVO_ALARM, EMG_POWER_OFF} emg_reason;
 
     /**
        \brief check occurrence of emergency state
@@ -339,6 +339,7 @@ private:
     double m_dt;
     std::vector<double> m_commandOld, m_velocityOld;
     hrp::Vector3 G;
+    bool m_enable_poweroff_check;
 };
 
 #endif


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/1034
に基づいて、read_power_stateをよんでサーボOFFするものを作りました。
- servoがONでpowerがOFFのときに、サーボOFFするようにしました
- このときに、emergencySygnalとしてEMG_POWER_OFFを出力するようにしました
- デフォルトでは、この機能ははたらかずRobotHardwareの挙動が以前とかわらないようにしました。また、この機能はconfに`enable_poweroff_check:true`とかくとはたらくようにしました。

１点ご相談なのですが、サーボがきれたときなどで
RobotHardwareからemergencySygnalというのが出力されていて、
その値はrobot.hにenumで定義されてます。
```
    /**                                                                                                                                                                                                                                     
       \brief reasons of emergency                                                                                                                                                                                                          
     */
    typedef enum {EMG_SERVO_ERROR, EMG_FZ, EMG_SERVO_ALARM} emg_reason;
```
そのフラグにEMG_POWER_OFFというのを今回追加しました。
```
    /**                                                                                                                                                                                                                                     
       \brief reasons of emergency                                                                                                                                                                                                          
     */
    typedef enum {EMG_SERVO_ERROR, EMG_FZ, EMG_SERVO_ALARM, EMG_POWER_OFF} emg_reason;
```
デフォルトではこのフラグは出力されないですが、
EMG_POWER_OFFの追加は問題ないでしょうか。

よろしくお願いします。