### PR TITLE
change root link height depending on limb length

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -219,6 +219,14 @@ module OpenHRP
       boolean is_estop_while_walking;
       /// Sequence for all end-effectors' ik limb parameters
       sequence<IKLimbParameters> ik_limb_parameters;
+      /// Whether change root link height depending on limb length
+      boolean use_root_height_control;
+      /// Root link height time constant [s]
+      double root_height_time_const;
+      /// Root link height change limitation [m/s] (lower, upper)
+      DblArray2 root_height_vlimit;
+      /// Sequence of limb length margin from max limb length [m]
+      sequence<double> limb_length_margin;
     };
 
     /**

--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -219,12 +219,12 @@ module OpenHRP
       boolean is_estop_while_walking;
       /// Sequence for all end-effectors' ik limb parameters
       sequence<IKLimbParameters> ik_limb_parameters;
-      /// Whether change root link height depending on limb length
-      boolean use_root_height_control;
-      /// Root link height time constant [s]
-      double root_height_time_const;
-      /// Root link height change limitation [m/s] (lower, upper)
-      DblArray2 root_height_vlimit;
+      /// Whether change root link height for avoiding limb stretch
+      boolean use_limb_stretch_avoidance;
+      /// Limb stretch avoidance time constant [s]
+      double limb_stretch_avoidance_time_const;
+      /// Root link height change limitation for avoiding limb stretch [m/s] (lower, upper)
+      DblArray2 limb_stretch_avoidance_vlimit;
       /// Sequence of limb length margin from max limb length [m]
       sequence<double> limb_length_margin;
     };

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -132,6 +132,7 @@ class Stabilizer
   double calcDampingControl (const double tau_d, const double tau, const double prev_d,
                              const double DD, const double TT);
   hrp::Vector3 calcDampingControl (const hrp::Vector3& prev_d, const hrp::Vector3& TT);
+  double calcDampingControl (const double prev_d, const double TT);
   hrp::Vector3 calcDampingControl (const hrp::Vector3& tau_d, const hrp::Vector3& tau, const hrp::Vector3& prev_d,
                                    const hrp::Vector3& DD, const hrp::Vector3& TT);
   double vlimit(double value, double llimit_value, double ulimit_value);
@@ -247,6 +248,7 @@ class Stabilizer
     std::string target_name; // Name of end link
     std::string ee_name; // Name of ee (e.g., rleg, lleg, ...)
     std::string sensor_name; // Name of force sensor in the limb
+    std::string parent_name; // Name of parent ling in the limb
     hrp::Vector3 localp; // Position of ee in end link frame (^{l}p_e = R_l^T (p_e - p_l))
     hrp::Vector3 localCOPPos; // Position offset of reference COP in end link frame (^{l}p_{cop} = R_l^T (p_{cop} - p_l) - ^{l}p_e)
     hrp::Matrix33 localR; // Rotation of ee in end link frame (^{l}R_e = R_l^T R_e)
@@ -262,7 +264,7 @@ class Stabilizer
     hrp::Vector3 target_ee_diff_p, d_pos_swing, d_rpy_swing, prev_d_pos_swing, prev_d_rpy_swing;
     hrp::Matrix33 target_ee_diff_r;
     // IK parameter
-    double avoid_gain, reference_gain;
+    double avoid_gain, reference_gain, max_limb_length, limb_length_margin;
   };
   enum cmode {MODE_IDLE, MODE_AIR, MODE_ST, MODE_SYNC_TO_IDLE, MODE_SYNC_TO_AIR} control_mode;
   // members
@@ -290,7 +292,7 @@ class Stabilizer
   hrp::Vector3 act_zmp, act_cog, act_cogvel, act_cp, rel_act_zmp, rel_act_cp, prev_act_cog, act_base_rpy, current_base_rpy, current_base_pos, sbp_cog_offset;
   hrp::Vector3 foot_origin_offset[2];
   std::vector<double> prev_act_force_z;
-  double zmp_origin_off, transition_smooth_gain;
+  double zmp_origin_off, transition_smooth_gain, d_pos_z_root;
   boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_cogvel_filter;
   OpenHRP::StabilizerService::STAlgorithm st_algorithm;
   SimpleZMPDistributor* szd;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -119,6 +119,7 @@ class Stabilizer
   void calcTPCC();
   void calcEEForceMomentControl();
   void calcSwingEEModification ();
+  void limbStretchAvoidanceControl (const std::vector<hrp::Vector3>& ee_p, const std::vector<hrp::Matrix33>& ee_R);
   void getParameter(OpenHRP::StabilizerService::stParam& i_stp);
   void setParameter(const OpenHRP::StabilizerService::stParam& i_stp);
   void setBoolSequenceParam (std::vector<bool>& st_bool_values, const OpenHRP::StabilizerService::BoolSequence& output_bool_values, const std::string& prop_name);
@@ -280,7 +281,7 @@ class Stabilizer
   std::vector<double> toeheel_ratio;
   double dt;
   int transition_count, loop;
-  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_root_height_control;
+  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_limb_stretch_avoidance;
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
@@ -292,7 +293,7 @@ class Stabilizer
   hrp::Vector3 act_zmp, act_cog, act_cogvel, act_cp, rel_act_zmp, rel_act_cp, prev_act_cog, act_base_rpy, current_base_rpy, current_base_pos, sbp_cog_offset;
   hrp::Vector3 foot_origin_offset[2];
   std::vector<double> prev_act_force_z;
-  double zmp_origin_off, transition_smooth_gain, d_pos_z_root, root_height_time_const, root_height_vlimit[2];
+  double zmp_origin_off, transition_smooth_gain, d_pos_z_root, limb_stretch_avoidance_time_const, limb_stretch_avoidance_vlimit[2];
   boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_cogvel_filter;
   OpenHRP::StabilizerService::STAlgorithm st_algorithm;
   SimpleZMPDistributor* szd;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -280,7 +280,7 @@ class Stabilizer
   std::vector<double> toeheel_ratio;
   double dt;
   int transition_count, loop;
-  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error;
+  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_root_height_control;
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot;
@@ -292,7 +292,7 @@ class Stabilizer
   hrp::Vector3 act_zmp, act_cog, act_cogvel, act_cp, rel_act_zmp, rel_act_cp, prev_act_cog, act_base_rpy, current_base_rpy, current_base_pos, sbp_cog_offset;
   hrp::Vector3 foot_origin_offset[2];
   std::vector<double> prev_act_force_z;
-  double zmp_origin_off, transition_smooth_gain, d_pos_z_root;
+  double zmp_origin_off, transition_smooth_gain, d_pos_z_root, root_height_time_const, root_height_vlimit[2];
   boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_cogvel_filter;
   OpenHRP::StabilizerService::STAlgorithm st_algorithm;
   SimpleZMPDistributor* szd;


### PR DESCRIPTION
脚が伸びきり，逆運動学が解けないor関節速度が過大になるのを避けるため，
必要に応じてリアルタイムに腰を下げるようにしました．
デフォルトの挙動はかわりません．

- デフォルト
![without_drop_root_link](https://cloud.githubusercontent.com/assets/11713954/20057591/c3c17b74-a52f-11e6-8a6f-309ad71b9b44.gif)

- use_root_height_control : True
![with_drop_root_link](https://cloud.githubusercontent.com/assets/11713954/20057630/e8ea4e08-a52f-11e6-9dfb-94adf3ef148a.gif)

