### PR TITLE
Update rmfo removeforceoffset functions

### DIFF
--- a/idl/RemoveForceSensorLinkOffsetService.idl
+++ b/idl/RemoveForceSensorLinkOffsetService.idl
@@ -11,6 +11,7 @@ module OpenHRP
      * @brief Parameters for a link mass and center of mass. The link is assumed to be end-effector-side from force-moment sensor.
      */
     typedef sequence<double, 3> DblSequence3;
+    typedef sequence<string> StrSequence;
     struct forcemomentOffsetParam {
       /// Force offset [N].
       DblSequence3 force_offset;
@@ -49,5 +50,12 @@ module OpenHRP
      * @return true if dump successfully, false otherwise
      */
     boolean dumpForceMomentOffsetParams(in string filename);
+
+    /**
+     * @brief remove offsets on sensor outputs form force/torque sensors. Sensor offsets (force_offset and moment_offset in ForceMomentOffsetParam) are calibrated. This function takes 8.0[s]. Please keep the robot static and make sure that robot's sensors do not contact with any objects.
+     * @param names is list of sensor names to be calibrated. If not specified, all sensors are calibrated by default.
+     * @return true if set successfully, false otherwise
+     */
+    boolean removeForceSensorOffset(in StrSequence names);
   };
 };

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -2194,6 +2194,14 @@ dr=0, dp=0, dw=0, tm=10, wait=True):
         '''
         return self.seq_svc.clearJointAngles(gname)
 
+    def removeForceSensorOffsetRMFO(self, sensor_names=[]):
+        '''!@brief
+        remove force sensor offset by RemoveForceSensorOffset (RMFO) RTC.
+        @param sensor_names : list of sensor names to be calibrated. If not specified, all sensors are calibrated by default.
+        @return bool : true if set successfully, false otherwise
+        '''
+        return self.rmfo_svc.removeForceSensorOffset(sensor_names)
+
     # ##
     # ## initialize
     # ##

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.cpp
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.cpp
@@ -13,6 +13,8 @@
 #include <hrpUtil/MatrixSolvers.h>
 #include <hrpModel/Sensor.h>
 
+typedef coil::Guard<coil::Mutex> Guard;
+
 // Module specification
 // <rtc-template block="module_spec">
 static const char* removeforcesensorlinkoffset_spec[] =
@@ -111,6 +113,7 @@ RTC::ReturnCode_t RemoveForceSensorLinkOffset::onInitialize()
     registerOutPort(std::string("off_"+s->name).c_str(), *m_forceOut[i]);
     m_forcemoment_offset_param.insert(std::pair<std::string, ForceMomentOffsetParam>(s->name, ForceMomentOffsetParam()));
   }
+  max_sensor_offset_calib_counter = static_cast<int>(8.0/m_dt); // 8.0[s] by default
   return RTC::RTC_OK;
 }
 
@@ -173,6 +176,7 @@ RTC::ReturnCode_t RemoveForceSensorLinkOffset::onExecute(RTC::UniqueId ec_id)
     //
     updateRootLinkPosRot(rpy);
     m_robot->calcForwardKinematics();
+    Guard guard(m_mutex);
     for (unsigned int i=0; i<m_forceIn.size(); i++){
       if ( m_force[i].data.length()==6 ) {
         std::string sensor_name = m_forceIn[i]->name();
@@ -187,20 +191,33 @@ RTC::ReturnCode_t RemoveForceSensorLinkOffset::onExecute(RTC::UniqueId ec_id)
         if ( sensor ) {
           // real force sensor
           hrp::Matrix33 sensorR = sensor->link->R * sensor->localR;
-          hrp::Vector3 mg = hrp::Vector3(0,0, m_forcemoment_offset_param[sensor_name].link_offset_mass * grav * -1);
+          ForceMomentOffsetParam& fmp = m_forcemoment_offset_param[sensor_name];
+          hrp::Vector3 mg = hrp::Vector3(0,0, fmp.link_offset_mass * grav * -1);
+          hrp::Vector3 cxmg = hrp::Vector3(sensorR * fmp.link_offset_centroid).cross(mg);
+          // Sensor offset calib
+          if (fmp.sensor_offset_calib_counter > 0) { // while calibrating
+              fmp.force_offset_sum += (data_p - sensorR.transpose() * mg);
+              fmp.moment_offset_sum += (data_r - sensorR.transpose() * cxmg);
+              fmp.sensor_offset_calib_counter--;
+              if (fmp.sensor_offset_calib_counter == 0) {
+                  fmp.force_offset = fmp.force_offset_sum/max_sensor_offset_calib_counter;
+                  fmp.moment_offset = fmp.moment_offset_sum/max_sensor_offset_calib_counter;
+                  sem_post(&(fmp.wait_sem));
+              }
+          }
           // force and moments which do not include offsets
-          hrp::Vector3 off_force = sensorR * (data_p - m_forcemoment_offset_param[sensor_name].force_offset) - mg;
-          hrp::Vector3 off_moment = sensorR * (data_r - m_forcemoment_offset_param[sensor_name].moment_offset) - hrp::Vector3(sensorR * m_forcemoment_offset_param[sensor->name].link_offset_centroid).cross(mg);
+          fmp.off_force = sensorR * (data_p - fmp.force_offset) - mg;
+          fmp.off_moment = sensorR * (data_r - fmp.moment_offset) - cxmg;
           // convert absolute force -> sensor local force
-          off_force = hrp::Vector3(sensorR.transpose() * off_force);
-          off_moment = hrp::Vector3(sensorR.transpose() * off_moment);
+          fmp.off_force = hrp::Vector3(sensorR.transpose() * fmp.off_force);
+          fmp.off_moment = hrp::Vector3(sensorR.transpose() * fmp.off_moment);
           for (size_t j = 0; j < 3; j++) {
-            m_force[i].data[j] = off_force(j);
-            m_force[i].data[3+j] = off_moment(j);
+            m_force[i].data[j] = fmp.off_force(j);
+            m_force[i].data[3+j] = fmp.off_moment(j);
           }
           if ( DEBUGP ) {
-            std::cerr << "[" << m_profile.instance_name << "]   off force = " << off_force.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "]")) << std::endl;
-            std::cerr << "[" << m_profile.instance_name << "]   off moment = " << off_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "]")) << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "]   off force = " << fmp.off_force.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "]")) << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "]   off moment = " << fmp.off_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "]")) << std::endl;
           }
         } else {
           std::cerr << "[" << m_profile.instance_name << "] unknwon force param " << sensor_name << std::endl;
@@ -311,6 +328,90 @@ bool RemoveForceSensorLinkOffset::dumpForceMomentOffsetParams(const std::string&
   }
   return true;
 };
+
+bool RemoveForceSensorLinkOffset::removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names)
+{
+    std::cerr << "[" << m_profile.instance_name << "] removeForceSensorOffset..." << std::endl;
+
+    // Check argument validity
+    std::vector<std::string> valid_names, invalid_names, calibrating_names;
+    bool is_valid_argument = true;
+    {
+        Guard guard(m_mutex);
+        if ( names.length() == 0 ) { // If no sensor names are specified, calibrate all sensors.
+            std::cerr << "[" << m_profile.instance_name << "]   No sensor names are specified, calibrate all sensors = [";
+            for ( std::map<std::string, ForceMomentOffsetParam>::iterator it = m_forcemoment_offset_param.begin(); it != m_forcemoment_offset_param.end(); it++ ) {
+                valid_names.push_back(it->first);
+                std::cerr << it->first << " ";
+            }
+            std::cerr << "]" << std::endl;
+        } else {
+            for (size_t i = 0; i < names.length(); i++) {
+                std::string name(names[i]);
+                if ( m_forcemoment_offset_param.find(name) != m_forcemoment_offset_param.end() ) {
+                    if ( m_forcemoment_offset_param[name].sensor_offset_calib_counter == 0 ) {
+                        valid_names.push_back(name);
+                    } else {
+                        calibrating_names.push_back(name);
+                        is_valid_argument = false;
+                    }
+                } else{
+                    invalid_names.push_back(name);
+                    is_valid_argument = false;
+                }
+            }
+        }
+    }
+    // Return if invalid or calibrating
+    if ( !is_valid_argument ) {
+        std::cerr << "[" << m_profile.instance_name << "]   Cannot start removeForceSensorOffset, invalid = [";
+        for (size_t i = 0; i < invalid_names.size(); i++) std::cerr << invalid_names[i] << " ";
+        std::cerr << "], calibrating = [";
+        for (size_t i = 0; i < calibrating_names.size(); i++) std::cerr << calibrating_names[i] << " ";
+        std::cerr << "]" << std::endl;
+        return false;
+    }
+
+    // Start calibration
+    //   Print output force before calib
+    std::cerr << "[" << m_profile.instance_name << "]   Calibrate sensor names = [";
+    for (size_t i = 0; i < valid_names.size(); i++) std::cerr << valid_names[i] << " ";
+    std::cerr << "]" << std::endl;
+    {
+        Guard guard(m_mutex);
+        for (size_t i = 0; i < valid_names.size(); i++) {
+            std::cerr << "[" << m_profile.instance_name << "]     Offset-removed force before calib [" << valid_names[i] << "], ";
+            std::cerr << "force = " << m_forcemoment_offset_param[valid_names[i]].off_force.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][N]")) << ", ";
+            std::cerr << "moment = " << m_forcemoment_offset_param[valid_names[i]].off_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][Nm]"));
+            std::cerr << std::endl;
+        }
+        for (size_t i = 0; i < valid_names.size(); i++) {
+            m_forcemoment_offset_param[valid_names[i]].force_offset_sum = hrp::Vector3::Zero();
+            m_forcemoment_offset_param[valid_names[i]].moment_offset_sum = hrp::Vector3::Zero();
+            m_forcemoment_offset_param[valid_names[i]].sensor_offset_calib_counter = max_sensor_offset_calib_counter;
+        }
+    }
+    //   Wait
+    for (size_t i = 0; i < valid_names.size(); i++) {
+        sem_wait(&(m_forcemoment_offset_param[valid_names[i]].wait_sem));
+    }
+    //   Print output force and offset after calib
+    {
+        Guard guard(m_mutex);
+        std::cerr << "[" << m_profile.instance_name << "]   Calibrate done" << std::endl;
+        for (size_t i = 0; i < valid_names.size(); i++) {
+            std::cerr << "[" << m_profile.instance_name << "]     Calibrated offset [" << valid_names[i] << "], ";
+            std::cerr << "force_offset = " << m_forcemoment_offset_param[valid_names[i]].force_offset.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][N]")) << ", ";
+            std::cerr << "moment_offset = " << m_forcemoment_offset_param[valid_names[i]].moment_offset.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][Nm]")) << std::endl;
+            std::cerr << "[" << m_profile.instance_name << "]     Offset-removed force after calib [" << valid_names[i] << "], ";
+            std::cerr << "force = " << m_forcemoment_offset_param[valid_names[i]].off_force.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][N]")) << ", ";
+            std::cerr << "moment = " << m_forcemoment_offset_param[valid_names[i]].off_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][Nm]"));
+            std::cerr << std::endl;
+        }
+    }
+    std::cerr << "[" << m_profile.instance_name << "] removeForceSensorOffset...done" << std::endl;
+    return true;
+}
 
 /*
 RTC::ReturnCode_t RemoveForceSensorLinkOffset::onAborting(RTC::UniqueId ec_id)

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
@@ -26,6 +26,7 @@
 
 #include "RemoveForceSensorLinkOffsetService_impl.h"
 #include "../ImpedanceController/RatsMatrix.h"
+#include <semaphore.h>
 
 // Service implementation headers
 // <rtc-template block="service_impl_h">
@@ -107,6 +108,7 @@ class RemoveForceSensorLinkOffset
   bool getForceMomentOffsetParam(const std::string& i_name_, OpenHRP::RemoveForceSensorLinkOffsetService::forcemomentOffsetParam& i_param_);
   bool loadForceMomentOffsetParams(const std::string& filename);
   bool dumpForceMomentOffsetParams(const std::string& filename);
+  bool removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names);
 
  protected:
   // Configuration variable declaration
@@ -158,12 +160,22 @@ class RemoveForceSensorLinkOffset
  private:
   struct ForceMomentOffsetParam {
     hrp::Vector3 force_offset, moment_offset, link_offset_centroid;
+    hrp::Vector3 off_force, off_moment;
     double link_offset_mass;
+    // Members for sensor offset calib
+    hrp::Vector3 force_offset_sum, moment_offset_sum;
+    int sensor_offset_calib_counter;
+    sem_t wait_sem;
 
     ForceMomentOffsetParam ()
       : force_offset(hrp::Vector3::Zero()), moment_offset(hrp::Vector3::Zero()),
-        link_offset_centroid(hrp::Vector3::Zero()), link_offset_mass(0)
-    {};
+        off_force(hrp::Vector3::Zero()), off_moment(hrp::Vector3::Zero()),
+        link_offset_centroid(hrp::Vector3::Zero()), link_offset_mass(0),
+        force_offset_sum(hrp::Vector3::Zero()), moment_offset_sum(hrp::Vector3::Zero()),
+        sensor_offset_calib_counter(0), wait_sem()
+    {
+        sem_init(&wait_sem, 0, 0);
+    };
   };
   void updateRootLinkPosRot (const hrp::Vector3& rpy);
   void printForceMomentOffsetParam(const std::string& i_name_);
@@ -173,6 +185,8 @@ class RemoveForceSensorLinkOffset
   double m_dt;
   hrp::BodyPtr m_robot;
   unsigned int m_debugLevel;
+  int max_sensor_offset_calib_counter;
+  coil::Mutex m_mutex;
 };
 
 

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.txt
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.txt
@@ -22,6 +22,11 @@ Note that "off_xx" values from this component are same as "xx" values from Robot
 This means, if zero force-moment offset and zero mass offset are specified,
 "off_xx" values equal to "xx".
 
+\subsection offsettype Offset type
+Two types of offsets are considered.
+1. Sensor offset (drift, ...etc) : In idl, force_offset and moment_offset
+2. Link offset (hands and feets mass properties) : In idl, link_offset_centroid and link_offset_mass
+
 \subsection frame Frame
 
 This component requires robot's attitude sensing to know the direction

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.cpp
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.cpp
@@ -35,6 +35,11 @@ CORBA::Boolean RemoveForceSensorLinkOffsetService_impl::dumpForceMomentOffsetPar
 	return m_rmfsoff->dumpForceMomentOffsetParams(std::string(filename));
 };
 
+CORBA::Boolean RemoveForceSensorLinkOffsetService_impl::removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names)
+{
+	return m_rmfsoff->removeForceSensorOffset(names);
+}
+
 void RemoveForceSensorLinkOffsetService_impl::rmfsoff(RemoveForceSensorLinkOffset *i_rmfsoff)
 {
 	m_rmfsoff = i_rmfsoff;

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
@@ -20,6 +20,7 @@ public:
   CORBA::Boolean getForceMomentOffsetParam(const char *i_name_, OpenHRP::RemoveForceSensorLinkOffsetService::forcemomentOffsetParam_out i_param_);
   CORBA::Boolean loadForceMomentOffsetParams(const char *fiename);
   CORBA::Boolean dumpForceMomentOffsetParams(const char *fiename);
+  CORBA::Boolean removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names);
   //
   void rmfsoff(RemoveForceSensorLinkOffset *i_rmfsoff);
 private:

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py
@@ -118,6 +118,16 @@ def demoDumpLoadForceMomentOffsetParams():
         print >> sys.stderr, "    loadForceMomentOffsetParams => OK"
     assert((ret and vcheck))
 
+def demoRemoveForceSensorOffsetRMFO():
+    print >> sys.stderr, "4. remove force sensor offset"
+    print >> sys.stderr, "  Test valid calibration"
+    ret = hcf.removeForceSensorOffsetRMFO() # all sensors by default
+    print >> sys.stderr, "  Test invalid calibration"
+    ret = ret and not hcf.removeForceSensorOffsetRMFO(["testtest"]) # invalid sensor name
+    if ret:
+        print >> sys.stderr, "    removeforcesensorlinkoffset => OK"
+    assert(ret)
+
 def demo():
     import numpy
     init()
@@ -126,6 +136,7 @@ def demo():
         demoGetForceMomentOffsetParam()
         demoSetForceMomentOffsetParam()
         demoDumpLoadForceMomentOffsetParams()
+        demoRemoveForceSensorOffsetRMFO()
 
 if __name__ == '__main__':
     demo()


### PR DESCRIPTION
Remove Force Sensor Offsetのオフセット更新プログラムを
https://github.com/start-jsk/rtmros_common/blob/master/hrpsys_ros_bridge/euslisp/rtm-ros-robot-interface.l#L1065-L1068
のeusのものから、だいたい同じことを行うものをc++実装に移しました。
使いかたはRobotHardwareのhcf.removeForceSensorOffset()と同じで、空中でセンサになにもふれてない状況で
```
hcf.removeForceSensorOffsetRMFO() # 引数なしは全センサ
```
や
```
hcf.removeForceSensorOffsetRMFO(["rhsensor", "lhsensor"]) # センサのリストを与えられる
```
でできます。

https://github.com/fkanehiro/hrpsys-base/issues/456
など議論がありましたが、これでRMFO RTCを使ってるユーザは
`hcf.removeForceSensorOffsetRMFO()`
を実行するだけで良くなり一本化されます。

@YoheiKakiuchi さん
いかがでしょうか。