### PR TITLE
Add argument for duration of calibration. Set 8.0[s] as default value in python code

### DIFF
--- a/idl/RemoveForceSensorLinkOffsetService.idl
+++ b/idl/RemoveForceSensorLinkOffsetService.idl
@@ -52,10 +52,11 @@ module OpenHRP
     boolean dumpForceMomentOffsetParams(in string filename);
 
     /**
-     * @brief remove offsets on sensor outputs form force/torque sensors. Sensor offsets (force_offset and moment_offset in ForceMomentOffsetParam) are calibrated. This function takes 8.0[s]. Please keep the robot static and make sure that robot's sensors do not contact with any objects.
+     * @brief remove offsets on sensor outputs form force/torque sensors. Sensor offsets (force_offset and moment_offset in ForceMomentOffsetParam) are calibrated. This function takes several time (for example 8.0[s]). Please keep the robot static and make sure that robot's sensors do not contact with any objects.
      * @param names is list of sensor names to be calibrated. If not specified, all sensors are calibrated by default.
+     * @param tm is calibration time[s].
      * @return true if set successfully, false otherwise
      */
-    boolean removeForceSensorOffset(in StrSequence names);
+    boolean removeForceSensorOffset(in StrSequence names, in double tm);
   };
 };

--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -2194,13 +2194,14 @@ dr=0, dp=0, dw=0, tm=10, wait=True):
         '''
         return self.seq_svc.clearJointAngles(gname)
 
-    def removeForceSensorOffsetRMFO(self, sensor_names=[]):
+    def removeForceSensorOffsetRMFO(self, sensor_names=[], tm=8.0):
         '''!@brief
         remove force sensor offset by RemoveForceSensorOffset (RMFO) RTC.
         @param sensor_names : list of sensor names to be calibrated. If not specified, all sensors are calibrated by default.
+        @param tm : calibration time[s]. 8.0[s] by default.
         @return bool : true if set successfully, false otherwise
         '''
-        return self.rmfo_svc.removeForceSensorOffset(sensor_names)
+        return self.rmfo_svc.removeForceSensorOffset(sensor_names, tm)
 
     # ##
     # ## initialize

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.cpp
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.cpp
@@ -42,7 +42,8 @@ RemoveForceSensorLinkOffset::RemoveForceSensorLinkOffset(RTC::Manager* manager)
     m_rpyIn("rpy", m_rpy),
     m_RemoveForceSensorLinkOffsetServicePort("RemoveForceSensorLinkOffsetService"),
     // </rtc-template>
-    m_debugLevel(0)
+    m_debugLevel(0),
+    max_sensor_offset_calib_counter(0)
 {
   m_service0.rmfsoff(this);
 }
@@ -329,7 +330,7 @@ bool RemoveForceSensorLinkOffset::dumpForceMomentOffsetParams(const std::string&
   return true;
 };
 
-bool RemoveForceSensorLinkOffset::removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names)
+bool RemoveForceSensorLinkOffset::removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names, const double tm)
 {
     std::cerr << "[" << m_profile.instance_name << "] removeForceSensorOffset..." << std::endl;
 
@@ -385,6 +386,7 @@ bool RemoveForceSensorLinkOffset::removeForceSensorOffset (const ::OpenHRP::Remo
             std::cerr << "moment = " << m_forcemoment_offset_param[valid_names[i]].off_moment.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][Nm]"));
             std::cerr << std::endl;
         }
+        max_sensor_offset_calib_counter = static_cast<int>(tm/m_dt);
         for (size_t i = 0; i < valid_names.size(); i++) {
             m_forcemoment_offset_param[valid_names[i]].force_offset_sum = hrp::Vector3::Zero();
             m_forcemoment_offset_param[valid_names[i]].moment_offset_sum = hrp::Vector3::Zero();
@@ -398,7 +400,7 @@ bool RemoveForceSensorLinkOffset::removeForceSensorOffset (const ::OpenHRP::Remo
     //   Print output force and offset after calib
     {
         Guard guard(m_mutex);
-        std::cerr << "[" << m_profile.instance_name << "]   Calibrate done" << std::endl;
+        std::cerr << "[" << m_profile.instance_name << "]   Calibrate done (calib time = " << tm << "[s])" << std::endl;
         for (size_t i = 0; i < valid_names.size(); i++) {
             std::cerr << "[" << m_profile.instance_name << "]     Calibrated offset [" << valid_names[i] << "], ";
             std::cerr << "force_offset = " << m_forcemoment_offset_param[valid_names[i]].force_offset.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "][N]")) << ", ";

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffset.h
@@ -108,7 +108,7 @@ class RemoveForceSensorLinkOffset
   bool getForceMomentOffsetParam(const std::string& i_name_, OpenHRP::RemoveForceSensorLinkOffsetService::forcemomentOffsetParam& i_param_);
   bool loadForceMomentOffsetParams(const std::string& filename);
   bool dumpForceMomentOffsetParams(const std::string& filename);
-  bool removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names);
+  bool removeForceSensorOffset (const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names, const double tm);
 
  protected:
   // Configuration variable declaration

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.cpp
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.cpp
@@ -35,9 +35,9 @@ CORBA::Boolean RemoveForceSensorLinkOffsetService_impl::dumpForceMomentOffsetPar
 	return m_rmfsoff->dumpForceMomentOffsetParams(std::string(filename));
 };
 
-CORBA::Boolean RemoveForceSensorLinkOffsetService_impl::removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names)
+CORBA::Boolean RemoveForceSensorLinkOffsetService_impl::removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names, CORBA::Double tm)
 {
-	return m_rmfsoff->removeForceSensorOffset(names);
+	return m_rmfsoff->removeForceSensorOffset(names, tm);
 }
 
 void RemoveForceSensorLinkOffsetService_impl::rmfsoff(RemoveForceSensorLinkOffset *i_rmfsoff)

--- a/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
+++ b/rtc/RemoveForceSensorLinkOffset/RemoveForceSensorLinkOffsetService_impl.h
@@ -20,7 +20,7 @@ public:
   CORBA::Boolean getForceMomentOffsetParam(const char *i_name_, OpenHRP::RemoveForceSensorLinkOffsetService::forcemomentOffsetParam_out i_param_);
   CORBA::Boolean loadForceMomentOffsetParams(const char *fiename);
   CORBA::Boolean dumpForceMomentOffsetParams(const char *fiename);
-  CORBA::Boolean removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names);
+  CORBA::Boolean removeForceSensorOffset(const ::OpenHRP::RemoveForceSensorLinkOffsetService::StrSequence& names, CORBA::Double tm);
   //
   void rmfsoff(RemoveForceSensorLinkOffset *i_rmfsoff);
 private:

--- a/sample/SampleRobot/samplerobot_remove_force_offset.py
+++ b/sample/SampleRobot/samplerobot_remove_force_offset.py
@@ -121,9 +121,9 @@ def demoDumpLoadForceMomentOffsetParams():
 def demoRemoveForceSensorOffsetRMFO():
     print >> sys.stderr, "4. remove force sensor offset"
     print >> sys.stderr, "  Test valid calibration"
-    ret = hcf.removeForceSensorOffsetRMFO() # all sensors by default
+    ret = hcf.removeForceSensorOffsetRMFO(tm=1.0) # all sensors by default
     print >> sys.stderr, "  Test invalid calibration"
-    ret = ret and not hcf.removeForceSensorOffsetRMFO(["testtest"]) # invalid sensor name
+    ret = ret and not hcf.removeForceSensorOffsetRMFO(["testtest"], 1.0) # invalid sensor name
     if ret:
         print >> sys.stderr, "    removeforcesensorlinkoffset => OK"
     assert(ret)


### PR DESCRIPTION
RMFOの力オフセットキャリブ時間を引数で設定できるようにしました。
8.0[s]のデフォルト値をpythonで設定しました。
よろしくお願いいたします。