### PR TITLE
Fix toe heel phase count of refzmp_generator

### DIFF
--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -34,7 +34,7 @@ add_test(testGaitGeneratorTest12 testGaitGenerator --test12 --use-gnuplot false)
 add_test(testGaitGeneratorTest13 testGaitGenerator --test13 --use-gnuplot false)
 add_test(testGaitGeneratorTest14 testGaitGenerator --test14 --use-gnuplot false)
 add_test(testGaitGeneratorTest15 testGaitGenerator --test15 --use-gnuplot false)
-#add_test(testGaitGeneratorTest16 testGaitGenerator --test16 --use-gnuplot false)
+add_test(testGaitGeneratorTest16 testGaitGenerator --test16 --use-gnuplot false)
 
 install(TARGETS ${target}
   RUNTIME DESTINATION bin

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -125,18 +125,18 @@ namespace rats
     // Calculate swing foot zmp offset for toe heel zmp transition
     if (use_toe_heel_transition &&
         !(is_start_double_support_phase() || is_end_double_support_phase())) { // Do not use toe heel zmp transition during start and end double support period because there is no swing foot
-        if (thp_ptr->is_between_phases(cnt, SOLE0)) {
-            double ratio = thp_ptr->calc_phase_ratio(cnt+1, SOLE0);
+        if (thp.is_between_phases(cnt, SOLE0)) {
+            double ratio = thp.calc_phase_ratio(cnt+1, SOLE0);
             swing_foot_zmp_offsets.front()(0) = (1-ratio)*swing_foot_zmp_offsets.front()(0) + ratio*toe_zmp_offset_x;
-        } else if (thp_ptr->is_between_phases(cnt, HEEL2SOLE, SOLE2)) {
-            double ratio = thp_ptr->calc_phase_ratio(cnt, HEEL2SOLE, SOLE2);
+        } else if (thp.is_between_phases(cnt, HEEL2SOLE, SOLE2)) {
+            double ratio = thp.calc_phase_ratio(cnt, HEEL2SOLE, SOLE2);
             swing_foot_zmp_offsets.front()(0) = ratio*swing_foot_zmp_offsets.front()(0) + (1-ratio)*heel_zmp_offset_x;
-        } else if (thp_ptr->is_between_phases(cnt, SOLE0, SOLE2TOE)) {
+        } else if (thp.is_between_phases(cnt, SOLE0, SOLE2TOE)) {
             swing_foot_zmp_offsets.front()(0) = toe_zmp_offset_x;
-        } else if (thp_ptr->is_between_phases(cnt, SOLE2HEEL, HEEL2SOLE)) {
+        } else if (thp.is_between_phases(cnt, SOLE2HEEL, HEEL2SOLE)) {
             swing_foot_zmp_offsets.front()(0) = heel_zmp_offset_x;
-        } else if (thp_ptr->is_between_phases(cnt, SOLE2TOE, SOLE2HEEL)) {
-            double ratio = thp_ptr->calc_phase_ratio(cnt, SOLE2TOE, SOLE2HEEL);
+        } else if (thp.is_between_phases(cnt, SOLE2TOE, SOLE2HEEL)) {
+            double ratio = thp.calc_phase_ratio(cnt, SOLE2TOE, SOLE2HEEL);
             swing_foot_zmp_offsets.front()(0) = ratio * heel_zmp_offset_x + (1-ratio) * toe_zmp_offset_x;
         }
         zmp_diff = swing_foot_zmp_offsets.front()(0)-default_zmp_offsets[swing_leg_types_list[refzmp_index].front()](0);
@@ -182,6 +182,7 @@ namespace rats
     } else {
       refzmp_index++;
       refzmp_count = one_step_count = step_count_list[refzmp_index];
+      thp.set_one_step_count(one_step_count);
       //std::cerr << "fs " << fs_index << "/" << fnl.size() << " rf " << refzmp_index << "/" << refzmp_cur_list.size() << " flg " << std::endl;
     }
   };
@@ -289,11 +290,11 @@ namespace rats
   {
       double tmp_ip_ratio;
       size_t current_count = one_step_count - lcg_count;
-      if (thp_ptr->is_phase_starting(current_count, start_phase)) {
+      if (thp.is_phase_starting(current_count, start_phase)) {
           toe_heel_interpolator->clear();
           toe_heel_interpolator->set(&start);
-          //toe_heel_interpolator->go(&goal, thp_ptr->calc_phase_period(start_phase, goal_phase, dt));
-          toe_heel_interpolator->setGoal(&goal, thp_ptr->calc_phase_period(start_phase, goal_phase, dt));
+          //toe_heel_interpolator->go(&goal, thp.calc_phase_period(start_phase, goal_phase, dt));
+          toe_heel_interpolator->setGoal(&goal, thp.calc_phase_period(start_phase, goal_phase, dt));
           toe_heel_interpolator->sync();
       }
       if (!toe_heel_interpolator->isEmpty()) {
@@ -310,25 +311,25 @@ namespace rats
       size_t current_count = one_step_count - lcg_count;
       double dif_angle = 0.0;
       hrp::Vector3 ee_local_pivot_pos(hrp::Vector3(0,0,0));
-      if ( thp_ptr->is_between_phases(current_count, SOLE0, SOLE2TOE) ) {
+      if ( thp.is_between_phases(current_count, SOLE0, SOLE2TOE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE0, SOLE2TOE, 0.0, _current_toe_angle);
           ee_local_pivot_pos(0) = toe_pos_offset_x;
-      } else if ( thp_ptr->is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
+      } else if ( thp.is_between_phases(current_count, SOLE2HEEL, HEEL2SOLE) ) {
           dif_angle = calc_interpolated_toe_heel_angle(SOLE2HEEL, HEEL2SOLE, -1 * _current_heel_angle, 0.0);
           ee_local_pivot_pos(0) = heel_pos_offset_x;
-      } else if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
+      } else if ( thp.is_between_phases(current_count, SOLE2TOE, SOLE2HEEL) ) {
           // If SOLE1 phase does not exist, interpolate toe => heel smoothly, without 0 velocity phase.
-          if ( thp_ptr->is_no_SOLE1_phase() ) {
+          if ( thp.is_no_SOLE1_phase() ) {
               dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, SOLE2HEEL, _current_toe_angle, -1 * _current_heel_angle);
               double tmpd = (-1*_current_heel_angle-_current_toe_angle);
               if (std::fabs(tmpd) > 1e-5) {
                   ee_local_pivot_pos(0) = (heel_pos_offset_x - toe_pos_offset_x) * (dif_angle - _current_toe_angle) / tmpd + toe_pos_offset_x;
               }
           } else {
-              if ( thp_ptr->is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
+              if ( thp.is_between_phases(current_count, SOLE2TOE, TOE2SOLE) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE2TOE, TOE2SOLE, _current_toe_angle, 0.0);
                   ee_local_pivot_pos(0) = toe_pos_offset_x;
-              } else if ( thp_ptr->is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
+              } else if ( thp.is_between_phases(current_count, SOLE1, SOLE2HEEL) ) {
                   dif_angle = calc_interpolated_toe_heel_angle(SOLE1, SOLE2HEEL, 0.0, -1 * _current_heel_angle);
                   ee_local_pivot_pos(0) = heel_pos_offset_x;
               }
@@ -459,7 +460,7 @@ namespace rats
       }
       if (footstep_index < fnsl.size()) {
         one_step_count = static_cast<size_t>(fnsl[footstep_index].front().step_time/dt);
-        thp_ptr->set_one_step_count(one_step_count);
+        thp.set_one_step_count(one_step_count);
       }
       if (footstep_index + 1 < fnsl.size()) {
         next_one_step_count = static_cast<size_t>(fnsl[footstep_index+1].front().step_time/dt);

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -170,7 +170,6 @@ namespace rats
         {
             for (size_t i = 0; i < NUM_TH_PHASES; i++) ratio[i] = toe_heel_phase_ratio[i];
         };
-        int get_NUM_TH_PHASES () const { return NUM_TH_PHASES; };
         // functions for checking phase and calculating phase time and ratio
         bool is_phase_starting (const size_t current_count, const toe_heel_phase _phase) const
         {
@@ -1276,7 +1275,7 @@ namespace rats
     double get_heel_angle () const { return lcg.get_heel_angle(); };
     double get_foot_dif_rot_angle () const { return lcg.get_foot_dif_rot_angle(); };
     void get_toe_heel_phase_ratio (std::vector<double>& ratio) const { thp.get_toe_heel_phase_ratio(ratio); };
-    int get_NUM_TH_PHASES () const { return thp.get_NUM_TH_PHASES(); };
+    int get_NUM_TH_PHASES () const { return NUM_TH_PHASES; };
     bool get_use_toe_joint () const { return lcg.get_use_toe_joint(); };
     void get_leg_default_translate_pos (std::vector<hrp::Vector3>& off) const { off = footstep_param.leg_default_translate_pos; };
     size_t get_overwritable_footstep_index_offset () const { return overwritable_footstep_index_offset; };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -213,7 +213,7 @@ namespace rats
       size_t refzmp_index, refzmp_count, one_step_count;
       double toe_zmp_offset_x, heel_zmp_offset_x; // [m]
       double dt;
-      toe_heel_phase_counter* thp_ptr;
+      toe_heel_phase_counter thp;
       bool use_toe_heel_transition;
       boost::shared_ptr<interpolator> zmp_weight_interpolator;
       void calc_current_refzmp (hrp::Vector3& ret, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after);
@@ -224,11 +224,11 @@ namespace rats
 #ifndef HAVE_MAIN
     public:
 #endif
-      refzmp_generator(toe_heel_phase_counter* _thp_ptr, const double _dt)
+      refzmp_generator(const double _dt)
         : refzmp_cur_list(), foot_x_axises_list(), swing_leg_types_list(), step_count_list(), default_zmp_offsets(),
           refzmp_index(0), refzmp_count(0), one_step_count(0),
           toe_zmp_offset_x(0), heel_zmp_offset_x(0), dt(_dt),
-          thp_ptr(_thp_ptr), use_toe_heel_transition(false)
+          thp(), use_toe_heel_transition(false)
       {
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
           default_zmp_offsets.push_back(hrp::Vector3::Zero());
@@ -242,7 +242,6 @@ namespace rats
       };
       ~refzmp_generator()
       {
-          thp_ptr = NULL;
       };
       void remove_refzmp_cur_list_over_length (const size_t len)
       {
@@ -260,6 +259,7 @@ namespace rats
         foot_x_axises_list.clear();
         swing_leg_types_list.clear();
         step_count_list.clear();
+        thp.set_one_step_count(one_step_count);
       };
       void push_refzmp_from_footstep_nodes_for_dual (const std::vector<step_node>& fns,
                                                      const std::vector<step_node>& _support_leg_steps,
@@ -284,6 +284,7 @@ namespace rats
               std::cerr << "zmp_weight_map cannot be set because interpolating." << std::endl;
           }
       };
+      bool set_toe_heel_phase_ratio (const std::vector<double>& ratio) { return thp.set_toe_heel_phase_ratio(ratio); };
       // getter
       bool get_current_refzmp (hrp::Vector3& rzmp, std::vector<hrp::Vector3>& swing_foot_zmp_offsets, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const double default_double_support_static_ratio_before, const double default_double_support_static_ratio_after)
       {
@@ -620,7 +621,7 @@ namespace rats
       std::vector<cycloid_delay_hoffarbib_trajectory_generator> cdtg;
       cycloid_delay_kick_hoffarbib_trajectory_generator cdktg;
       cross_delay_hoffarbib_trajectory_generator crdtg;
-      toe_heel_phase_counter* thp_ptr;
+      toe_heel_phase_counter thp;
       interpolator* foot_ratio_interpolator;
       interpolator* swing_foot_rot_ratio_interpolator;
       // Parameters for toe-heel contact
@@ -646,14 +647,14 @@ namespace rats
 #ifndef HAVE_MAIN
     public:
 #endif
-      leg_coords_generator(const double _dt, toe_heel_phase_counter* _thp_ptr)
+      leg_coords_generator(const double _dt)
         : support_leg_steps(), swing_leg_steps(), swing_leg_src_steps(), swing_leg_dst_steps(),
           default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), swing_rot_ratio(0), foot_midcoords_ratio(0), dt(_dt),
           current_toe_angle(0), current_heel_angle(0),
           time_offset(0.35), final_distance_weight(1.0), time_offset_xy2z(0),
           footstep_index(0), lcg_count(0), default_orbit_type(CYCLOID),
           rdtg(), cdtg(),
-          thp_ptr(_thp_ptr),
+          thp(),
           foot_ratio_interpolator(NULL), swing_foot_rot_ratio_interpolator(NULL), toe_heel_interpolator(NULL),
           toe_pos_offset_x(0.0), heel_pos_offset_x(0.0), toe_angle(0.0), heel_angle(0.0), foot_dif_rot_angle(0.0), use_toe_joint(false)
       {
@@ -685,7 +686,6 @@ namespace rats
             delete toe_heel_interpolator;
             toe_heel_interpolator = NULL;
         }
-        thp_ptr = NULL;
       };
       void set_default_step_height (const double _tmp) { default_step_height = _tmp; };
       void set_default_top_ratio (const double _tmp) { default_top_ratio = _tmp; };
@@ -746,6 +746,7 @@ namespace rats
             }
           }
       };
+      bool set_toe_heel_phase_ratio (const std::vector<double>& ratio) { return thp.set_toe_heel_phase_ratio(ratio); };
       void reset(const size_t _one_step_count, const size_t _next_one_step_count,
                  const std::vector<step_node>& _swing_leg_dst_steps,
                  const std::vector<step_node>& _swing_leg_src_steps,
@@ -762,7 +763,7 @@ namespace rats
         support_leg_steps_list.push_back(support_leg_steps);
         one_step_count = lcg_count = _one_step_count;
         next_one_step_count = _next_one_step_count;
-        thp_ptr->set_one_step_count(one_step_count);
+        thp.set_one_step_count(one_step_count);
         footstep_index = 0;
         current_step_height = 0.0;
         switch (default_orbit_type) {
@@ -875,6 +876,7 @@ namespace rats
       double get_heel_angle () const { return heel_angle; };
       double get_foot_dif_rot_angle () const { return foot_dif_rot_angle; };
       bool get_use_toe_joint () const { return use_toe_joint; };
+      void get_toe_heel_phase_ratio (std::vector<double>& ratio) const { thp.get_toe_heel_phase_ratio(ratio); };
     };
 
   class gait_generator
@@ -894,7 +896,6 @@ namespace rats
     std::vector< std::vector<step_node> > footstep_nodes_list;
     // Footstep list for overwriting future footstep queue
     std::vector< std::vector<step_node> > overwrite_footstep_nodes_list;
-    toe_heel_phase_counter thp;
     refzmp_generator rg;
     leg_coords_generator lcg;
     footstep_parameter footstep_param;
@@ -964,7 +965,7 @@ namespace rats
                     /* arguments for footstep_parameter */
                     const std::vector<hrp::Vector3>& _leg_pos, std::vector<std::string> _all_limbs,
                     const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
-        : footstep_nodes_list(), overwrite_footstep_nodes_list(), thp(), rg(&thp, _dt), lcg(_dt, &thp),
+        : footstep_nodes_list(), overwrite_footstep_nodes_list(), rg(_dt), lcg(_dt),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
         dt(_dt), all_limbs(_all_limbs), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
@@ -1100,7 +1101,12 @@ namespace rats
     void set_heel_pos_offset_x (const double _offx) { lcg.set_heel_pos_offset_x(_offx); };
     void set_toe_angle (const double _angle) { lcg.set_toe_angle(_angle); };
     void set_heel_angle (const double _angle) { lcg.set_heel_angle(_angle); };
-    bool set_toe_heel_phase_ratio (const std::vector<double>& ratio) { return thp.set_toe_heel_phase_ratio(ratio); };
+    bool set_toe_heel_phase_ratio (const std::vector<double>& ratio)
+    {
+        bool lcgret = lcg.set_toe_heel_phase_ratio(ratio);
+        bool rgret = rg.set_toe_heel_phase_ratio(ratio);
+        return lcgret && rgret;
+    };
     void set_use_toe_joint (const bool ut) { lcg.set_use_toe_joint(ut); };
     void set_leg_default_translate_pos (const std::vector<hrp::Vector3>& off) { footstep_param.leg_default_translate_pos = off;};
     void set_optional_go_pos_finalize_footstep_num (const size_t num) { optional_go_pos_finalize_footstep_num = num; };
@@ -1274,7 +1280,7 @@ namespace rats
     double get_toe_angle () const { return lcg.get_toe_angle(); };
     double get_heel_angle () const { return lcg.get_heel_angle(); };
     double get_foot_dif_rot_angle () const { return lcg.get_foot_dif_rot_angle(); };
-    void get_toe_heel_phase_ratio (std::vector<double>& ratio) const { thp.get_toe_heel_phase_ratio(ratio); };
+    void get_toe_heel_phase_ratio (std::vector<double>& ratio) const { lcg.get_toe_heel_phase_ratio(ratio); };
     int get_NUM_TH_PHASES () const { return NUM_TH_PHASES; };
     bool get_use_toe_joint () const { return lcg.get_use_toe_joint(); };
     void get_leg_default_translate_pos (std::vector<hrp::Vector3>& off) const { off = footstep_param.leg_default_translate_pos; };

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -25,7 +25,7 @@ private:
     }
     bool check_zmp_diff (const hrp::Vector3& prev_zmp, const hrp::Vector3& zmp)
     {
-        return (prev_zmp - zmp).norm() < 10.0*1e-3; // [mm]
+        return (prev_zmp - zmp).norm() < 20.0*1e-3; // [mm]
     }
     // plot and pattern generation
     void plot_and_save (FILE* gp, const std::string graph_fname, const std::string plot_str)
@@ -670,13 +670,17 @@ public:
         /* initialize sample footstep_list */
         parse_params();
         gg->clear_footstep_nodes_list();
+        std::vector<hrp::Vector3> dzo;
+        dzo.push_back(hrp::Vector3(20*1e-3,-30*1e-3,0));
+        dzo.push_back(hrp::Vector3(20*1e-3,30*1e-3,0));
+        gg->set_default_zmp_offsets(dzo);
         gg->set_toe_zmp_offset_x(137*1e-3);
         gg->set_heel_zmp_offset_x(-105*1e-3);
         gg->set_toe_pos_offset_x(137*1e-3);
         gg->set_heel_pos_offset_x(-105*1e-3);
         gg->set_toe_angle(20);
         gg->set_heel_angle(5);
-        gg->set_default_step_time(1);
+        gg->set_default_step_time(2);
         gg->set_default_double_support_ratio_before(0.1);
         gg->set_default_double_support_ratio_after(0.1);
         gg->set_use_toe_heel_transition(true);


### PR DESCRIPTION
refzmp_generator でのtoe heelのphaseカウントがleg_coords_generatorと共通化されていましたが、
本来はわけるべきで一歩一歩の時刻が違うときにおかしくなっていたのを直しました。
よろしくお願いします。