### PR TITLE
[rtc/TorqueFilter/IIRFilter.cpp] Fix problem of resetting coefficient…

### DIFF
--- a/rtc/TorqueFilter/IIRFilter.cpp
+++ b/rtc/TorqueFilter/IIRFilter.cpp
@@ -38,6 +38,10 @@ bool IIRFilter::setParameter(int dim, std::vector<double>& A, std::vector<double
         return false;
     }
 
+    // clear previous coefficients
+    m_fb_coefficients.clear();
+    m_ff_coefficients.clear();
+
     if (A.size() == dim) {
         m_fb_coefficients.push_back(1.0);
     }


### PR DESCRIPTION
```
IIRFilter filter;
std::vector<double> fb1, ff1;
//略
filter.setParameter(2,fb1,ff1);
```
した後にやっぱりフィルタ係数を上書きしたい場合に
```
std::vector<double> fb2, ff2;
//略
filter.setParameter(2,fb2,ff2);
```
などをしてもIIRFilterの内部変数(m_fb_coefficients,m_ff_coefficients)に.push_back()されるだけで，
フィルタの係数が更新されなかったので.clear()を追加しましたが大丈夫でしょうか？