### PR TITLE
add time stamp to warning messages

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -495,7 +495,8 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
       if (control_mode == MODE_SYNC_TO_ABC) {
         control_mode = MODE_ABC;
       } else if (control_mode == MODE_SYNC_TO_IDLE && transition_interpolator->isEmpty() ) {
-        std::cerr << "[" << m_profile.instance_name << "] Finished cleanup" << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                  << "] Finished cleanup" << std::endl;
         control_mode = MODE_IDLE;
       }
     }
@@ -965,7 +966,8 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param, const std::string& lim
   rats::difference_rotation(vel_r, param.target_link->R, param.target_r0);
   if (vel_p.norm() > pos_ik_thre && transition_interpolator->isEmpty()) {
       if (param.pos_ik_error_count % ik_error_debug_print_freq == 0) {
-          std::cerr << "[" << m_profile.instance_name << "] Too large IK error in " << limb_name << " (vel_p) = [" << vel_p(0) << " " << vel_p(1) << " " << vel_p(2) << "][m], count = " << param.pos_ik_error_count << std::endl;
+          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    << "] Too large IK error in " << limb_name << " (vel_p) = [" << vel_p(0) << " " << vel_p(1) << " " << vel_p(2) << "][m], count = " << param.pos_ik_error_count << std::endl;
       }
       param.pos_ik_error_count++;
       has_ik_failed = true;
@@ -974,7 +976,8 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param, const std::string& lim
   }
   if (vel_r.norm() > rot_ik_thre && transition_interpolator->isEmpty()) {
       if (param.rot_ik_error_count % ik_error_debug_print_freq == 0) {
-          std::cerr << "[" << m_profile.instance_name << "] Too large IK error in " << limb_name << " (vel_r) = [" << vel_r(0) << " " << vel_r(1) << " " << vel_r(2) << "][rad], count = " << param.rot_ik_error_count << std::endl;
+          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    << "] Too large IK error in " << limb_name << " (vel_r) = [" << vel_r(0) << " " << vel_r(1) << " " << vel_r(2) << "][rad], count = " << param.rot_ik_error_count << std::endl;
       }
       param.rot_ik_error_count++;
       has_ik_failed = true;
@@ -1856,7 +1859,8 @@ bool AutoBalancer::getFootstepParam(OpenHRP::AutoBalancerService::FootstepParam&
 
 bool AutoBalancer::adjustFootSteps(const OpenHRP::AutoBalancerService::Footstep& rfootstep, const OpenHRP::AutoBalancerService::Footstep& lfootstep)
 {
-  std::cerr << "[" << m_profile.instance_name << "] adjustFootSteps" << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+            << "] adjustFootSteps" << std::endl;
   if (control_mode == MODE_ABC && !gg_is_walking && adjust_footstep_interpolator->isEmpty()) {
       Guard guard(m_mutex);
       //

--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -460,7 +460,8 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
                 if (has_servoOn) {
                 if (! m_have_safe_posture ) {
                     // first transition collision -> safe
-                    std::cerr << "[" << m_profile.instance_name << "] set safe posture" << std::endl;
+                    std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                              << "] set safe posture" << std::endl;
                     for ( unsigned int i = 0; i < m_q.data.length(); i++ ) {
                         m_lastsafe_jointdata[i] = m_robot->joint(i)->q;
                     }

--- a/rtc/EmergencyStopper/EmergencyStopper.cpp
+++ b/rtc/EmergencyStopper/EmergencyStopper.cpp
@@ -321,11 +321,13 @@ RTC::ReturnCode_t EmergencyStopper::onExecute(RTC::UniqueId ec_id)
         m_emergencySignalIn.read();
         if ( m_emergencySignal.data == 0 ) {
             Guard guard(m_mutex);
-            std::cerr << "[" << m_profile.instance_name << "] emergencySignal is reset!" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                      << "] emergencySignal is reset!" << std::endl;
             is_stop_mode = false;
         } else if (!is_stop_mode) {
             Guard guard(m_mutex);
-            std::cerr << "[" << m_profile.instance_name << "] emergencySignal is set!" << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                      << "] emergencySignal is set!" << std::endl;
             is_stop_mode = true;
         }
     }

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -269,7 +269,8 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       // fixed joint has ulimit = vlimit
       if ( servo_state[i] == 1 && (lvlimit < uvlimit) && ((lvlimit > qvel) || (uvlimit < qvel)) ) {
         if (loop % debug_print_freq == 0 || debug_print_velocity_first ) {
-          std::cerr << "[" << m_profile.instance_name<< "] velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
+          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    << "] velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
                     << ", lvlimit =" << lvlimit
                     << ", uvlimit =" << uvlimit
                     << ", servo_state = " <<  ( servo_state[i] ? "ON" : "OFF") << std::endl;
@@ -298,7 +299,8 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       bool servo_limit_state = (llimit < ulimit) && ((llimit > m_qRef.data[i]) || (ulimit < m_qRef.data[i]));
       if ( servo_state[i] == 1 && servo_limit_state ) {
         if (loop % debug_print_freq == 0 || debug_print_position_first) {
-          std::cerr << "[" << m_profile.instance_name<< "] position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
+          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    << "] position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
                     << ", llimit =" << llimit
                     << ", ulimit =" << ulimit
                     << ", servo_state = " <<  ( servo_state[i] ? "ON" : "OFF")
@@ -325,7 +327,8 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       double error = pos_vel_limited_angle - m_qCurrent.data[i];
       if ( servo_state[i] == 1 && fabs(error) > limit ) {
         if (loop % debug_print_freq == 0 || debug_print_error_first ) {
-          std::cerr << "[" << m_profile.instance_name<< "] error limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << pos_vel_limited_angle
+          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    << "] error limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << pos_vel_limited_angle
                     << ", qCurrent=" << m_qCurrent.data[i] << " "
                     << ", Error=" << error << " > " << limit << " (limit)"
                     << ", servo_state = " <<  ( 1 ? "ON" : "OFF");

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -1103,7 +1103,7 @@ void Stabilizer::getTargetParameters ()
     transition_count++;
   } else if ( transition_count > 0 ) {
     if ( transition_count == 1 ) {
-      std::cerr << "[" << m_profile.instance_name << "] Move to MODE_IDLE" << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9) << "] Move to MODE_IDLE" << std::endl;
       reset_emergency_flag = true;
     }
     transition_count--;
@@ -1277,7 +1277,8 @@ void Stabilizer::calcStateForEmergencySignal()
     }
     if (is_cp_outside) {
       if (initial_cp_too_large_error || loop % static_cast <int>(0.2/dt) == 0 ) { // once per 0.2[s]
-        std::cerr << "[" << m_profile.instance_name << "] CP too large error " << "[" << act_cp(0) << "," << act_cp(1) << "] [m]" << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                  << "] CP too large error " << "[" << act_cp(0) << "," << act_cp(1) << "] [m]" << std::endl;
       }
       initial_cp_too_large_error = false;
     } else {
@@ -1296,7 +1297,8 @@ void Stabilizer::calcStateForEmergencySignal()
                       will_fall = true;
                       std::cerr << "swgsuptime : " << m_controlSwingSupportTime.data[i] << ", state : " << contact_states[i] << std::endl;
                       if (loop % static_cast <int>(1.0/dt) == 0 ) { // once per 1.0[s]
-                          std::cerr << "[" << m_profile.instance_name << "] " << stikp[i].ee_name << " cannot support total weight, "
+                          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                                    << "] " << stikp[i].ee_name << " cannot support total weight, "
                                     << "otherwise robot will fall down toward " << "(" << projected_normal.at(i)(0) << "," << projected_normal.at(i)(1) << ") direction" << std::endl;
                       }
                   }
@@ -1313,7 +1315,8 @@ void Stabilizer::calcStateForEmergencySignal()
       if (fall_direction.norm() > sin(tilt_margin[1])) {
           is_falling = true;
           if (loop % static_cast <int>(0.2/dt) == 0 ) { // once per 0.2[s]
-              std::cerr << "[" << m_profile.instance_name << "] robot is falling down toward " << "(" << fall_direction(0) << "," << fall_direction(1) << ") direction" << std::endl;
+              std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                        << "] robot is falling down toward " << "(" << fall_direction(0) << "," << fall_direction(1) << ") direction" << std::endl;
           }
       }
   }
@@ -1671,7 +1674,8 @@ RTC::ReturnCode_t Stabilizer::onRateChanged(RTC::UniqueId ec_id)
 
 void Stabilizer::sync_2_st ()
 {
-  std::cerr << "[" << m_profile.instance_name << "] " << "Sync IDLE => ST"  << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+            << "] Sync IDLE => ST"  << std::endl;
   pangx_ref = pangy_ref = pangx = pangy = 0;
   rdx = rdy = rx = ry = 0;
   d_rpy[0] = d_rpy[1] = 0;
@@ -1698,7 +1702,8 @@ void Stabilizer::sync_2_st ()
 
 void Stabilizer::sync_2_idle ()
 {
-  std::cerr << "[" << m_profile.instance_name << "] " << "Sync ST => IDLE"  << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+            << "] Sync ST => IDLE"  << std::endl;
   transition_count = transition_time / dt;
   for (int i = 0; i < m_robot->numJoints(); i++ ) {
     transition_joint_q[i] = m_robot->joint(i)->q;


### PR DESCRIPTION
warning メッセージにタイムスタンプを追加しました。
基本的に、onExecute内で出力されるメッセージを修正しており、
タイムスタンプはlogとの対応が取りやすいようにqRefのスタンプを出力します。
debugLevelを変えないと出力されないメッセージは除いてあります。

これまで、
~~~
[el] position limit over CHEST_JOINT1(13), qRef=-0.000638579, llimit =0, ulimit =0.575959, servo_state = ON, prev_angle = 0
~~~

このPR
~~~
[el] tm = 12.72, position limit over CHEST_JOINT1(13), qRef=-0.000638579, llimit =0, ulimit =0.575959, servo_state = ON, prev_angle = 0
~~~