### PR TITLE
[CMakeLists.txt] use separate_arguments to set semicolon to variable.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -262,7 +262,9 @@ if(EXISTS \${_catkin_marker_file})
     # append to existing list of sourcespaces if it's not in the list
     list(FIND _existing_sourcespaces \"${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}\" _existing_sourcespace_index)
     if(_existing_sourcespace_index EQUAL -1)
-      file(APPEND \${_catkin_marker_file} \"\;${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}\")
+      set(_catkin_marker_file_content \" ${CMAKE_INSTALL_PREFIX}/${CATKIN_PACKAGE_SHARE_DESTINATION}\") # head space is necessary because it is converted to semicolon.
+      separate_arguments(_catkin_marker_file_content)
+      file(APPEND \${_catkin_marker_file} \"${_catkin_marker_file_content}\")
     endif()
   endif()
 else()


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/1112 の問題を https://github.com/fkanehiro/hrpsys-base/issues/1112#issuecomment-285591209 の
> http://stackoverflow.com/questions/11593180/cmake-how-to-output-semicolon-as-command-options-in-add-custom-target

のように修正します．


https://cmake.org/cmake/help/v3.0/command/separate_arguments.html の以下の説明を参考にしました．
> separate_arguments(VARIABLE)
Convert the value of VARIABLE to a semi-colon separated list. All spaces are replaced with ‘;’. This helps with generating command lines.
