### PR TITLE
[WIP] Use serialized data ports for force sensor connection

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -375,9 +375,12 @@ class HrpsysConfigurator(object):
         connectPorts(self.sh.port("qOut"), self.seq.port("qInit"))
         if StrictVersion(self.seq_version) >= StrictVersion('315.2.0'):
             connectPorts(self.sh.port("zmpOut"), self.seq.port("zmpRefInit"))
-        for sen in self.getForceSensorNames():
-            connectPorts(self.seq.port(sen + "Ref"),
-                         self.sh.port(sen + "In"))
+        if self.seq.port("wrenchesAll") and self.sh.port("wrenchesAllIn"):
+            connectPorts(self.seq.port("wrenchesAll"), self.sh.port("wrenchesAllIn"))
+        else:
+            for sen in self.getForceSensorNames():
+                connectPorts(self.seq.port(sen + "Ref"),
+                             self.sh.port(sen + "In"))
 
         # connection for st
         if rtm.findPort(self.rh.ref, "lfsensor") and rtm.findPort(

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -52,6 +52,7 @@ SequencePlayer::SequencePlayer(RTC::Manager* manager)
       m_accRefOut("accRef", m_accRef),
       m_basePosOut("basePos", m_basePos),
       m_baseRpyOut("baseRpy", m_baseRpy),
+      m_wrenchesAllOut("wrenchesAll", m_wrenchesAll),
       m_optionalDataOut("optionalData", m_optionalData),
       m_SequencePlayerServicePort("SequencePlayerService"),
       // </rtc-template>
@@ -91,6 +92,7 @@ RTC::ReturnCode_t SequencePlayer::onInitialize()
     addOutPort("accRef", m_accRefOut);
     addOutPort("basePos", m_basePosOut);
     addOutPort("baseRpy", m_baseRpyOut);
+    addOutPort("wrenchesAll", m_wrenchesAllOut);
     addOutPort("optionalData", m_optionalDataOut);
   
     // Set service provider to Ports
@@ -153,6 +155,7 @@ RTC::ReturnCode_t SequencePlayer::onInitialize()
       m_wrenches[i].data.length(6);
       registerOutPort(std::string(fsensor_names[i]+"Ref").c_str(), *m_wrenchesOut[i]);
     }
+    m_wrenchesAll.data.length(nforce*6);
 
     if (prop.hasKey("seq_optional_data_dim")) {
       coil::stringTo(optional_data_dim, prop["seq_optional_data_dim"].c_str());
@@ -267,6 +270,9 @@ RTC::ReturnCode_t SequencePlayer::onExecute(RTC::UniqueId ec_id)
           m_wrenches[i].data[4] = wrenches[force_i++];
           m_wrenches[i].data[5] = wrenches[force_i++];
         }
+        for (size_t i = 0; i < m_wrenchesAll.data.length(); i++) {
+            m_wrenchesAll.data[i] = wrenches[i];
+        }
         m_qRef.tm = m_qInit.tm;
         m_qRefOut.write();
         m_tqRefOut.write();
@@ -278,6 +284,7 @@ RTC::ReturnCode_t SequencePlayer::onExecute(RTC::UniqueId ec_id)
         for (size_t i = 0; i < m_wrenchesOut.size(); i++) {
           m_wrenchesOut[i]->write();
         }
+        m_wrenchesAllOut.write();
 
         if (m_clearFlag){
             m_seq->clear(0.001);

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -157,6 +157,8 @@ class SequencePlayer
   OutPort<TimedOrientation3D> m_baseRpyOut;
   std::vector<TimedDoubleSeq> m_wrenches;
   std::vector<OutPort<TimedDoubleSeq> *> m_wrenchesOut;
+  TimedDoubleSeq m_wrenchesAll;
+  OutPort<TimedDoubleSeq> m_wrenchesAllOut;
   TimedDoubleSeq m_optionalData;
   OutPort<TimedDoubleSeq> m_optionalDataOut;
 

--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -41,6 +41,7 @@ StateHolder::StateHolder(RTC::Manager* manager)
     m_basePosIn("basePosIn", m_basePos),
     m_baseRpyIn("baseRpyIn", m_baseRpy),
     m_zmpIn("zmpIn", m_zmp),
+    m_wrenchesAllIn("wrenchesAllIn", m_wrenchesAll),
     m_optionalDataIn("optionalDataIn", m_optionalData),
     m_qOut("qOut", m_q),
     m_tqOut("tqOut", m_tq),
@@ -88,6 +89,7 @@ RTC::ReturnCode_t StateHolder::onInitialize()
     addInPort("basePosIn", m_basePosIn);
     addInPort("baseRpyIn", m_baseRpyIn);
     addInPort("zmpIn", m_zmpIn);
+    addInPort("wrenchesAllIn", m_wrenchesAllIn);
     addInPort("optionalDataIn", m_optionalDataIn);
   
   // Set OutPort buffer
@@ -179,6 +181,7 @@ RTC::ReturnCode_t StateHolder::onInitialize()
     registerInPort(std::string(fsensor_names[i]+"In").c_str(), *m_wrenchesIn[i]);
     registerOutPort(std::string(fsensor_names[i]+"Out").c_str(), *m_wrenchesOut[i]);
   }
+  m_wrenchesAll.data.length(nforce*6);
 
   
   return RTC::RTC_OK;
@@ -249,6 +252,9 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
             m_wrenches[i].data[0] = m_wrenches[i].data[1] = m_wrenches[i].data[2] = 0.0;
             m_wrenches[i].data[3] = m_wrenches[i].data[4] = m_wrenches[i].data[5] = 0.0;
         }
+        for (unsigned int i=0; i<m_wrenchesAll.data.length(); i++){
+            m_wrenchesAll.data[i] = 0;
+        }
     }
 
     if (m_requestGoActual){
@@ -276,6 +282,7 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
       if ( m_wrenchesIn[i]->isNew() ) {
         m_wrenchesIn[i]->read();
       }
+      m_wrenchesAllIn.read();
     }
 
     double *a = m_baseTform.data.get_buffer();

--- a/rtc/StateHolder/StateHolder.h
+++ b/rtc/StateHolder/StateHolder.h
@@ -116,6 +116,7 @@ class StateHolder
   InPort<TimedOrientation3D> m_baseRpyIn;
   InPort<TimedPoint3D> m_zmpIn;
   std::vector<InPort<TimedDoubleSeq> *> m_wrenchesIn;
+  InPort<TimedDoubleSeq> m_wrenchesAllIn;
   TimedDoubleSeq m_optionalData;
   InPort<TimedDoubleSeq> m_optionalDataIn;
 
@@ -134,6 +135,7 @@ class StateHolder
   TimedPose3D m_basePose;
   TimedPoint3D m_zmp;
   std::vector<TimedDoubleSeq> m_wrenches;
+  TimedDoubleSeq m_wrenchesAll;
   OutPort<TimedDoubleSeq> m_qOut;
   OutPort<TimedDoubleSeq> m_tqOut;
   OutPort<TimedPoint3D> m_basePosOut;


### PR DESCRIPTION
**DO NOT MERGE YET**

https://github.com/fkanehiro/hrpsys-base/issues/1088
で、力センサなどのポートを
- [センサ数ぶんのポート数] x [6次元配列]（現状）
- 一個の[センサ数x6次元配列]（本PR）

にするのはいかがでしょうか、という議論をさせていただいてましたが、
私の文章がわかりにくかったので、例としてのPRを作って見ました。
（本当は必要な変更箇所がこれ以外にもあります）
PRでは、互換性のために現状のポートのコードもそのまま残して、あらたなものを追加だけしてます。

ポート数がへるという点もありますが、
https://github.com/fkanehiro/hrpsys-base/issues/1088
で主に議論させていただいていたメリットは、センサ名などのロボット固有情報へ
依存するプログラムがへる、というものでした。
端的には、この変更のhrpsys_config.pyの部分がそれにあたります。
このPRの
```
 +            connectPorts(self.seq.port("wrenchesAll"), self.sh.port("wrenchesAllIn")) 
```
の部分がそれにあたります。
現状の方法だとhrpsys_config.pyでもセンサ名が必要で、for文でつながないといけないですが、
このPRの上記の箇所では、ロボット依存のセンサ名がいらなくて、一個のポートでつなげています。


https://github.com/fkanehiro/hrpsys-base/issues/1088
ではこのようなものをイメージしていたのですが、いかがでしょうか。