### PR TITLE
Add beep trylock, print PDgain, print time in EC debug

### DIFF
--- a/ec/hrpEC/hrpEC-common.cpp
+++ b/ec/hrpEC/hrpEC-common.cpp
@@ -147,7 +147,8 @@ namespace RTC
 #ifndef OPENRTM_VERSION_TRUNK
             if (loop % debug_count == 0 && ENABLE_DEBUG_PRINT) {
               gettimeofday(&debug_tv4, NULL);
-              fprintf(stderr, "[hrpEC] Processing time breakdown : waitForNextPeriod %f[ms], warker (onExecute) %f[ms], ExecutionProfile %f[ms], time from prev cicle %f[ms]\n",
+              fprintf(stderr, "[hrpEC] [%d.%6.6d] Processing time breakdown : waitForNextPeriod %f[ms], warker (onExecute) %f[ms], ExecutionProfile %f[ms], time from prev cicle %f[ms]\n",
+                      tv.tv_sec, tv.tv_usec,
                       DELTA_SEC(debug_tv1, debug_tv2)*1e3,
                       DELTA_SEC(debug_tv2, debug_tv3)*1e3,
                       DELTA_SEC(debug_tv3, debug_tv4)*1e3,

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -113,6 +113,10 @@ bool robot::loadGain()
         strm >> default_dgain[i];
     }
     strm.close();
+    // Print loaded gain
+    std::cerr << "[RobotHardware] loadGain" << std::endl;
+    for (unsigned int i=0; i<numJoints(); i++) {                                                                                                                                               std::cerr << "[RobotHardware]   " << joint(i)->name << ", pgain = " << default_pgain[i] << ", dgain = " << default_dgain[i] << std::endl;
+    }
     return true;
 }
 


### PR DESCRIPTION
3つくらいのPRをまとめました

- Beeperでrealtime threadをmutex lockしていたのを、realtime threadをブロックしないようにtrylockにしました（時々lockでrealtime threadが待たされることがあることがわかりました）
- RObotHardwareでPDゲインをload時にprintするようにしました。
- hrpECの中で、ENABLE_DEBUG_PRINTされてるとき（デフォルト無効かされてます）のprint分に、gettimeofdayの結果を表示するようにしましｔ

よろしくお願いします。