### PR TITLE
Update otd, ic, kf, abc, st rtcs

### DIFF
--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -406,7 +406,7 @@ RTC::ReturnCode_t AutoBalancer::onDeactivated(RTC::UniqueId ec_id)
   if (control_mode == MODE_ABC) {
     control_mode = MODE_SYNC_TO_IDLE;
     double tmp_ratio = 0.0;
-    transition_interpolator->go(&tmp_ratio, m_dt, true); // sync in one controller loop
+    transition_interpolator->setGoal(&tmp_ratio, m_dt, true); // sync in one controller loop
   }
   return RTC::RTC_OK;
 }
@@ -1080,7 +1080,7 @@ void AutoBalancer::startABCparam(const OpenHRP::AutoBalancerService::StrSequence
   transition_interpolator->clear();
   transition_interpolator->set(&tmp_ratio);
   tmp_ratio = 1.0;
-  transition_interpolator->go(&tmp_ratio, transition_time, true);
+  transition_interpolator->setGoal(&tmp_ratio, transition_time, true);
   for ( std::map<std::string, ABCIKparam>::iterator it = ikp.begin(); it != ikp.end(); it++ ) {
     it->second.is_active = false;
   }
@@ -1102,7 +1102,7 @@ void AutoBalancer::stopABCparam()
   transition_interpolator->clear();
   transition_interpolator->set(&tmp_ratio);
   tmp_ratio = 0.0;
-  transition_interpolator->go(&tmp_ratio, transition_time, true);
+  transition_interpolator->setGoal(&tmp_ratio, transition_time, true);
   control_mode = MODE_SYNC_TO_IDLE;
 }
 
@@ -1581,7 +1581,7 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
   adjust_footstep_transition_time = i_param.adjust_footstep_transition_time;
   if (zmp_offset_interpolator->isEmpty()) {
       zmp_offset_interpolator->clear();
-      zmp_offset_interpolator->go(default_zmp_offsets_array, zmp_transition_time, true);
+      zmp_offset_interpolator->setGoal(default_zmp_offsets_array, zmp_transition_time, true);
   } else {
       std::cerr << "[" << m_profile.instance_name << "]   default_zmp_offsets cannot be set because interpolating." << std::endl;
   }
@@ -1625,7 +1625,7 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
               double tmp_ratio = 0.0;
               leg_names_interpolator->set(&tmp_ratio);
               tmp_ratio = 1.0;
-              leg_names_interpolator->go(&tmp_ratio, 5.0, true);
+              leg_names_interpolator->setGoal(&tmp_ratio, 5.0, true);
               control_mode = MODE_SYNC_TO_ABC;
           }
       }
@@ -1924,7 +1924,7 @@ bool AutoBalancer::adjustFootSteps(const OpenHRP::AutoBalancerService::Footstep&
       double tmp = 0.0;
       adjust_footstep_interpolator->set(&tmp);
       tmp = 1.0;
-      adjust_footstep_interpolator->go(&tmp, adjust_footstep_transition_time, true);
+      adjust_footstep_interpolator->setGoal(&tmp, adjust_footstep_transition_time, true);
   }
   while (!adjust_footstep_interpolator->isEmpty() )
     usleep(1000);

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -605,6 +605,10 @@ RTC::ReturnCode_t AutoBalancer::onExecute(RTC::UniqueId ec_id)
 
     for (unsigned int i=0; i<m_limbCOPOffsetOut.size(); i++){
         m_limbCOPOffset[i].tm = m_qRef.tm;
+        // transition (TODO:set stopABCmode value instead of 0)
+        m_limbCOPOffset[i].data.x = transition_interpolator_ratio * m_limbCOPOffset[i].data.x;// + (1-transition_interpolator_ratio) * 0;
+        m_limbCOPOffset[i].data.y = transition_interpolator_ratio * m_limbCOPOffset[i].data.y;// + (1-transition_interpolator_ratio) * 0;
+        m_limbCOPOffset[i].data.z = transition_interpolator_ratio * m_limbCOPOffset[i].data.z;// + (1-transition_interpolator_ratio) * 0;
         m_limbCOPOffsetOut[i]->write();
     }
 
@@ -631,7 +635,6 @@ void AutoBalancer::getTargetParameters()
   m_robot->rootLink()->p = input_basePos;
   m_robot->rootLink()->R = input_baseRot;
   m_robot->calcForwardKinematics();
-  //
   if (control_mode != MODE_IDLE) {
     coordinates tmp_fix_coords;
     if (!zmp_offset_interpolator->isEmpty()) {
@@ -934,6 +937,12 @@ void AutoBalancer::getTargetParameters()
           }
       }
       multi_mid_coords(fix_leg_coords, tmp_end_coords_list);
+      // limbCOPOffset
+      for (unsigned int i=0; i<m_limbCOPOffsetOut.size(); i++){
+          m_limbCOPOffset[i].data.x = 0;
+          m_limbCOPOffset[i].data.y = 0;
+          m_limbCOPOffset[i].data.z = 0;
+      }
   }
 };
 

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -50,6 +50,7 @@ ImpedanceController::ImpedanceController(RTC::Manager* manager)
       m_baseRpyIn("baseRpyIn", m_baseRpy),
       m_rpyIn("rpy", m_rpy),
       m_qOut("q", m_q),
+      m_otdDataOut("otdData", m_otdData),
       m_ImpedanceControllerServicePort("ImpedanceControllerService"),
       // </rtc-template>
       m_robot(hrp::BodyPtr()),
@@ -81,6 +82,7 @@ RTC::ReturnCode_t ImpedanceController::onInitialize()
 
     // Set OutPort buffer
     addOutPort("q", m_qOut);
+    addOutPort("otdData", m_otdDataOut);
   
     // Set service provider to Ports
     m_ImpedanceControllerServicePort.registerProvider("service0", "ImpedanceControllerService", m_service0);
@@ -266,6 +268,7 @@ RTC::ReturnCode_t ImpedanceController::onInitialize()
     m_q.data.length(dof);
     qrefv.resize(dof);
     loop = 0;
+    m_otdData.data.length(4); // mode, raw, filtered, dfiltered
 
     return RTC::RTC_OK;
 }
@@ -340,6 +343,7 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
     if (m_qRefIn.isNew()) {
         m_qRefIn.read();
         m_q.tm = m_qRef.tm;
+        m_otdData.tm = m_qRef.tm;
     }
     if ( m_qRef.data.length() ==  m_robot->numJoints() &&
          m_qCurrent.data.length() ==  m_robot->numJoints() ) {
@@ -364,6 +368,12 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
             m_robot->joint(i)->q = m_qRef.data[i];
           }
           m_qOut.write();
+          if (ee_map.find("rleg") != ee_map.end() && ee_map.find("lleg") != ee_map.end()) { // if legged robot, output default value
+            m_otdData.data[0] = static_cast<double>(ObjectTurnaroundDetector::MODE_MAX_TIME);
+            m_otdData.data[1] = 0;
+            m_otdData.data[2] = 0;
+            m_otdDataOut.write();
+          }
           return RTC_OK;
         }
 
@@ -521,8 +531,10 @@ RTC::ReturnCode_t ImpedanceController::onExecute(RTC::UniqueId ec_id)
             }
         }
 
-        if (ee_map.find("rleg") != ee_map.end() && ee_map.find("lleg") != ee_map.end()) // if legged robot
+        if (ee_map.find("rleg") != ee_map.end() && ee_map.find("lleg") != ee_map.end()) {// if legged robot
             calcObjectTurnaroundDetectorState();
+            m_otdDataOut.write();
+        }
     } else {
         if ( DEBUGP || loop % 100 == 0 ) {
             std::cerr << "ImpedanceController is not working..." << std::endl;
@@ -683,6 +695,11 @@ void ImpedanceController::calcObjectTurnaroundDetectorState()
         }
     }
     otd->checkDetection(otd_fmv, otd_hposv);
+    // otdData
+    m_otdData.data[0] = static_cast<double>(otd->getMode());
+    m_otdData.data[1] = otd->getRawWrench();
+    m_otdData.data[2] = otd->getFilteredWrench();
+    m_otdData.data[3] = otd->getFilteredDwrench();
     // Revert to org state
     for ( unsigned int i = 0; i < m_robot->numJoints(); i++ ) {
         m_robot->joint(i)->q = org_q[i];

--- a/rtc/ImpedanceController/ImpedanceController.cpp
+++ b/rtc/ImpedanceController/ImpedanceController.cpp
@@ -656,6 +656,7 @@ void ImpedanceController::calcObjectTurnaroundDetectorState()
         m_robot->joint(i)->q = m_qCurrent.data[i];
     }
     updateRootLinkPosRot(m_rpy);
+    m_robot->calcForwardKinematics();
     // Calc
     std::vector<hrp::Vector3> otd_fmv, otd_hposv;
     hrp::Vector3 fmpos;
@@ -687,6 +688,7 @@ void ImpedanceController::calcObjectTurnaroundDetectorState()
         m_robot->joint(i)->q = org_q[i];
     }
     m_robot->rootLink()->R = orgR;
+    m_robot->calcForwardKinematics();
 };
 
 //

--- a/rtc/ImpedanceController/ImpedanceController.h
+++ b/rtc/ImpedanceController/ImpedanceController.h
@@ -134,6 +134,8 @@ class ImpedanceController
   // <rtc-template block="outport_declare">
   TimedDoubleSeq m_q;
   OutPort<TimedDoubleSeq> m_qOut;
+  TimedDoubleSeq m_otdData;
+  OutPort<TimedDoubleSeq> m_otdDataOut;
   
   // </rtc-template>
 

--- a/rtc/ImpedanceController/ObjectTurnaroundDetector.h
+++ b/rtc/ImpedanceController/ObjectTurnaroundDetector.h
@@ -18,7 +18,7 @@ class ObjectTurnaroundDetector
     boost::shared_ptr<FirstOrderLowPassFilter<double> > dwrench_filter;
     hrp::Vector3 axis, moment_center;
     double prev_wrench, dt;
-    double detect_ratio_thre, start_ratio_thre, ref_dwrench, max_time, current_time;
+    double detect_ratio_thre, start_ratio_thre, ref_dwrench, max_time, current_time, current_wrench;
     size_t count;
     // detect_count_thre*dt and start_ratio_thre*dt are threshould for time.
     //   detect_count_thre*dt : Threshould for time [s] after the first object turnaround detection (Wait detect_time_thre [s] after first object turnaround detection).
@@ -83,6 +83,7 @@ class ObjectTurnaroundDetector
           dwrench_filter->reset(0);
           is_dwr_changed = false;
         }
+        current_wrench = wrench_value;
         double tmp_wr = wrench_filter->passFilter(wrench_value);
         double tmp_dwr = dwrench_filter->passFilter((tmp_wr-prev_wrench)/dt);
         prev_wrench = tmp_wr;
@@ -163,5 +164,6 @@ class ObjectTurnaroundDetector
     detector_total_wrench getDetectorTotalWrench () const { return dtw; };
     double getFilteredWrench () const { return wrench_filter->getCurrentValue(); };
     double getFilteredDwrench () const { return dwrench_filter->getCurrentValue(); };
+    double getRawWrench () const { return current_wrench; };
 };
 #endif // OBJECTTURNAROUNDDETECTOR_H

--- a/rtc/KalmanFilter/CMakeLists.txt
+++ b/rtc/KalmanFilter/CMakeLists.txt
@@ -15,10 +15,12 @@ set_target_properties(KalmanFilter PROPERTIES PREFIX "")
 
 add_executable(KalmanFilterComp KalmanFilterComp.cpp ${comp_sources})
 target_link_libraries(KalmanFilterComp ${libs})
+add_executable(testKFilter testKFilter.cpp)
+target_link_libraries(testKFilter ${libs})
 add_executable(testKalmanFilterEstimation testKalmanFilterEstimation.cpp)
 target_link_libraries(testKalmanFilterEstimation ${libs})
 
-set(target KalmanFilter KalmanFilterComp testKalmanFilterEstimation)
+set(target KalmanFilter KalmanFilterComp testKalmanFilterEstimation testKFilter)
 
 install(TARGETS ${target}
   RUNTIME DESTINATION bin

--- a/rtc/KalmanFilter/KalmanFilter.cpp
+++ b/rtc/KalmanFilter/KalmanFilter.cpp
@@ -210,6 +210,7 @@ RTC::ReturnCode_t KalmanFilter::onExecute(RTC::UniqueId ec_id)
     Eigen::Vector3d acc = m_sensorR * hrp::Vector3(m_acc.data.ax-sx_ref+acc_offset(0), m_acc.data.ay-sy_ref+acc_offset(1), m_acc.data.az-sz_ref+acc_offset(2)); // transform to imaginary acc data
     acc = sensorR_offset * acc;
     Eigen::Vector3d gyro = m_sensorR * hrp::Vector3(m_rate.data.avx, m_rate.data.avy, m_rate.data.avz); // transform to imaginary rate data
+    gyro = sensorR_offset * gyro;
     if (DEBUGP) {
         std::cerr << "[" << m_profile.instance_name << "] raw data acc : " << std::endl << acc << std::endl;
         std::cerr << "[" << m_profile.instance_name << "] raw data gyro : " << std::endl << gyro << std::endl;

--- a/rtc/KalmanFilter/testKFilter.cpp
+++ b/rtc/KalmanFilter/testKFilter.cpp
@@ -1,0 +1,101 @@
+// -*- C++ -*-
+/*!
+ * @file  testKalmanFilter.cpp
+ * @brief Test program for KalmanFilter.cpp requires input log data files
+ * @date  $Date$
+ *
+ * $Id$
+ */
+
+
+#include <stdio.h>
+#include <fstream>
+#include "RPYKalmanFilter.h"
+
+// Usage
+// testKalmanFilter --acc-file /tmp/kftest/test.acc --rate-file /tmp/kftest/test.rate --pose-file /tmp/kftest/test.pose --Q-angle 1e-3 --Q-rate 1e-10 --dt 0.005 --R-angle 1 --use-gnuplot true
+
+int main(int argc, char *argv[])
+{
+  // Default file names and params
+  double Q_pos = 0.001;
+  double Q_vel = 0.003;
+  double R_pos = 0.005;
+  double dt = 0.004;
+  std::string input_file("test.dat");
+  bool use_gnuplot = false;
+
+  // Parse argument
+  for (int i = 0; i < argc; ++ i) {
+      std::string arg(argv[i]);
+      if ( arg == "--Q-pos" ) { // KF parameters
+          if (++i < argc) Q_pos = atof(argv[i]);
+      } else if ( arg == "--Q-vel" ) {
+          if (++i < argc) Q_vel = atof(argv[i]);
+      } else if ( arg == "--R-pos" ) {
+          if (++i < argc) R_pos = atof(argv[i]);
+      } else if ( arg == "--dt" ) { // sampling time[s]
+          if (++i < argc) dt = atof(argv[i]);
+      } else if ( arg == "--input-file" ) { // File path for rate
+          if (++i < argc) input_file = argv[i];
+      } else if ( arg == "--use-gnuplot" ) { // Use gnuplot (true or false)
+          if (++i < argc) use_gnuplot = (std::string(argv[i])=="true"?true:false);
+      }
+  }
+
+  // Setup input and output files
+  std::ifstream inputf(input_file.c_str());
+  std::cerr << "File : " << input_file << std::endl;
+  if (!inputf.is_open()) {
+      std::cerr << "No such " << input_file << std::endl;
+      return -1;
+  }
+  std::string ofname("/tmp/testKalmanFilter.dat");
+  std::ofstream ofs(ofname.c_str());
+
+  // Test kalman filter
+  KFilter kf;
+  //kf.setF(1, -dt, 0, 1);
+  //kf.setB(dt, 0);
+  kf.setQ(Q_pos*dt, 0, 0, Q_vel*dt);
+  kf.setB(0, 0);
+  kf.setF(1, dt, 0, 1);
+  kf.setP(0, 0, 0, 0);
+  kf.setR(R_pos);
+  //hrp::Vector3 rate, acc, rpy, rpyRaw, baseRpyCurrent, rpyAct;
+  double time, time2=0.0;
+  double data;
+  while(!inputf.eof()){
+      inputf >> time >> data;
+      kf.update(0, data);
+      if (use_gnuplot) {
+          ofs << time2 << " " << data << " " << kf.getx()[0] << " " << kf.getx()[1] << std::endl;
+      } else {
+          std::cout << data << std::endl;
+      }
+      time2+=dt;
+  }
+  // gnuplot
+  if (use_gnuplot) {
+      FILE* gp[2];
+      std::string titles[2] = {"Pos", "Vel"};
+      for (size_t ii = 0; ii < 2; ii++) {
+          gp[ii] = popen("gnuplot", "w");
+          fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
+          fprintf(gp[ii], "set xlabel \"Time [s]\"\n");
+          fprintf(gp[ii], "set ylabel \"Pos\"\n");
+          if (ii==0) {
+              fprintf(gp[ii], "plot \"%s\" using 1:%d with lines title \"Filtered\"\n", ofname.c_str(), 2);
+              fprintf(gp[ii], "replot \"%s\" using 1:%d with lines title \"Raw\"\n", ofname.c_str(), 3);
+          } else {
+              fprintf(gp[ii], "plot \"%s\" using 1:%d with lines title \"Vel\"\n", ofname.c_str(), 4);
+          }
+          fflush(gp[ii]);
+      }
+      std::cout << "Type any keys + enter to exit." << std::endl;
+      double tmp;
+      std::cin >> tmp;
+      for (size_t j = 0; j < 2; j++) pclose(gp[j]);
+  }
+  return 0;
+}

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -123,6 +123,7 @@ class Stabilizer
   void getParameter(OpenHRP::StabilizerService::stParam& i_stp);
   void setParameter(const OpenHRP::StabilizerService::stParam& i_stp);
   void setBoolSequenceParam (std::vector<bool>& st_bool_values, const OpenHRP::StabilizerService::BoolSequence& output_bool_values, const std::string& prop_name);
+  void setBoolSequenceParamWithCheckContact (std::vector<bool>& st_bool_values, const OpenHRP::StabilizerService::BoolSequence& output_bool_values, const std::string& prop_name);
   std::string getStabilizerAlgorithmString (OpenHRP::StabilizerService::STAlgorithm _st_algorithm);
   void waitSTTransition();
   // funcitons for calc final torque output

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -1007,11 +1007,13 @@ public:
         }
 
         hrp::dvector ret(state_dim);
-        //hrp::dmatrix selection_matrix = hrp::dmatrix::Identity(6,6);
-        hrp::dmatrix selection_matrix = hrp::dmatrix::Zero(3,6);
-        selection_matrix(0,2) = 1.0;
-        selection_matrix(1,3) = 1.0;
-        selection_matrix(2,4) = 1.0;
+        // Consider 6DOF total wrench (Fx, Fy, Fz, Mx, My, Mz)
+        hrp::dmatrix selection_matrix = hrp::dmatrix::Identity(6,6);
+        // Consdier 3DOF total wrench (Fz, Mx, My)
+//         hrp::dmatrix selection_matrix = hrp::dmatrix::Zero(3,6);
+//         selection_matrix(0,2) = 1.0;
+//         selection_matrix(1,3) = 1.0;
+//         selection_matrix(2,4) = 1.0;
         {
             hrp::dvector selected_total_wrench = hrp::dvector::Zero(selection_matrix.rows());
             hrp::dmatrix selected_Gmat = hrp::dmatrix::Zero(selection_matrix.rows(), Gmat.cols());


### PR DESCRIPTION
いくつかの変更をまとめています
- OTD : calcForwardKinematicsを呼ばれてなかった部分でよぶようにし、otdの出力をポートから出せるようにしました
- KF : sensorRPY_offsetがaccしかきいてなかったので、gyroにも作用させるようにしました。またKFilterクラスのテストをつけてみました
- ABC : 補完器のgoをsetGoalにかえてみて、limbCOPOffsetをMODE_IDLE時には０に遷移さえるようにしました
- ST : EEFMQPCOP2モードで６DOFの力・モーメントを等式に使うようにしました。また、is_feedback\control_enableフラグをMODE_ST時でも変えられるようにしました


よろしくお願いします。