### PR TITLE
interpolate root height to avoid limb stretching

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -301,6 +301,8 @@ module OpenHRP
       GaitType default_gait_type;
       /// Sequence for all end-effectors' ik limb parameters
       sequence<IKLimbParameters> ik_limb_parameters;
+      /// Sequence of limb length margin from max limb length [m]
+      sequence<double> limb_length_margin;
     };
 
     /**

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -393,6 +393,7 @@ class HrpsysConfigurator(object):
             connectPorts(self.abc.port("walkingStates"), self.st.port("walkingStates"))
             connectPorts(self.abc.port("sbpCogOffset"), self.st.port("sbpCogOffset"))
             connectPorts(self.abc.port("toeheelRatio"), self.st.port("toeheelRatio"))
+            connectPorts(self.abc.port("interpolatedRootHeight"), self.st.port("interpolatedRootHeight"))
             if self.es:
                 connectPorts(self.st.port("emergencySignal"), self.es.port("emergencySignal"))
             connectPorts(self.st.port("emergencySignal"), self.abc.port("emergencySignal"))

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -923,6 +923,10 @@ void AutoBalancer::getTargetParameters()
       }
       multi_mid_coords(fix_leg_coords, tmp_end_coords_list);
   }
+
+  {
+    std::vector<hrp::Vector3> future_d_ee_pos = gg->get_future_d_ee_pos();
+  }
 };
 
 hrp::Matrix33 AutoBalancer::OrientRotationMatrix (const hrp::Matrix33& rot, const hrp::Vector3& axis1, const hrp::Vector3& axis2)

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -192,10 +192,11 @@ class AutoBalancer
   struct ABCIKparam {
     hrp::Vector3 target_p0, localPos, adjust_interpolation_target_p0, adjust_interpolation_org_p0;
     hrp::Matrix33 target_r0, localR, adjust_interpolation_target_r0, adjust_interpolation_org_r0;
+    std::string parent_name; // Name of parent ling in the limb
     rats::coordinates target_end_coords;
     hrp::Link* target_link;
     hrp::JointPathExPtr manip;
-    double avoid_gain, reference_gain;
+    double avoid_gain, reference_gain, max_limb_length, limb_length_margin;
     size_t pos_ik_error_count, rot_ik_error_count;
     bool is_active, has_toe_joint;
   };

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -211,6 +211,7 @@ class AutoBalancer
   void waitABCTransition();
   hrp::Matrix33 OrientRotationMatrix (const hrp::Matrix33& rot, const hrp::Vector3& axis1, const hrp::Vector3& axis2);
   void fixLegToCoords (const hrp::Vector3& fix_pos, const hrp::Matrix33& fix_rot);
+  void interpolateLimbStretch ();
   void startWalking ();
   void stopWalking ();
   void copyRatscoords2Footstep(OpenHRP::AutoBalancerService::Footstep& out_fs, const rats::coordinates& in_fs);

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -166,6 +166,8 @@ class AutoBalancer
   std::vector<OutPort<TimedDoubleSeq> *> m_ref_forceOut;
   std::vector<TimedPoint3D> m_limbCOPOffset;
   std::vector<OutPort<TimedPoint3D> *> m_limbCOPOffsetOut;
+  TimedDouble m_interpolatedRootHeight;
+  OutPort<TimedDouble> m_interpolatedRootHeightOut;
   // for debug
   OutPort<TimedPoint3D> m_cogOut;
   
@@ -242,12 +244,14 @@ class AutoBalancer
   double m_dt, move_base_gain;
   hrp::BodyPtr m_robot;
   coil::Mutex m_mutex;
+  double d_root_z_pos, prev_d_root_z_pos;
 
   double transition_interpolator_ratio, transition_time, zmp_transition_time, adjust_footstep_transition_time, leg_names_interpolator_ratio;
   interpolator *zmp_offset_interpolator;
   interpolator *transition_interpolator;
   interpolator *adjust_footstep_interpolator;
   interpolator *leg_names_interpolator;
+  interpolator *limb_stretch_avoidance_interpolator;
   hrp::Vector3 input_zmp, input_basePos;
   hrp::Matrix33 input_baseRot;
 

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -638,6 +638,41 @@ namespace rats
     //   std::cerr << ")" << std::endl;
     // }
 
+    {
+      double omega = std::sqrt(gravitational_acceleration / cog(2) - refzmp(2));
+      future_d_ee_pos.resize(all_limbs.size(), hrp::Vector3::Zero());
+      std::vector<step_node> swg_leg_stps = lcg.get_swing_leg_steps();
+      if (lcg.get_lcg_count() <= static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1
+          && lcg.get_lcg_count() > static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * default_double_support_ratio_after) - 1) { // single support phase
+        double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * default_double_support_ratio_after;
+        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + (cog - prev_cog) / dt / omega * std::sinh(omega * remain_time) + refzmp;
+        for (size_t i = 0; i < all_limbs.size(); i++) {
+          bool is_swing = false;
+          for (size_t j = 0; j < swg_leg_stps.size(); j++) {
+            if (all_limbs[i] ==  leg_type_map[swg_leg_stps[j].l_r]) {
+              future_d_ee_pos[i] = (prev_cog - swg_leg_stps[j].worldcoords.pos) - (future_cog - footstep_nodes_list[lcg.get_footstep_index()][j].worldcoords.pos);
+              is_swing = true;
+            }
+          }
+          if (!is_swing) future_d_ee_pos[i] = prev_cog - future_cog;
+        }
+      } else if (lcg.get_lcg_count() > static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1) { // double support (before) phase
+        double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * (1.0 - default_double_support_ratio_before);
+        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * remain_time) + refzmp + (refzmp - prev_refzmp)/dt * remain_time;
+        for (size_t i = 0; i < all_limbs.size(); i++) {
+          future_d_ee_pos[i] = prev_cog - future_cog;
+        }
+      } else {  // double support (after) phase
+        double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt;
+        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * remain_time) + refzmp + (refzmp - prev_refzmp)/dt * remain_time;
+        for (size_t i = 0; i < all_limbs.size(); i++) {
+          future_d_ee_pos[i] = prev_cog - future_cog;
+        }
+      }
+      prev_cog = cog;
+      prev_refzmp = refzmp;
+    }
+
     /* update swing_leg_coords, support_leg_coords */
     if ( solved ) {
       lcg.update_leg_steps(footstep_nodes_list, default_double_support_ratio_swing_before, default_double_support_ratio_swing_after, thtc);

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -646,27 +646,30 @@ namespace rats
           && lcg.get_lcg_count() > static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * default_double_support_ratio_after) - 1) { // single support phase
         double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * default_double_support_ratio_after;
         hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + (cog - prev_cog) / dt / omega * std::sinh(omega * remain_time) + refzmp;
+        future_cog(2) = cog(2);
         for (size_t i = 0; i < all_limbs.size(); i++) {
           bool is_swing = false;
           for (size_t j = 0; j < swg_leg_stps.size(); j++) {
             if (all_limbs[i] ==  leg_type_map[swg_leg_stps[j].l_r]) {
-              future_d_ee_pos[i] = (prev_cog - swg_leg_stps[j].worldcoords.pos) - (future_cog - footstep_nodes_list[lcg.get_footstep_index()][j].worldcoords.pos);
+              future_d_ee_pos[i] = (cog - swg_leg_stps[j].worldcoords.pos) - (future_cog - footstep_nodes_list[lcg.get_footstep_index()][j].worldcoords.pos);
               is_swing = true;
             }
           }
-          if (!is_swing) future_d_ee_pos[i] = prev_cog - future_cog;
+          if (!is_swing) future_d_ee_pos[i] = cog - future_cog;
         }
       } else if (lcg.get_lcg_count() > static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1) { // double support (before) phase
         double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * (1.0 - default_double_support_ratio_before);
         hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * remain_time) + refzmp + (refzmp - prev_refzmp)/dt * remain_time;
+        future_cog(2) = cog(2);
         for (size_t i = 0; i < all_limbs.size(); i++) {
-          future_d_ee_pos[i] = prev_cog - future_cog;
+          future_d_ee_pos[i] = cog - future_cog;
         }
       } else {  // double support (after) phase
         double remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt;
         hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * remain_time) + refzmp + (refzmp - prev_refzmp)/dt * remain_time;
+        future_cog(2) = cog(2);
         for (size_t i = 0; i < all_limbs.size(); i++) {
-          future_d_ee_pos[i] = prev_cog - future_cog;
+          future_d_ee_pos[i] = cog - future_cog;
         }
       }
       prev_cog = cog;

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -638,43 +638,7 @@ namespace rats
     //   std::cerr << ")" << std::endl;
     // }
 
-    {
-      double omega = std::sqrt(gravitational_acceleration / cog(2) - refzmp(2));
-      future_d_ee_pos.resize(all_limbs.size(), hrp::Vector3::Zero());
-      std::vector<step_node> swg_leg_stps = lcg.get_swing_leg_steps();
-      if (lcg.get_lcg_count() < static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1
-          && lcg.get_lcg_count() >= static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * default_double_support_ratio_after) - 1) { // single support phase
-        limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * default_double_support_ratio_after;
-        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + (cog - prev_cog) / dt / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp;
-        future_cog(2) = cog(2);
-        for (size_t i = 0; i < all_limbs.size(); i++) {
-          bool is_swing = false;
-          for (size_t j = 0; j < swg_leg_stps.size(); j++) {
-            if (all_limbs[i] ==  leg_type_map[swg_leg_stps[j].l_r]) {
-              future_d_ee_pos[i] = (cog - swg_leg_stps[j].worldcoords.pos) - (future_cog - footstep_nodes_list[lcg.get_footstep_index()][j].worldcoords.pos);
-              is_swing = true;
-            }
-          }
-          if (!is_swing) future_d_ee_pos[i] = cog - future_cog;
-        }
-      } else if (lcg.get_lcg_count() >= static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1) { // double support (before) phase
-        limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * (1.0 - default_double_support_ratio_before);
-        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp + (refzmp - prev_refzmp)/dt * limb_stretch_remain_time;
-        future_cog(2) = cog(2);
-        for (size_t i = 0; i < all_limbs.size(); i++) {
-          future_d_ee_pos[i] = cog - future_cog;
-        }
-      } else {  // double support (after) phase
-        limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt + footstep_nodes_list[lcg.get_footstep_index() + (get_footstep_index()<footstep_nodes_list.size()-1?1:0)][0].step_time * default_double_support_ratio_before;
-        hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp + (refzmp - prev_refzmp)/dt * limb_stretch_remain_time;
-        future_cog(2) = cog(2);
-        for (size_t i = 0; i < all_limbs.size(); i++) {
-          future_d_ee_pos[i] = cog - future_cog;
-        }
-      }
-      prev_cog = cog;
-      prev_refzmp = refzmp;
-    }
+    calc_future_cog();
 
     /* update swing_leg_coords, support_leg_coords */
     if ( solved ) {
@@ -715,6 +679,48 @@ namespace rats
     }
     // world frame
     cur_fs.worldcoords.pos = prev_fs.worldcoords.pos + prev_fs.worldcoords.rot * cur_fs.worldcoords.pos;
+  };
+
+  /* calculate future cog when touching down and taking off
+   * and difference between current and future end-effector position
+   * based on LIPM daynamics
+   */
+  void gait_generator::calc_future_cog ()
+  {
+    double omega = std::sqrt(gravitational_acceleration / cog(2) - refzmp(2));
+    std::vector<step_node> swg_leg_stps = lcg.get_swing_leg_steps();
+    if (lcg.get_lcg_count() < static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1
+        && lcg.get_lcg_count() >= static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * default_double_support_ratio_after) - 1) { // single support phase
+      limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * default_double_support_ratio_after;
+      hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + (cog - prev_cog) / dt / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp;
+      future_cog(2) = cog(2);
+      for (size_t i = 0; i < all_limbs.size(); i++) {
+        bool is_swing = false;
+        for (size_t j = 0; j < swg_leg_stps.size(); j++) {
+          if (all_limbs[i] ==  leg_type_map[swg_leg_stps[j].l_r]) {
+            future_d_ee_pos[i] = (cog - swg_leg_stps[j].worldcoords.pos) - (future_cog - footstep_nodes_list[lcg.get_footstep_index()][j].worldcoords.pos);
+            is_swing = true;
+          }
+        }
+        if (!is_swing) future_d_ee_pos[i] = cog - future_cog;
+      }
+    } else if (lcg.get_lcg_count() >= static_cast<size_t>(footstep_nodes_list[lcg.get_footstep_index()][0].step_time/dt * (1.0 - default_double_support_ratio_before)) - 1) { // double support (before) phase
+      limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt - footstep_nodes_list[lcg.get_footstep_index()][0].step_time * (1.0 - default_double_support_ratio_before);
+      hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp + (refzmp - prev_refzmp)/dt * limb_stretch_remain_time;
+      future_cog(2) = cog(2);
+      for (size_t i = 0; i < all_limbs.size(); i++) {
+        future_d_ee_pos[i] = cog - future_cog;
+      }
+    } else {  // double support (after) phase
+      limb_stretch_remain_time = static_cast<double>(lcg.get_lcg_count() + 1) * dt + footstep_nodes_list[lcg.get_footstep_index() + (get_footstep_index()<footstep_nodes_list.size()-1?1:0)][0].step_time * default_double_support_ratio_before;
+      hrp::Vector3 future_cog = (cog - refzmp) * std::cosh(omega * limb_stretch_remain_time) + ((cog - prev_cog)/dt - (refzmp - prev_refzmp)/dt) / omega * std::sinh(omega * limb_stretch_remain_time) + refzmp + (refzmp - prev_refzmp)/dt * limb_stretch_remain_time;
+      future_cog(2) = cog(2);
+      for (size_t i = 0; i < all_limbs.size(); i++) {
+        future_d_ee_pos[i] = cog - future_cog;
+      }
+    }
+    prev_cog = cog;
+    prev_refzmp = refzmp;
   };
 
   /* generate vector of step_node from :go-pos params

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -1123,6 +1123,7 @@ namespace rats
                                     const double delay = 1.6);
     bool proc_one_tick ();
     void limit_stride (step_node& cur_fs, const step_node& prev_fs) const;
+    void calc_future_cog ();
     void append_footstep_nodes (const std::vector<std::string>& _legs, const std::vector<coordinates>& _fss)
     {
         std::vector<step_node> tmp_sns;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -1054,6 +1054,7 @@ namespace rats
     double leg_margin[4], overwritable_stride_limitation[4];
     bool use_stride_limitation;
     stride_limitation_type default_stride_limitation_type;
+    double limb_stretch_remain_time;
     std::vector<hrp::Vector3> future_d_ee_pos;
 
     /* preview controller parameters */
@@ -1101,7 +1102,7 @@ namespace rats
         dt(_dt), all_limbs(_all_limbs), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0), overwritable_footstep_index_offset(1),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
-        use_inside_step_limitation(true), use_stride_limitation(false), default_stride_limitation_type(SQUARE),
+        use_inside_step_limitation(true), use_stride_limitation(false), default_stride_limitation_type(SQUARE), limb_stretch_remain_time(0.0),
         preview_controller_ptr(NULL) {
         swing_foot_zmp_offsets = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
         prev_que_sfzos = boost::assign::list_of<hrp::Vector3>(hrp::Vector3::Zero());
@@ -1434,6 +1435,7 @@ namespace rats
     double get_toe_check_thre () const { return thtc.get_toe_check_thre(); };
     double get_heel_check_thre () const { return thtc.get_heel_check_thre(); };
     std::vector<hrp::Vector3> get_future_d_ee_pos () const { return future_d_ee_pos; };
+    double get_limb_stretch_remain_time () const { return limb_stretch_remain_time; };
     void print_param (const std::string& print_str = "") const
     {
         double stride_fwd_x, stride_y, stride_th, stride_bwd_x;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -1029,7 +1029,7 @@ namespace rats
     footstep_parameter footstep_param;
     velocity_mode_parameter vel_param, offset_vel_param;
     toe_heel_type_checker thtc;
-    hrp::Vector3 cog, refzmp, prev_que_rzmp; /* cog by calculating proc_one_tick */
+    hrp::Vector3 cog, prev_cog, refzmp, prev_refzmp, prev_que_rzmp; /* cog by calculating proc_one_tick */
     std::vector<hrp::Vector3> swing_foot_zmp_offsets, prev_que_sfzos;
     double dt; /* control loop [s] */
     std::vector<std::string> all_limbs;
@@ -1054,6 +1054,7 @@ namespace rats
     double leg_margin[4], overwritable_stride_limitation[4];
     bool use_stride_limitation;
     stride_limitation_type default_stride_limitation_type;
+    std::vector<hrp::Vector3> future_d_ee_pos;
 
     /* preview controller parameters */
     //preview_dynamics_filter<preview_control>* preview_controller_ptr;
@@ -1096,7 +1097,7 @@ namespace rats
                     const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
         : footstep_nodes_list(), overwrite_footstep_nodes_list(), rg(_dt), lcg(_dt),
         footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
-        vel_param(), offset_vel_param(), thtc(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
+        vel_param(), offset_vel_param(), thtc(), cog(hrp::Vector3::Zero()), prev_cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()),
         dt(_dt), all_limbs(_all_limbs), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0), overwritable_footstep_index_offset(1),
         velocity_mode_flg(VEL_IDLING), emergency_flg(IDLING),
@@ -1107,6 +1108,7 @@ namespace rats
         leg_type_map = boost::assign::map_list_of<leg_type, std::string>(RLEG, "rleg")(LLEG, "lleg")(RARM, "rarm")(LARM, "larm");
         for (size_t i = 0; i < 4; i++) leg_margin[i] = 0.1;
         for (size_t i = 0; i < 4; i++) overwritable_stride_limitation[i] = 0.2;
+        future_d_ee_pos.resize(_all_limbs.size(), hrp::Vector3::Zero());
     };
     ~gait_generator () {
       if ( preview_controller_ptr != NULL ) {
@@ -1430,6 +1432,7 @@ namespace rats
     stride_limitation_type get_stride_limitation_type () const { return default_stride_limitation_type; };
     double get_toe_check_thre () const { return thtc.get_toe_check_thre(); };
     double get_heel_check_thre () const { return thtc.get_heel_check_thre(); };
+    std::vector<hrp::Vector3> get_future_d_ee_pos () const { return future_d_ee_pos; };
     void print_param (const std::string& print_str = "") const
     {
         double stride_fwd_x, stride_y, stride_th, stride_bwd_x;

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -1272,6 +1272,7 @@ namespace rats
     void set_stride_limitation_type (const stride_limitation_type _tmp) { default_stride_limitation_type = _tmp; };
     void set_toe_check_thre (const double _a) { thtc.set_toe_check_thre(_a); };
     void set_heel_check_thre (const double _a) { thtc.set_heel_check_thre(_a); };
+    void clear_future_d_ee_pos () { future_d_ee_pos.assign(all_limbs.size(), hrp::Vector3::Zero()); };
     /* Get overwritable footstep index. For example, if overwritable_footstep_index_offset = 1, overwrite next footstep. If overwritable_footstep_index_offset = 0, overwrite current swinging footstep. */
     size_t get_overwritable_index () const
     {

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -620,6 +620,7 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
       control_mode = MODE_AIR;
       break;
     }
+    if (control_mode != MODE_ST) d_pos_z_root = 0.0;
   }
   if ( m_robot->numJoints() == m_qRef.data.length() ) {
     if (is_legged_robot) {
@@ -1510,7 +1511,6 @@ void Stabilizer::calcEEForceMomentControl() {
       //   IK target is link origin pos and rot, not ee pos and rot.
       std::vector<hrp::Vector3> tmpp(stikp.size());
       std::vector<hrp::Matrix33> tmpR(stikp.size());
-      double tmp_d_pos_z_root = 0.0;
       for (size_t i = 0; i < stikp.size(); i++) {
         if (is_ik_enable[i]) {
           // Add damping_control compensation to target value
@@ -1530,7 +1530,7 @@ void Stabilizer::calcEEForceMomentControl() {
         }
       }
 
-      if (use_limb_stretch_avoidance) limbStretchAvoidanceControl(tmpp ,tmpR);
+      limbStretchAvoidanceControl(tmpp ,tmpR);
 
       // IK
       for (size_t i = 0; i < stikp.size(); i++) {
@@ -1594,23 +1594,26 @@ void Stabilizer::calcSwingEEModification ()
 
 void Stabilizer::limbStretchAvoidanceControl (const std::vector<hrp::Vector3>& ee_p, const std::vector<hrp::Matrix33>& ee_R)
 {
-  double tmp_d_pos_z_root = 0.0;
-  for (size_t i = 0; i < stikp.size(); i++) {
-    if (is_ik_enable[i]) {
-      // Check whether inside limb length limitation
-      hrp::Link* parent_link = m_robot->link(stikp[i].parent_name);
-      hrp::Vector3 targetp = (ee_p[i] - ee_R[i] * stikp[i].localR.transpose() * stikp[i].localp) - parent_link->p; // position from parent to target link (world frame)
-      double limb_length_limitation = stikp[i].max_limb_length - stikp[i].limb_length_margin;
-      double tmp = limb_length_limitation * limb_length_limitation - targetp(0) * targetp(0) - targetp(1) * targetp(1);
-      if (targetp.norm() > limb_length_limitation && tmp >= 0) {
-        tmp_d_pos_z_root = std::min(tmp_d_pos_z_root, targetp(2) + std::sqrt(tmp));
+  double tmp_d_pos_z_root = 0.0, prev_d_pos_z_root = d_pos_z_root;
+  if (use_limb_stretch_avoidance) {
+    for (size_t i = 0; i < stikp.size(); i++) {
+      if (is_ik_enable[i]) {
+        // Check whether inside limb length limitation
+        hrp::Link* parent_link = m_robot->link(stikp[i].parent_name);
+        hrp::Vector3 targetp = (ee_p[i] - ee_R[i] * stikp[i].localR.transpose() * stikp[i].localp) - parent_link->p; // position from parent to target link (world frame)
+        double limb_length_limitation = stikp[i].max_limb_length - stikp[i].limb_length_margin;
+        double tmp = limb_length_limitation * limb_length_limitation - targetp(0) * targetp(0) - targetp(1) * targetp(1);
+        if (targetp.norm() > limb_length_limitation && tmp >= 0) {
+          tmp_d_pos_z_root = std::min(tmp_d_pos_z_root, targetp(2) + std::sqrt(tmp));
+        }
       }
     }
+    tmp_d_pos_z_root = std::min(tmp_d_pos_z_root, interpolated_d_pos_z_root);
+    // Change root link height depending on limb length
+    d_pos_z_root = tmp_d_pos_z_root == 0.0 ? calcDampingControl(d_pos_z_root, limb_stretch_avoidance_time_const) : tmp_d_pos_z_root;
+  } else {
+    d_pos_z_root = calcDampingControl(d_pos_z_root, limb_stretch_avoidance_time_const);
   }
-  tmp_d_pos_z_root = std::min(tmp_d_pos_z_root, interpolated_d_pos_z_root);
-  // Change root link height depending on limb length
-  double prev_d_pos_z_root = d_pos_z_root;
-  d_pos_z_root = tmp_d_pos_z_root == 0.0 ? calcDampingControl(d_pos_z_root, limb_stretch_avoidance_time_const) : tmp_d_pos_z_root;
   d_pos_z_root = vlimit(d_pos_z_root, prev_d_pos_z_root + limb_stretch_avoidance_vlimit[0], prev_d_pos_z_root + limb_stretch_avoidance_vlimit[1]);
   m_robot->rootLink()->p(2) += d_pos_z_root;
 }

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -55,6 +55,7 @@ Stabilizer::Stabilizer(RTC::Manager* manager)
     m_qRefSeqIn("qRefSeq", m_qRefSeq),
     m_walkingStatesIn("walkingStates", m_walkingStates),
     m_sbpCogOffsetIn("sbpCogOffset", m_sbpCogOffset),
+    m_interpolatedRootHeightIn("interpolatedRootHeight", m_interpolatedRootHeight),
     m_qRefOut("q", m_qRef),
     m_tauOut("tau", m_tau),
     m_zmpOut("zmp", m_zmp),
@@ -115,6 +116,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   addInPort("qRefSeq", m_qRefSeqIn);
   addInPort("walkingStates", m_walkingStatesIn);
   addInPort("sbpCogOffset", m_sbpCogOffsetIn);
+  addInPort("interpolatedRootHeight", m_interpolatedRootHeightIn);
 
   // Set OutPort buffer
   addOutPort("q", m_qRefOut);
@@ -584,6 +586,10 @@ RTC::ReturnCode_t Stabilizer::onExecute(RTC::UniqueId ec_id)
     sbp_cog_offset(0) = m_sbpCogOffset.data.x;
     sbp_cog_offset(1) = m_sbpCogOffset.data.y;
     sbp_cog_offset(2) = m_sbpCogOffset.data.z;
+  }
+  if (m_interpolatedRootHeightIn.isNew()){
+    m_interpolatedRootHeightIn.read();
+    interpolated_d_pos_z_root = m_interpolatedRootHeight.data;
   }
 
   if (is_legged_robot) {
@@ -1601,6 +1607,7 @@ void Stabilizer::limbStretchAvoidanceControl (const std::vector<hrp::Vector3>& e
       }
     }
   }
+  tmp_d_pos_z_root = std::min(tmp_d_pos_z_root, interpolated_d_pos_z_root);
   // Change root link height depending on limb length
   double prev_d_pos_z_root = d_pos_z_root;
   d_pos_z_root = tmp_d_pos_z_root == 0.0 ? calcDampingControl(d_pos_z_root, limb_stretch_avoidance_time_const) : tmp_d_pos_z_root;

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -171,6 +171,7 @@ class Stabilizer
   RTC::TimedDoubleSeq m_qRefSeq;
   RTC::TimedBoolean m_walkingStates;
   RTC::TimedPoint3D m_sbpCogOffset;
+  RTC::TimedDouble m_interpolatedRootHeight;
   // for debug ouput
   RTC::TimedPoint3D m_originRefZmp, m_originRefCog, m_originRefCogVel, m_originNewZmp;
   RTC::TimedPoint3D m_originActZmp, m_originActCog, m_originActCogVel;
@@ -196,6 +197,7 @@ class Stabilizer
   RTC::InPort<RTC::TimedDoubleSeq> m_qRefSeqIn;
   RTC::InPort<RTC::TimedBoolean> m_walkingStatesIn;
   RTC::InPort<RTC::TimedPoint3D> m_sbpCogOffsetIn;
+  RTC::InPort<RTC::TimedDouble> m_interpolatedRootHeightIn;
 
   std::vector<RTC::TimedDoubleSeq> m_wrenches;
   std::vector<RTC::InPort<RTC::TimedDoubleSeq> *> m_wrenchesIn;
@@ -293,7 +295,7 @@ class Stabilizer
   hrp::Vector3 act_zmp, act_cog, act_cogvel, act_cp, rel_act_zmp, rel_act_cp, prev_act_cog, act_base_rpy, current_base_rpy, current_base_pos, sbp_cog_offset;
   hrp::Vector3 foot_origin_offset[2];
   std::vector<double> prev_act_force_z;
-  double zmp_origin_off, transition_smooth_gain, d_pos_z_root, limb_stretch_avoidance_time_const, limb_stretch_avoidance_vlimit[2];
+  double zmp_origin_off, transition_smooth_gain, d_pos_z_root, interpolated_d_pos_z_root, limb_stretch_avoidance_time_const, limb_stretch_avoidance_vlimit[2];
   boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_cogvel_filter;
   OpenHRP::StabilizerService::STAlgorithm st_algorithm;
   SimpleZMPDistributor* szd;


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/pull/1069 の脚の伸びきりを防ぐための腰の高さ変化を
Autobalancer内で補間するようにしました．
なお，未来のロボットの姿勢（脚長）は，LIPMの運動通りに動いたとして求めています．

よろしくお願いします．

- 腰高さ変化の補間あり・なしのプロット
![limb_strech_avoidance](https://cloud.githubusercontent.com/assets/11713954/20244529/853b1600-a9c9-11e6-9269-1e3e0b0538d9.png)
