### PR TITLE
CMake : correct project name and precise VTK version

### DIFF
--- a/rtc/DataLogger/CMakeLists.txt
+++ b/rtc/DataLogger/CMakeLists.txt
@@ -7,7 +7,7 @@ set_target_properties(DataLogger PROPERTIES PREFIX "")
 add_executable(DataLoggerComp DataLoggerComp.cpp ${comp_sources})
 target_link_libraries(DataLoggerComp ${libs})
 
-find_package(VTK)
+find_package(VTK 5.8 EXACT)
 if (NOT "${VTK_LIBRARIES}" STREQUAL "")
   list(REMOVE_ITEM VTK_LIBRARIES "vtkproj4")
 endif()


### PR DESCRIPTION
I had a lot of trouble figuring out the reason the link error when linking with VTK 7. This fix solved the problem.