### PR TITLE
Call quit_beep when is_beep_port_connected is true, because beeping is not required in these RTCs and deregated to Beeper RTC in this case.

### DIFF
--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -340,6 +340,7 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
     if (!is_beep_port_connected && (loop % 500 == 0) ) {
       if ( m_beepCommandOut.connectors().size() > 0 ) {
         is_beep_port_connected = true;
+        quit_beep();
         std::cerr << "[" << m_profile.instance_name<< "] beepCommand data port connection found! Use BeeperRTC." << std::endl;
       }
     }

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -204,6 +204,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
   if (!is_beep_port_connected && (loop % 500 == 0) ) {
     if ( m_beepCommandOut.connectors().size() > 0 ) {
       is_beep_port_connected = true;
+      quit_beep();
       std::cerr << "[" << m_profile.instance_name<< "] beepCommand data port connection found! Use BeeperRTC." << std::endl;
     }
   }


### PR DESCRIPTION
Beep RTCを使ってるときに、COとELでbeepのアクセスが必要ないので、
「Beep RTCを使ってるとき」というif文のところでquit_beepするようにしました。
Stable RTCとしての利用においてはCOとELの挙動はかわらないと思います

よろしくお願いします。