### PR TITLE
[3rdparty/qpOASES/CMakeLists.txt] trust server of QPOASES

### DIFF
--- a/3rdparty/qpOASES/CMakeLists.txt
+++ b/3rdparty/qpOASES/CMakeLists.txt
@@ -1,5 +1,5 @@
 if (NOT EXISTS ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
-  execute_process(COMMAND svn co https://projects.coin-or.org/svn/qpOASES/stable/3.0 ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
+  execute_process(COMMAND svn co --trust-server-cert --non-interactive https://projects.coin-or.org/svn/qpOASES/stable/3.0 ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0)
   execute_process(COMMAND sed -i -e "s/qpOASES\ STATIC/qpOASES\ SHARED/g" ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0/CMakeLists.txt)
   execute_process(COMMAND cmake -E chdir ${CMAKE_CURRENT_BINARY_DIR}/qpOASES-3.0 make)
 endif()


### PR DESCRIPTION
初めてqpoasesをsvnでcheckoutする際，
```bash
$ svn co https://projects.coin-or.org/svn/qpOASES/stable/3.0
Error validating server certificate for 'https://projects.coin-or.org:443':
 - The certificate is not issued by a trusted authority. Use the
   fingerprint to validate the certificate manually!
Certificate information:
 - Hostname: *.coin-or.org
 - Valid: from Apr 11 20:44:41 2014 GMT until Apr 11 20:44:41 2017 GMT
 - Issuer: http://certs.godaddy.com/repository/, GoDaddy.com, Inc., Scottsdale, Arizona, US
 - Fingerprint: E7:5B:E2:82:44:7F:EF:52:8B:E2:07:B0:D9:B4:27:0C:0E:64:11:56
(R)eject, accept (t)emporarily or accept (p)ermanently? 
```
のように認証待ちで，表示が無いまま，buildが止まってしまうので，
以下の２つのオプションを追加しました．
- --trust-server-cert
- --non-interactive
