### PR TITLE
fix time stamp of warning messages

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -40,6 +40,17 @@ static const char* autobalancer_spec[] =
     };
 // </rtc-template>
 
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
+
 AutoBalancer::AutoBalancer(RTC::Manager* manager)
     : RTC::DataFlowComponentBase(manager),
       // <rtc-template block="initializer">
@@ -495,7 +506,7 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
       if (control_mode == MODE_SYNC_TO_ABC) {
         control_mode = MODE_ABC;
       } else if (control_mode == MODE_SYNC_TO_IDLE && transition_interpolator->isEmpty() ) {
-        std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+        std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                   << "] Finished cleanup" << std::endl;
         control_mode = MODE_IDLE;
       }
@@ -966,7 +977,7 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param, const std::string& lim
   rats::difference_rotation(vel_r, param.target_link->R, param.target_r0);
   if (vel_p.norm() > pos_ik_thre && transition_interpolator->isEmpty()) {
       if (param.pos_ik_error_count % ik_error_debug_print_freq == 0) {
-          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+          std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                     << "] Too large IK error in " << limb_name << " (vel_p) = [" << vel_p(0) << " " << vel_p(1) << " " << vel_p(2) << "][m], count = " << param.pos_ik_error_count << std::endl;
       }
       param.pos_ik_error_count++;
@@ -976,7 +987,7 @@ bool AutoBalancer::solveLimbIKforLimb (ABCIKparam& param, const std::string& lim
   }
   if (vel_r.norm() > rot_ik_thre && transition_interpolator->isEmpty()) {
       if (param.rot_ik_error_count % ik_error_debug_print_freq == 0) {
-          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+          std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                     << "] Too large IK error in " << limb_name << " (vel_r) = [" << vel_r(0) << " " << vel_r(1) << " " << vel_r(2) << "][rad], count = " << param.rot_ik_error_count << std::endl;
       }
       param.rot_ik_error_count++;
@@ -1859,7 +1870,7 @@ bool AutoBalancer::getFootstepParam(OpenHRP::AutoBalancerService::FootstepParam&
 
 bool AutoBalancer::adjustFootSteps(const OpenHRP::AutoBalancerService::Footstep& rfootstep, const OpenHRP::AutoBalancerService::Footstep& lfootstep)
 {
-  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+  std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
             << "] adjustFootSteps" << std::endl;
   if (control_mode == MODE_ABC && !gg_is_walking && adjust_footstep_interpolator->isEmpty()) {
       Guard guard(m_mutex);

--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -46,6 +46,17 @@ static const char* component_spec[] =
 };
 // </rtc-template>
 
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
+
 CollisionDetector::CollisionDetector(RTC::Manager* manager)
     : RTC::DataFlowComponentBase(manager),
       // <rtc-template block="initializer">
@@ -460,7 +471,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
                 if (has_servoOn) {
                 if (! m_have_safe_posture ) {
                     // first transition collision -> safe
-                    std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                    std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                               << "] set safe posture" << std::endl;
                     for ( unsigned int i = 0; i < m_q.data.length(); i++ ) {
                         m_lastsafe_jointdata[i] = m_robot->joint(i)->q;

--- a/rtc/EmergencyStopper/EmergencyStopper.cpp
+++ b/rtc/EmergencyStopper/EmergencyStopper.cpp
@@ -16,6 +16,7 @@
 #include "hrpsys/idl/RobotHardwareService.hh"
 
 #include "EmergencyStopper.h"
+#include <iomanip>
 
 typedef coil::Guard<coil::Mutex> Guard;
 
@@ -38,6 +39,17 @@ static const char* emergencystopper_spec[] =
     ""
 };
 // </rtc-template>
+
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
 
 EmergencyStopper::EmergencyStopper(RTC::Manager* manager)
     : RTC::DataFlowComponentBase(manager),
@@ -321,12 +333,12 @@ RTC::ReturnCode_t EmergencyStopper::onExecute(RTC::UniqueId ec_id)
         m_emergencySignalIn.read();
         if ( m_emergencySignal.data == 0 ) {
             Guard guard(m_mutex);
-            std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+            std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                       << "] emergencySignal is reset!" << std::endl;
             is_stop_mode = false;
         } else if (!is_stop_mode) {
             Guard guard(m_mutex);
-            std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+            std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                       << "] emergencySignal is set!" << std::endl;
             is_stop_mode = true;
         }

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
@@ -40,6 +40,17 @@ static const char* ReferenceForceUpdater_spec[] =
   };
 // </rtc-template>
 
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
+
 ReferenceForceUpdater::ReferenceForceUpdater(RTC::Manager* manager)
   : RTC::DataFlowComponentBase(manager),
     // <rtc-template block="initializer">
@@ -290,7 +301,7 @@ RTC::ReturnCode_t ReferenceForceUpdater::onExecute(RTC::UniqueId ec_id)
       if ( ! transition_interpolator_isEmpty ) {
         transition_interpolator[arm]->get(&transition_interpolator_ratio[arm_idx], true);
         if ( transition_interpolator[arm]->isEmpty() && m_RFUParam[arm].is_active && m_RFUParam[arm].is_stopping ) {
-          std::cerr << "[" << m_profile.instance_name << "] ReferenceForceUpdater active => inactive." << std::endl;
+          std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm << "] ReferenceForceUpdater active => inactive." << std::endl;
           m_RFUParam[arm].is_active = false;
           m_RFUParam[arm].is_stopping = false;
         }

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -16,6 +16,7 @@
 #include <math.h>
 #include <vector>
 #include <limits>
+#include <iomanip>
 #define deg2rad(x)((x)*M_PI/180)
 
 // Module specification
@@ -37,6 +38,17 @@ static const char* softerrorlimiter_spec[] =
     ""
   };
 // </rtc-template>
+
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
 
 SoftErrorLimiter::SoftErrorLimiter(RTC::Manager* manager)
   : RTC::DataFlowComponentBase(manager),
@@ -269,7 +281,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       // fixed joint has ulimit = vlimit
       if ( servo_state[i] == 1 && (lvlimit < uvlimit) && ((lvlimit > qvel) || (uvlimit < qvel)) ) {
         if (loop % debug_print_freq == 0 || debug_print_velocity_first ) {
-          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+          std::cerr << "[" << m_profile.instance_name<< "] [" << m_qRef.tm
                     << "] velocity limit over " << m_robot->joint(i)->name << "(" << i << "), qvel=" << qvel
                     << ", lvlimit =" << lvlimit
                     << ", uvlimit =" << uvlimit
@@ -299,7 +311,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       bool servo_limit_state = (llimit < ulimit) && ((llimit > m_qRef.data[i]) || (ulimit < m_qRef.data[i]));
       if ( servo_state[i] == 1 && servo_limit_state ) {
         if (loop % debug_print_freq == 0 || debug_print_position_first) {
-          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+          std::cerr << "[" << m_profile.instance_name<< "] [" << m_qRef.tm
                     << "] position limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << m_qRef.data[i]
                     << ", llimit =" << llimit
                     << ", ulimit =" << ulimit
@@ -327,7 +339,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
       double error = pos_vel_limited_angle - m_qCurrent.data[i];
       if ( servo_state[i] == 1 && fabs(error) > limit ) {
         if (loop % debug_print_freq == 0 || debug_print_error_first ) {
-          std::cerr << "[" << m_profile.instance_name<< "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+          std::cerr << "[" << m_profile.instance_name<< "] [" << m_qRef.tm
                     << "] error limit over " << m_robot->joint(i)->name << "(" << i << "), qRef=" << pos_vel_limited_angle
                     << ", qCurrent=" << m_qCurrent.data[i] << " "
                     << ", Error=" << error << " > " << limit << " (limit)"

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -37,6 +37,17 @@ static const char* stabilizer_spec[] =
   };
 // </rtc-template>
 
+static std::ostream& operator<<(std::ostream& os, const struct RTC::Time &tm)
+{
+    int pre = os.precision();
+    os.setf(std::ios::fixed);
+    os << std::setprecision(6)
+       << (tm.sec + tm.nsec/1e9)
+       << std::setprecision(pre);
+    os.unsetf(std::ios::fixed);
+    return os;
+}
+
 static double switching_inpact_absorber(double force, double lower_th, double upper_th);
 
 Stabilizer::Stabilizer(RTC::Manager* manager)
@@ -1103,7 +1114,7 @@ void Stabilizer::getTargetParameters ()
     transition_count++;
   } else if ( transition_count > 0 ) {
     if ( transition_count == 1 ) {
-      std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9) << "] Move to MODE_IDLE" << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm << "] Move to MODE_IDLE" << std::endl;
       reset_emergency_flag = true;
     }
     transition_count--;
@@ -1277,7 +1288,7 @@ void Stabilizer::calcStateForEmergencySignal()
     }
     if (is_cp_outside) {
       if (initial_cp_too_large_error || loop % static_cast <int>(0.2/dt) == 0 ) { // once per 0.2[s]
-        std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+        std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                   << "] CP too large error " << "[" << act_cp(0) << "," << act_cp(1) << "] [m]" << std::endl;
       }
       initial_cp_too_large_error = false;
@@ -1297,7 +1308,7 @@ void Stabilizer::calcStateForEmergencySignal()
                       will_fall = true;
                       std::cerr << "swgsuptime : " << m_controlSwingSupportTime.data[i] << ", state : " << contact_states[i] << std::endl;
                       if (loop % static_cast <int>(1.0/dt) == 0 ) { // once per 1.0[s]
-                          std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+                          std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                                     << "] " << stikp[i].ee_name << " cannot support total weight, "
                                     << "otherwise robot will fall down toward " << "(" << projected_normal.at(i)(0) << "," << projected_normal.at(i)(1) << ") direction" << std::endl;
                       }
@@ -1315,7 +1326,7 @@ void Stabilizer::calcStateForEmergencySignal()
       if (fall_direction.norm() > sin(tilt_margin[1])) {
           is_falling = true;
           if (loop % static_cast <int>(0.2/dt) == 0 ) { // once per 0.2[s]
-              std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+              std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
                         << "] robot is falling down toward " << "(" << fall_direction(0) << "," << fall_direction(1) << ") direction" << std::endl;
           }
       }
@@ -1674,7 +1685,7 @@ RTC::ReturnCode_t Stabilizer::onRateChanged(RTC::UniqueId ec_id)
 
 void Stabilizer::sync_2_st ()
 {
-  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+  std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
             << "] Sync IDLE => ST"  << std::endl;
   pangx_ref = pangy_ref = pangx = pangy = 0;
   rdx = rdy = rx = ry = 0;
@@ -1702,7 +1713,7 @@ void Stabilizer::sync_2_st ()
 
 void Stabilizer::sync_2_idle ()
 {
-  std::cerr << "[" << m_profile.instance_name << "] [" << (m_qRef.tm.sec + m_qRef.tm.nsec/1e9)
+  std::cerr << "[" << m_profile.instance_name << "] [" << m_qRef.tm
             << "] Sync ST => IDLE"  << std::endl;
   transition_count = transition_time / dt;
   for (int i = 0; i < m_robot->numJoints(); i++ ) {

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -281,6 +281,8 @@ class Stabilizer
   std::vector<double> toeheel_ratio;
   double dt;
   int transition_count, loop;
+  int m_is_falling_counter;
+  std::vector<int> m_will_fall_counter;
   bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_limb_stretch_avoidance;
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;


### PR DESCRIPTION
以下のPRでスタンプをつけたのですが、シミュレーションでしか確認しておらず、
桁数が増えた時に指数表示になっていたのを修正しました。
 https://github.com/fkanehiro/hrpsys-base/pull/1087

また、Stabilizerの以下のところのメッセージが、
https://github.com/fkanehiro/hrpsys-base/blame/master/rtc/Stabilizer/Stabilizer.cpp#L1298
転倒した時などに毎周期出力されてログが大量になります。
デバッグの時だけ出力か、1秒に１回の出力に修正しても良いでしょうか？