### PR TITLE
Fix bug of hrpsys version checking. Use StrictVersion for version checking.

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -12,6 +12,7 @@ from waitInput import waitInputConfirm
 import socket
 import time
 import subprocess
+from distutils.version import StrictVersion
 
 # copy from transformations.py, Christoph Gohlke, The Regents of the University of California
 
@@ -355,14 +356,14 @@ class HrpsysConfigurator:
         connectPorts(self.seq.port("basePos"), self.sh.port("basePosIn"))
         connectPorts(self.seq.port("baseRpy"), self.sh.port("baseRpyIn"))
         connectPorts(self.seq.port("zmpRef"), self.sh.port("zmpIn"))
-        if self.seq_version >= '315.2.6':
+        if StrictVersion(self.seq_version) >= StrictVersion('315.2.6'):
             connectPorts(self.seq.port("optionalData"), self.sh.port("optionalDataIn"))
         connectPorts(self.sh.port("basePosOut"), [self.seq.port("basePosInit"),
                                                   self.fk.port("basePosRef")])
         connectPorts(self.sh.port("baseRpyOut"), [self.seq.port("baseRpyInit"),
                                                   self.fk.port("baseRpyRef")])
         connectPorts(self.sh.port("qOut"), self.seq.port("qInit"))
-        if self.seq_version >= '315.2.0':
+        if StrictVersion(self.seq_version) >= StrictVersion('315.2.0'):
             connectPorts(self.sh.port("zmpOut"), self.seq.port("zmpRefInit"))
         for sen in self.getForceSensorNames():
             connectPorts(self.seq.port(sen + "Ref"),
@@ -445,14 +446,14 @@ class HrpsysConfigurator:
         # connection for ic
         if self.ic:
             connectPorts(self.rh.port("q"), self.ic.port("qCurrent"))
-            if self.seq_version >= '315.3.0':
+            if StrictVersion(self.seq_version) >= StrictVersion('315.3.0'):
                 connectPorts(self.sh.port("basePosOut"), self.ic.port("basePosIn"))
                 connectPorts(self.sh.port("baseRpyOut"), self.ic.port("baseRpyIn"))
         # connection for rfu
         if self.rfu:
             if self.es:
                 connectPorts(self.es.port("q"), self.rfu.port("qRef"))
-            if self.seq_version >= '315.3.0':
+            if StrictVersion(self.seq_version) >= StrictVersion('315.3.0'):
                 connectPorts(self.sh.port("basePosOut"), self.rfu.port("basePosIn"))
                 connectPorts(self.sh.port("baseRpyOut"), self.rfu.port("baseRpyIn"))
         # connection for tf
@@ -1206,7 +1207,7 @@ class HrpsysConfigurator:
             raise RuntimeError("need to specify joint name")
         if frame_name:
             lname = lname + ':' + frame_name
-        if self.fk_version < '315.2.5' and ':' in lname:
+        if StrictVersion(self.fk_version) < StrictVersion('315.2.5') and ':' in lname:
             raise RuntimeError('frame_name ('+lname+') is not supported')
         pose = self.fk_svc.getCurrentPose(lname)
         if not pose[0]:
@@ -1306,7 +1307,7 @@ class HrpsysConfigurator:
             raise RuntimeError("need to specify joint name")
         if frame_name:
             lname = lname + ':' + frame_name
-        if self.fk_version < '315.2.5' and ':' in lname:
+        if StrictVersion(self.fk_version) < StrictVersion('315.2.5') and ':' in lname:
             raise RuntimeError('frame_name ('+lname+') is not supported')
         pose = self.fk_svc.getReferencePose(lname)
         if not pose[0]:
@@ -2034,13 +2035,13 @@ dr=0, dp=0, dw=0, tm=10, wait=True):
         return self.ic_svc.stopImpedanceController(arm)
 
     def startImpedance(self, arm, **kwargs):
-        if self.hrpsys_version and self.hrpsys_version < '315.2.0':
+        if self.hrpsys_version and StrictVersion(self.hrpsys_version) < StrictVersion('315.2.0'):
             print(self.configurator_name + '\033[31mstartImpedance: Try to connect unsupported RTC' + str(self.hrpsys_version) + '\033[0m')
         else:
             self.startImpedance_315_4(arm, **kwargs)
 
     def stopImpedance(self, arm):
-        if self.hrpsys_version and self.hrpsys_version < '315.2.0':
+        if self.hrpsys_version and StrictVersion(self.hrpsys_version) < StrictVersion('315.2.0'):
             print(self.configurator_name + '\033[31mstopImpedance: Try to connect unsupported RTC' + str(self.hrpsys_version) + '\033[0m')
         else:
             self.stopImpedance_315_4(arm)

--- a/sample/SampleRobot/samplerobot_auto_balancer.py
+++ b/sample/SampleRobot/samplerobot_auto_balancer.py
@@ -710,7 +710,8 @@ def demoStandingPosResetting():
 
 def demo():
     init()
-    if hrpsys_version >= '315.5.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         # sample for AutoBalancer mode
         demoAutoBalancerFixFeet()
         demoAutoBalancerFixFeetHands()

--- a/sample/SampleRobot/samplerobot_collision_detector.py
+++ b/sample/SampleRobot/samplerobot_collision_detector.py
@@ -147,7 +147,8 @@ def demo():
 
 def demo_co_loop():
     init()
-    if hrpsys_version >= '315.10.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.10.0'):
         demoCollisionCheckSafe()
         demoCollisionCheckFail()
         demoCollisionCheckFailWithSetTolerance()

--- a/sample/SampleRobot/samplerobot_emergency_stopper.py
+++ b/sample/SampleRobot/samplerobot_emergency_stopper.py
@@ -164,7 +164,8 @@ def demoEmergencyStopReleaseWhenDeactivated():
 
 def demo(key_interaction=False):
     init()
-    if hrpsys_version >= '315.6.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.6.0'):
         if key_interaction:
             demoEmergencyStopJointAngleWithKeyInteracton()
         else:

--- a/sample/SampleRobot/samplerobot_impedance_controller.py
+++ b/sample/SampleRobot/samplerobot_impedance_controller.py
@@ -34,7 +34,8 @@ def demo():
     hcf.startImpedance("larm")
     hcf.stopImpedance("larm")
     hcf.stopImpedance("rarm")
-    if hrpsys_version < '315.5.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) < StrictVersion('315.5.0'):
         return
 
     # 1. Getter check

--- a/sample/SampleRobot/samplerobot_kalman_filter.py
+++ b/sample/SampleRobot/samplerobot_kalman_filter.py
@@ -152,7 +152,8 @@ def demoSetKalmanFilterParameter():
 
 def demo():
     init()
-    if hrpsys_version >= '315.5.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         demoGetKalmanFilterParameter()
         demoSetKalmanFilterParameter()
 

--- a/sample/SampleRobot/samplerobot_reference_force_updater.py
+++ b/sample/SampleRobot/samplerobot_reference_force_updater.py
@@ -80,7 +80,8 @@ def checkDataPortFromLog(port_name, log_fname="/tmp/test-samplerobot-reference-f
 
 def demo():
     init()
-    if hrpsys_version >= '315.9.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.9.0'):
         demoReferenceForceUpdater()
 
 if __name__ == '__main__':

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py
@@ -121,7 +121,8 @@ def demoDumpLoadForceMomentOffsetParams():
 def demo():
     import numpy
     init()
-    if hrpsys_version >= '315.5.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         demoGetForceMomentOffsetParam()
         demoSetForceMomentOffsetParam()
         demoDumpLoadForceMomentOffsetParams()

--- a/sample/SampleRobot/samplerobot_sequence_player.py
+++ b/sample/SampleRobot/samplerobot_sequence_player.py
@@ -13,6 +13,8 @@ except:
     import socket
     import time
 
+from distutils.version import StrictVersion
+
 def init ():
     global hcf, hrpsys_version
     hcf = HrpsysConfigurator()
@@ -120,7 +122,7 @@ def checkRobotState (var_doc):
     checkZmp(var_doc)
     checkWaist(var_doc)
     checkTorque(var_doc, save_log=False)
-    if hrpsys_version >= '315.2.0':
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.2.0'):
         checkWrenches(var_doc, save_log=False)
         checkOptionalData(var_doc, save_log=False)
 
@@ -141,7 +143,7 @@ def demoSetJointAngles():
     hcf.seq_svc.waitInterpolation();
     checkJointAngles(reset_pose_doc)
     # check clear
-    if hrpsys_version < '315.5.0':
+    if StrictVersion(hrpsys_version) < StrictVersion('315.5.0'):
         return
     print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAngles(move_base_pose_doc['pos'], 5.0);
@@ -268,7 +270,7 @@ def demoSetJointAnglesOfGroup():
     hcf.seq_svc.waitInterpolationOfGroup('larm');
     checkJointAngles(p1)
     # check clear
-    if hrpsys_version < '315.5.0':
+    if StrictVersion(hrpsys_version) < StrictVersion('315.5.0'):
         return
     print >> sys.stderr, "   check clear"
     hcf.seq_svc.setJointAnglesOfGroup('larm', larm_pos0, 5.0);
@@ -381,16 +383,16 @@ def demoSetJointAnglesSequenceFull():
 def demo():
     init()
     demoSetJointAngles()
-    if hrpsys_version >= '315.5.0':
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         demoSetJointAnglesSequence()
     demoSetJointAngle()
     demoLoadPattern()
     demoSetZmp()
     demoSetBasePosRpy()
-    if hrpsys_version >= '315.2.0':
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.2.0'):
         demoSetWrenches()
     demoSetJointAnglesOfGroup()
-    if hrpsys_version >= '315.5.0':
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         demoSetJointAnglesSequenceOfGroup()
         demoSetJointAnglesSequenceFull()
 

--- a/sample/SampleRobot/samplerobot_soft_error_limiter.py
+++ b/sample/SampleRobot/samplerobot_soft_error_limiter.py
@@ -41,7 +41,8 @@ def init ():
 
 def demo ():
     init()
-    if hrpsys_version >= '315.5.0':
+    from distutils.version import StrictVersion
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         demoTestAllLimitTables()
         demoPositionLimit()
         demoVelocityLimit()

--- a/sample/SampleRobot/samplerobot_stabilizer.py
+++ b/sample/SampleRobot/samplerobot_stabilizer.py
@@ -15,6 +15,7 @@ except:
 
 import math
 from subprocess import check_output
+from distutils.version import StrictVersion
 
 def init ():
     global hcf, initial_pose, hrpsys_version
@@ -27,7 +28,7 @@ def init ():
     hcf.seq_svc.waitInterpolation()
     hrpsys_version = hcf.seq.ref.get_component_profile().version
     print("hrpsys_version = %s"%hrpsys_version)
-    if hrpsys_version >= '315.5.0':
+    if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
         # Start AutoBalancer
         hcf.startAutoBalancer()
         # Remove offset
@@ -212,7 +213,7 @@ def demo():
     OPENHRP3_DIR=check_output(['pkg-config', 'openhrp3.1', '--variable=prefix']).rstrip()
     if os.path.exists(OPENHRP3_DIR+"/share/OpenHRP-3.1/sample/model/sample1_bush.wrl"):
         init()
-        if hrpsys_version >= '315.5.0':
+        if StrictVersion(hrpsys_version) >= StrictVersion('315.5.0'):
             demoGetParameter()
             demoSetParameter()
             demoStartStopTPCCST()


### PR DESCRIPTION
hrpsysのversionチェックが機能してないことに気づきましたので、直しました。

今まではversion文字列で直接比較してる箇所みられましたが、
正しくなかったようで、315.10.x以降で動かなくなってたようです。

StrictVersionなどを使うのが良いようで、
http://stackoverflow.com/questions/11887762/compare-version-strings
古い体内環境でもimportできて使えてるようにみえたので、
これを使うようにしたいと思います。

具体的なコードは次になります。
```
# 315.10.x以前だったらうまくうごいてた
>>> "315.9.0" >= "315.8.0"
True
# 315.10.x以降だと文字列で比較できない
>>> "315.10.0" >= "315.8.0"
False
# 315.10.x以降でもStrictVersionでいける
>>> from distutils.version import StrictVersion
>>> StrictVersion("315.9.0") >= StrictVersion("315.8.0")
True
>>> StrictVersion("315.10.0") >= StrictVersion("315.8.0")
True
```

具体的には、hrpsys_versionを使ったコードが
　python/hrpsys_config.py
　samples/SampleRobot以下のサンプル＋テストコード
にみられたので、これらを修正しています。
このPRなしの状態だと、テストもほとんど実行されてなかったようです。

よろしくお願いします。
