### PR TITLE
Update testGaitGenerator and fix bug of overritable-footstep-index-offset = 0

### DIFF
--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -35,6 +35,8 @@ add_test(testGaitGeneratorTest13 testGaitGenerator --test13 --use-gnuplot false)
 add_test(testGaitGeneratorTest14 testGaitGenerator --test14 --use-gnuplot false)
 add_test(testGaitGeneratorTest15 testGaitGenerator --test15 --use-gnuplot false)
 add_test(testGaitGeneratorTest16 testGaitGenerator --test16 --use-gnuplot false)
+add_test(testGaitGeneratorTest17 testGaitGenerator --test17 --use-gnuplot false)
+add_test(testGaitGeneratorTest18 testGaitGenerator --test18 --use-gnuplot false)
 
 install(TARGETS ${target}
   RUNTIME DESTINATION bin

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -34,7 +34,7 @@ namespace rats
       u(2), v(2), 1;
     ret = dvm * cycloid_point + start + uz;
   };
-  void multi_mid_coords (coordinates& ret, const std::vector<coordinates>& cs)
+  void multi_mid_coords (coordinates& ret, const std::vector<coordinates>& cs, const double eps)
   {
       if (cs.size() == 1) {
           ret = cs.front();
@@ -43,10 +43,10 @@ namespace rats
           double ratio = (1.0 - 1.0 / cs.size());
           for (size_t i = 1; i < cs.size(); i++) {
               coordinates tmp;
-              mid_coords(tmp, ratio, cs.front(), cs.at(i));
+              mid_coords(tmp, ratio, cs.front(), cs.at(i), eps);
               tmp_mid_coords.push_back(tmp);
           }
-          multi_mid_coords(ret, tmp_mid_coords);
+          multi_mid_coords(ret, tmp_mid_coords, eps);
       }
       return;
   };
@@ -485,9 +485,10 @@ namespace rats
           if (it->l_r == RLEG or it->l_r == LLEG) sup_coords.push_back(it->worldcoords);
       }
       coordinates tmp_swg_src_mid, tmp_swg_dst_mid, tmp_swg_mid, tmp_sup_mid;
-      if (swg_src_coords.size() > 0) multi_mid_coords(tmp_swg_src_mid, swg_src_coords);
-      if (swg_dst_coords.size() > 0) multi_mid_coords(tmp_swg_dst_mid, swg_dst_coords);
-      if (sup_coords.size() > 0) multi_mid_coords(tmp_sup_mid, sup_coords);
+      const double rot_eps = 1e-5; // eps for mid_rot calculation
+      if (swg_src_coords.size() > 0) multi_mid_coords(tmp_swg_src_mid, swg_src_coords, rot_eps);
+      if (swg_dst_coords.size() > 0) multi_mid_coords(tmp_swg_dst_mid, swg_dst_coords, rot_eps);
+      if (sup_coords.size() > 0) multi_mid_coords(tmp_sup_mid, sup_coords, rot_eps);
       if (lcg_count == one_step_count) {
           foot_midcoords_interpolator->clear();
           double tmp[foot_midcoords_interpolator->dimension()];
@@ -528,7 +529,7 @@ namespace rats
       } else {
           tmp_swg_mid = tmp_swg_dst_mid;
       }
-      mid_coords(swing_support_midcoords, static_cast<double>(sup_coords.size()) / (swg_src_coords.size() + sup_coords.size()), tmp_swg_mid, tmp_sup_mid);
+      mid_coords(swing_support_midcoords, static_cast<double>(sup_coords.size()) / (swg_src_coords.size() + sup_coords.size()), tmp_swg_mid, tmp_sup_mid, rot_eps);
   };
 
   void leg_coords_generator::update_leg_steps (const std::vector< std::vector<step_node> >& fnsl, const double default_double_support_ratio_before, const double default_double_support_ratio_after, const toe_heel_type_checker& thtc)

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -21,6 +21,7 @@ namespace rats
     enum orbit_type {SHUFFLING, CYCLOID, RECTANGLE, STAIR, CYCLOIDDELAY, CYCLOIDDELAYKICK, CROSS};
     enum leg_type {RLEG, LLEG, RARM, LARM, BOTH, ALL};
     enum stride_limitation_type {SQUARE, CIRCLE};
+    std::string leg_type_to_leg_type_string (const leg_type l_r);
 
     struct step_node
     {
@@ -681,7 +682,7 @@ namespace rats
       std::vector<step_node> support_leg_steps;
       // Swing leg coordinates is interpolated from swing_leg_src_coords to swing_leg_dst_coords during swing phase.
       std::vector<step_node> swing_leg_steps, swing_leg_src_steps, swing_leg_dst_steps;
-      double default_step_height, default_top_ratio, current_step_height, swing_ratio, swing_rot_ratio, foot_midcoords_ratio, dt, current_toe_angle, current_heel_angle;
+      double default_step_height, default_top_ratio, current_step_height, swing_ratio, foot_midcoords_ratio, dt, current_toe_angle, current_heel_angle;
       double time_offset, final_distance_weight, time_offset_xy2z;
       std::vector<double> current_swing_time;
       // Index for current footstep. footstep_index should be [0,footstep_node_list.size()]. Current footstep is footstep_node_list[footstep_index].
@@ -700,13 +701,15 @@ namespace rats
       cross_delay_hoffarbib_trajectory_generator crdtg;
       toe_heel_phase_counter thp;
       interpolator* foot_ratio_interpolator;
-      interpolator* swing_foot_rot_ratio_interpolator;
+      // Map for interpolator of each swing foot rot interpolation. In constructor, prepared for all limbs. In control loop, swing foot element is used.
+      std::map<leg_type, interpolator*> swing_foot_rot_interpolator;
       // Parameters for toe-heel contact
       interpolator* toe_heel_interpolator;
       double toe_pos_offset_x, heel_pos_offset_x, toe_angle, heel_angle, foot_dif_rot_angle;
       bool use_toe_joint, use_toe_heel_auto_set;
       toe_heel_type current_src_toe_heel_type, current_dst_toe_heel_type;
-      void calc_current_swing_leg_steps (std::vector<step_node>& rets, const double step_height, const double _current_toe_angle, const double _current_heel_angle);
+      void calc_current_swing_foot_rot (std::map<leg_type, hrp::Vector3>& tmp_swing_foot_rot, const double _default_double_support_ratio_before, const double _default_double_support_ratio_after);
+      void calc_current_swing_leg_steps (std::vector<step_node>& rets, const double step_height, const double _current_toe_angle, const double _current_heel_angle, const double _default_double_support_ratio_before, const double _default_double_support_ratio_after);
       double calc_interpolated_toe_heel_angle (const toe_heel_phase start_phase, const toe_heel_phase goal_phase, const double start, const double goal);
       void modif_foot_coords_for_toe_heel_phase (coordinates& org_coords, const double _current_toe_angle, const double _current_heel_angle);
       void cycloid_midcoords (coordinates& ret, const coordinates& start,
@@ -727,13 +730,13 @@ namespace rats
 #endif
       leg_coords_generator(const double _dt)
         : support_leg_steps(), swing_leg_steps(), swing_leg_src_steps(), swing_leg_dst_steps(),
-          default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), swing_rot_ratio(0), foot_midcoords_ratio(0), dt(_dt),
+          default_step_height(0.05), default_top_ratio(0.5), current_step_height(0.0), swing_ratio(0), foot_midcoords_ratio(0), dt(_dt),
           current_toe_angle(0), current_heel_angle(0),
           time_offset(0.35), final_distance_weight(1.0), time_offset_xy2z(0),
           footstep_index(0), lcg_count(0), default_orbit_type(CYCLOID),
           rdtg(), cdtg(),
           thp(),
-          foot_ratio_interpolator(NULL), swing_foot_rot_ratio_interpolator(NULL), toe_heel_interpolator(NULL),
+          foot_ratio_interpolator(NULL), swing_foot_rot_interpolator(), toe_heel_interpolator(NULL),
           toe_pos_offset_x(0.0), heel_pos_offset_x(0.0), toe_angle(0.0), heel_angle(0.0), foot_dif_rot_angle(0.0), use_toe_joint(false), use_toe_heel_auto_set(false),
           current_src_toe_heel_type(SOLE), current_dst_toe_heel_type(SOLE)
       {
@@ -744,11 +747,17 @@ namespace rats
         cdktg.set_dt(dt);
         crdtg.set_dt(dt);
         if (foot_ratio_interpolator == NULL) foot_ratio_interpolator = new interpolator(1, dt);
-        if (swing_foot_rot_ratio_interpolator == NULL) swing_foot_rot_ratio_interpolator = new interpolator(1, dt);
+        std::vector<leg_type> tmp_leg_types = boost::assign::list_of<leg_type>(RLEG)(LLEG)(RARM)(LARM);
+         for (size_t i = 0; i < tmp_leg_types.size(); i++) {
+             if ( swing_foot_rot_interpolator.find(tmp_leg_types[i]) == swing_foot_rot_interpolator.end() ) {
+                 swing_foot_rot_interpolator.insert(std::pair<leg_type, interpolator*>(tmp_leg_types[i], new interpolator(3, dt))); // RPY
+                 swing_foot_rot_interpolator[tmp_leg_types[i]]->setName("GaitGenerator swing_foot_rot_interpolator " + leg_type_to_leg_type_string(tmp_leg_types[i]));
+                 std::cerr << "GaitGenerator swing_foot_rot_interpolator " + leg_type_to_leg_type_string(tmp_leg_types[i]) << std::endl;;
+             }
+         }
         //if (foot_ratio_interpolator == NULL) foot_ratio_interpolator = new interpolator(1, dt, interpolator::LINEAR);
         if (toe_heel_interpolator == NULL) toe_heel_interpolator = new interpolator(1, dt);
         foot_ratio_interpolator->setName("GaitGenerator foot_ratio_interpolator");
-        swing_foot_rot_ratio_interpolator->setName("GaitGenerator swing_foot_rot_ratio_interpolator");
         toe_heel_interpolator->setName("GaitGenerator toe_heel_interpolator");
       };
       ~leg_coords_generator()
@@ -757,9 +766,11 @@ namespace rats
             delete foot_ratio_interpolator;
             foot_ratio_interpolator = NULL;
         }
-        if (swing_foot_rot_ratio_interpolator != NULL) {
-            delete swing_foot_rot_ratio_interpolator;
-            swing_foot_rot_ratio_interpolator = NULL;
+        for (std::map<leg_type, interpolator*>::iterator it = swing_foot_rot_interpolator.begin(); it != swing_foot_rot_interpolator.end(); it++) {
+            if (it->second != NULL) {
+                delete it->second;
+                it->second = NULL;
+            }
         }
         if (toe_heel_interpolator != NULL) {
             delete toe_heel_interpolator;
@@ -891,10 +902,11 @@ namespace rats
         foot_ratio_interpolator->sync();
       };
       void clear_interpolators ( ) {
-        double tmp;
-        while (!swing_foot_rot_ratio_interpolator->isEmpty()) {
-            swing_foot_rot_ratio_interpolator->get(&tmp, true);
+        double tmpsw[3];
+        for (std::map<leg_type, interpolator*>::iterator it = swing_foot_rot_interpolator.begin(); it != swing_foot_rot_interpolator.end(); it++) {
+            while (!it->second->isEmpty()) it->second->get(tmpsw, true);
         }
+        double tmp;
         while (!foot_ratio_interpolator->isEmpty()) {
             foot_ratio_interpolator->get(&tmp, true);
         }

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -968,21 +968,22 @@ namespace rats
       double get_default_step_height () const { return default_step_height;};
       void get_swing_support_mid_coords(coordinates& ret) const
       {
-        std::vector<coordinates> swg_coords, sup_coords;
-        for (std::vector<step_node>::const_iterator it_src = swing_leg_src_steps.begin(), it_dst = swing_leg_dst_steps.begin();
-             it_src != swing_leg_src_steps.end() && it_dst != swing_leg_dst_steps.end();
-             it_src++, it_dst++) {
-            coordinates tmp;
-            mid_coords(tmp, foot_midcoords_ratio, it_src->worldcoords, it_dst->worldcoords);
-            if (it_src->l_r == RLEG or it_src->l_r == LLEG) swg_coords.push_back(tmp);
+        std::vector<coordinates> swg_src_coords, swg_dst_coords,sup_coords;
+        for (std::vector<step_node>::const_iterator it = swing_leg_src_steps.begin(); it != swing_leg_src_steps.end(); it++) {
+            if (it->l_r == RLEG or it->l_r == LLEG) swg_src_coords.push_back(it->worldcoords);
+        }
+        for (std::vector<step_node>::const_iterator it = swing_leg_dst_steps.begin(); it != swing_leg_dst_steps.end(); it++) {
+            if (it->l_r == RLEG or it->l_r == LLEG) swg_dst_coords.push_back(it->worldcoords);
         }
         for (std::vector<step_node>::const_iterator it = support_leg_steps.begin(); it != support_leg_steps.end(); it++) {
             if (it->l_r == RLEG or it->l_r == LLEG) sup_coords.push_back(it->worldcoords);
         }
-        coordinates tmp_swg_mid, tmp_sup_mid;
-        if (swg_coords.size() > 0) multi_mid_coords(tmp_swg_mid, swg_coords);
+        coordinates tmp_swg_src_mid, tmp_swg_dst_mid, tmp_swg_mid, tmp_sup_mid;
+        if (swg_src_coords.size() > 0) multi_mid_coords(tmp_swg_src_mid, swg_src_coords);
+        if (swg_dst_coords.size() > 0) multi_mid_coords(tmp_swg_dst_mid, swg_dst_coords);
+        mid_coords(tmp_swg_mid, foot_midcoords_ratio, tmp_swg_src_mid, tmp_swg_dst_mid);
         if (sup_coords.size() > 0) multi_mid_coords(tmp_sup_mid, sup_coords);
-        mid_coords(ret, static_cast<double>(sup_coords.size()) / (swg_coords.size() + sup_coords.size()), tmp_swg_mid, tmp_sup_mid);
+        mid_coords(ret, static_cast<double>(sup_coords.size()) / (swg_src_coords.size() + sup_coords.size()), tmp_swg_mid, tmp_sup_mid);
       };
       std::vector<leg_type> get_current_support_states () const
       {

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -16,7 +16,7 @@ namespace rats
                            const double ratio, const hrp::Vector3& start,
                            const hrp::Vector3& goal, const double height,
                            const double default_top_ratio = 0.5);
-    void multi_mid_coords (coordinates& mid_coords, const std::vector<coordinates>& cs);
+    void multi_mid_coords (coordinates& mid_coords, const std::vector<coordinates>& cs, const double eps = 0.001);
 
     enum orbit_type {SHUFFLING, CYCLOID, RECTANGLE, STAIR, CYCLOIDDELAY, CYCLOIDDELAYKICK, CROSS};
     enum leg_type {RLEG, LLEG, RARM, LARM, BOTH, ALL};

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -818,6 +818,10 @@ public:
               if (++i < arg_strs.size()) gg->set_default_double_support_static_ratio_before(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--default-double-support-static-ratio-after" ) {
               if (++i < arg_strs.size()) gg->set_default_double_support_static_ratio_after(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-ratio-swing-before" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_ratio_swing_before(atof(arg_strs[i].c_str()));
+          } else if ( arg_strs[i]== "--default-double-support-ratio-swing-after" ) {
+              if (++i < arg_strs.size()) gg->set_default_double_support_ratio_swing_after(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--swing-trajectory-delay-time-offset" ) {
               if (++i < arg_strs.size()) gg->set_swing_trajectory_delay_time_offset(atof(arg_strs[i].c_str()));
           } else if ( arg_strs[i]== "--swing-trajectory-final-distance-weight" ) {

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -38,6 +38,8 @@ protected:
     FILE* fp_thpos;
     std::string fname_sstime;
     FILE* fp_sstime;
+    std::string fname_ssmc;
+    FILE* fp_ssmc;
 private:
     // error check
     bool check_zmp_error (const hrp::Vector3& czmp, const hrp::Vector3& refzmp)
@@ -192,6 +194,20 @@ private:
                     (rleg_contact_states ? 1 : 0), (lleg_contact_states ? 1 : 0),
                     0.8*gg->get_current_toe_heel_ratio()+0.1); // scale+translation just for visualization
             fprintf(fp_sstime, "\n");
+
+            // swing support mid coords
+            fprintf(fp_ssmc, "%f ", i * dt);
+            coordinates tmp_ssmc;
+            gg->get_swing_support_mid_coords(tmp_ssmc);
+            for (size_t ii = 0; ii < 3; ii++) {
+                fprintf(fp_ssmc, "%f ", tmp_ssmc.pos(ii));
+            }
+            hrp::Vector3 tmp_ssmcr = hrp::rpyFromRot(tmp_ssmc.rot);
+            for (size_t ii = 0; ii < 3; ii++) {
+                fprintf(fp_ssmc, "%f ", tmp_ssmcr(ii));
+            }
+            fprintf(fp_ssmc, "\n");
+
             // Error checking
             is_small_zmp_error = check_zmp_error(gg->get_cart_zmp(), gg->get_refzmp()) && is_small_zmp_error;
             if (i>0) {
@@ -224,7 +240,7 @@ private:
     {
         /* plot */
         if (use_gnuplot) {
-            size_t gpsize = 7;
+            size_t gpsize = 9;
             FILE* gps[gpsize];
             for (size_t ii = 0; ii < gpsize;ii++) {
                 gps[ii] = popen("gnuplot", "w");
@@ -370,6 +386,36 @@ private:
                     << std::endl;
                 plot_and_save(gps[4], gtitle, oss.str());
             }
+            {
+                std::ostringstream oss("");
+                std::string gtitle("Swing_support_mid_coords_pos");
+                size_t tmp_start = 2;
+                oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+                std::string titles[3] = {"X", "Y", "Z"};
+                for (size_t ii = 0; ii < 3; ii++) {
+                    oss << "set xlabel 'Time [s]'" << std::endl;
+                    oss << "set ylabel 'Pos " << titles[ii] << "[m]'" << std::endl;
+                    oss << "plot "
+                        << "'" << fname_ssmc << "' using 1:" << (tmp_start+ii) << " with lines title ''"
+                        << std::endl;
+                }
+                plot_and_save(gps[7], gtitle, oss.str());
+            }
+            {
+                std::ostringstream oss("");
+                std::string gtitle("Swing_support_mid_coords_rot");
+                size_t tmp_start = 2;
+                oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+                std::string titles[3] = {"Roll", "Pitch", "Yaw"};
+                for (size_t ii = 0; ii < 3; ii++) {
+                    oss << "set xlabel 'Time [s]'" << std::endl;
+                    oss << "set ylabel 'Rot " << titles[ii] << "[rad]'" << std::endl;
+                    oss << "plot "
+                        << "'" << fname_ssmc << "' using 1:" << (tmp_start+ii+3) << " with lines title ''"
+                        << std::endl;
+                }
+                plot_and_save(gps[8], gtitle, oss.str());
+            }
             double tmp;
             std::cin >> tmp;
             for (size_t ii = 0; ii < gpsize; ii++) {
@@ -420,7 +466,8 @@ public:
                           fname_zoff("/tmp/plot-zoff.dat"), fp_zoff(fopen(fname_zoff.c_str(), "w")),
                           fname_fvel("/tmp/plot-fvel.dat"), fp_fvel(fopen(fname_fvel.c_str(), "w")),
                           fname_thpos("/tmp/plot-thpos.dat"), fp_thpos(fopen(fname_thpos.c_str(), "w")),
-                          fname_sstime("/tmp/plot-sstime.dat"), fp_sstime(fopen(fname_sstime.c_str(), "w"))
+                          fname_sstime("/tmp/plot-sstime.dat"), fp_sstime(fopen(fname_sstime.c_str(), "w")),
+                          fname_ssmc("/tmp/plot-ssmc.dat"), fp_ssmc(fopen(fname_ssmc.c_str(), "w"))
     {};
 
     virtual ~testGaitGenerator()

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -740,8 +740,40 @@ public:
         while ( gg->proc_one_tick() ) {
             proc_one_walking_motion(i);
             i++;
-            if ( i > 1*static_cast<size_t>(gg->get_default_step_time()/dt)) {
+            if ( i > static_cast<size_t>(gg->get_default_step_time()/dt) && gg->get_overwrite_check_timing() ) {
                 gg->finalize_velocity_mode();
+            }
+        }
+        plot_and_checkparam ();
+    };
+
+    void test18 ()
+    {
+        std::cerr << "test18 : Test goVelocity with changing velocity" << std::endl;
+        /* initialize sample footstep_list */
+        parse_params();
+        gg->clear_footstep_nodes_list();
+        gg->set_overwritable_footstep_index_offset(0);
+        gg->set_default_orbit_type(CYCLOIDDELAY);
+        gg->print_param();
+        step_node initial_support_leg_step = step_node(LLEG, coordinates(leg_pos[1]), 0, 0, 0, 0);
+        step_node initial_swing_leg_dst_step = step_node(RLEG, coordinates(leg_pos[0]), 0, 0, 0, 0);
+        coordinates fm_coords;
+        mid_coords(fm_coords, 0.5, initial_swing_leg_dst_step.worldcoords, initial_support_leg_step.worldcoords);
+        gg->initialize_velocity_mode(fm_coords, 0, 0, 0, boost::assign::list_of(RLEG));
+        gg->initialize_gait_parameter(cog, boost::assign::list_of(initial_support_leg_step), boost::assign::list_of(initial_swing_leg_dst_step));
+        while ( !gg->proc_one_tick() );
+        /* make step and dump */
+        size_t i = 0;
+        while ( gg->proc_one_tick() ) {
+            proc_one_walking_motion(i);
+            i++;
+            if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*3 && gg->get_overwrite_check_timing() ) {
+                gg->finalize_velocity_mode();
+            } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*2 && gg->get_overwrite_check_timing() ) {
+                gg->set_velocity_param(0.0, 0.0, 0);
+            } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt) && gg->get_overwrite_check_timing() ) {
+                gg->set_velocity_param(0.1, 0.05, 0);
             }
         }
         plot_and_checkparam ();
@@ -863,6 +895,7 @@ void print_usage ()
     std::cerr << "  --test15 : Stair walk down" << std::endl;
     std::cerr << "  --test16 : Set foot steps with param (toe heel contact)" << std::endl;
     std::cerr << "  --test17 : Test goVelocity (dx = 0.1, dy = 0.05, dth = 10.0)" << std::endl;
+    std::cerr << "  --test18 : Test goVelocity with changing velocity" << std::endl;
 };
 
 int main(int argc, char* argv[])
@@ -909,6 +942,8 @@ int main(int argc, char* argv[])
           tgg.test16();
       } else if (std::string(argv[1]) == "--test17") {
           tgg.test17();
+      } else if (std::string(argv[1]) == "--test18") {
+          tgg.test18();
       } else {
           print_usage();
           ret = 1;

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -749,7 +749,7 @@ public:
 
     void test18 ()
     {
-        std::cerr << "test18 : Test goVelocity with changing velocity" << std::endl;
+        std::cerr << "test18 : Test goVelocity with changing velocity (translation and rotation)" << std::endl;
         /* initialize sample footstep_list */
         parse_params();
         gg->clear_footstep_nodes_list();
@@ -768,10 +768,14 @@ public:
         while ( gg->proc_one_tick() ) {
             proc_one_walking_motion(i);
             i++;
-            if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*3 && gg->get_overwrite_check_timing() ) {
+            if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*5 && gg->get_overwrite_check_timing() ) {
                 gg->finalize_velocity_mode();
+            } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*4 && gg->get_overwrite_check_timing() ) {
+                gg->set_velocity_param(0, 0, 0);
+            } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*3 && gg->get_overwrite_check_timing() ) {
+                gg->set_velocity_param(0, 0, 10);
             } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt)*2 && gg->get_overwrite_check_timing() ) {
-                gg->set_velocity_param(0.0, 0.0, 0);
+                gg->set_velocity_param(0, 0, 0);
             } else if ( i > static_cast<size_t>(gg->get_default_step_time()/dt) && gg->get_overwrite_check_timing() ) {
                 gg->set_velocity_param(0.1, 0.05, 0);
             }
@@ -895,7 +899,7 @@ void print_usage ()
     std::cerr << "  --test15 : Stair walk down" << std::endl;
     std::cerr << "  --test16 : Set foot steps with param (toe heel contact)" << std::endl;
     std::cerr << "  --test17 : Test goVelocity (dx = 0.1, dy = 0.05, dth = 10.0)" << std::endl;
-    std::cerr << "  --test18 : Test goVelocity with changing velocity" << std::endl;
+    std::cerr << "  --test18 : Test goVelocity with changing velocity (translation and rotation)" << std::endl;
 };
 
 int main(int argc, char* argv[])

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -24,8 +24,18 @@ protected:
     std::vector<bool> prev_contact_states;
     std::vector<double> prev_swing_support_time;
     // For plot
-    std::string fname;
-    FILE* fp;
+    std::string fname_cogzmp;
+    FILE* fp_cogzmp;
+    std::string fname_fpos;
+    FILE* fp_fpos;
+    std::string fname_frot;
+    FILE* fp_frot;
+    std::string fname_zoff;
+    FILE* fp_zoff;
+    std::string fname_fvel;
+    FILE* fp_fvel;
+    std::string fname_thpos;
+    FILE* fp_thpos;
     std::string fname_sstime;
     FILE* fp_sstime;
 private:
@@ -53,13 +63,15 @@ private:
             //   //std::cerr << gg->lcg.gp_index << std::endl;
             //   gg->update_refzmp_queue(coordinates(hrp::Vector3(150, 105, 0)), coordinates(hrp::Vector3(150, -105, 0)));
             // }
-            fprintf(fp, "%f ", i * dt);
+
+            // COG and ZMP
+            fprintf(fp_cogzmp, "%f ", i * dt);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", gg->get_refzmp()(ii));
+                fprintf(fp_cogzmp, "%f ", gg->get_refzmp()(ii));
             }
             hrp::Vector3 czmp = gg->get_cart_zmp();
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", czmp(ii));
+                fprintf(fp_cogzmp, "%f ", czmp(ii));
             }
             for (size_t ii = 0; ii < 3; ii++) {
                 double cogpos;
@@ -70,87 +82,103 @@ private:
                 } else {
                     cogpos = gg->get_cog()(ii);
                 }
-                fprintf(fp, "%f ", cogpos);
+                fprintf(fp_cogzmp, "%f ", cogpos);
             }
+            fprintf(fp_cogzmp, "\n");
+
             // Foot pos
+            fprintf(fp_fpos, "%f ", i * dt);
             std::vector<std::string> tmp_string_vector = boost::assign::list_of("rleg");
             hrp::Vector3 rfoot_pos = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.pos : gg->get_swing_leg_steps().front().worldcoords.pos;
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", rfoot_pos(ii));
+                fprintf(fp_fpos, "%f ", rfoot_pos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), rfoot_pos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), rfoot_pos(ii));
             }
             tmp_string_vector = boost::assign::list_of("lleg");
             hrp::Vector3 lfoot_pos = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.pos : gg->get_swing_leg_steps().front().worldcoords.pos;
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", lfoot_pos(ii));
+                fprintf(fp_fpos, "%f ", lfoot_pos(ii));
                 min_lfoot_pos(ii) = std::min(min_lfoot_pos(ii), lfoot_pos(ii));
                 max_lfoot_pos(ii) = std::max(max_lfoot_pos(ii), lfoot_pos(ii));
             }
+            fprintf(fp_fpos, "\n");
+
             // Foot rot
+            fprintf(fp_frot, "%f ", i * dt);
             hrp::Vector3 rpy;
             tmp_string_vector = boost::assign::list_of("rleg");
             hrp::Matrix33 rfoot_rot = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.rot : gg->get_swing_leg_steps().front().worldcoords.rot;
             rpy = hrp::rpyFromRot(rfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
+                fprintf(fp_frot, "%f ", 180.0*rpy(ii)/M_PI);
             }
             tmp_string_vector = boost::assign::list_of("lleg");
             hrp::Matrix33 lfoot_rot = (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_leg_steps().front().worldcoords.rot : gg->get_swing_leg_steps().front().worldcoords.rot;
             rpy = hrp::rpyFromRot(lfoot_rot);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", 180.0*rpy(ii)/M_PI);
+                fprintf(fp_frot, "%f ", 180.0*rpy(ii)/M_PI);
             }
+            fprintf(fp_frot, "\n");
+
             // ZMP offsets
+            fprintf(fp_zoff, "%f ", i * dt);
             tmp_string_vector = boost::assign::list_of("rleg");
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
+                fprintf(fp_zoff, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
             tmp_string_vector = boost::assign::list_of("lleg");
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
+                fprintf(fp_zoff, "%f ", (gg->get_support_leg_names() == tmp_string_vector) ? gg->get_support_foot_zmp_offsets().front()(ii) : gg->get_swing_foot_zmp_offsets().front()(ii));
             }
+            fprintf(fp_zoff, "\n");
+
             // Foot vel
+            fprintf(fp_fvel, "%f ", i * dt);
             hrp::Vector3 tmpv;
             if ( i == 0 ) prev_rfoot_pos = rfoot_pos;
             tmpv = (rfoot_pos - prev_rfoot_pos)/dt;
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmpv(ii));
+                fprintf(fp_fvel, "%f ", tmpv(ii));
             }
             prev_rfoot_pos = rfoot_pos;
             if ( i == 0 ) prev_lfoot_pos = lfoot_pos;
             tmpv = (lfoot_pos - prev_lfoot_pos)/dt;
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmpv(ii));
+                fprintf(fp_fvel, "%f ", tmpv(ii));
             }
             prev_lfoot_pos = lfoot_pos;
+            fprintf(fp_fvel, "\n");
+
             // Toe heel pos
+            fprintf(fp_thpos, "%f ", i * dt);
             hrp::Vector3 tmppos;
             tmppos = rfoot_pos+rfoot_rot*hrp::Vector3(gg->get_toe_pos_offset_x(), 0, 0);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmppos(ii));
+                fprintf(fp_thpos, "%f ", tmppos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), tmppos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), tmppos(ii));
             }
             tmppos = lfoot_pos+lfoot_rot*hrp::Vector3(gg->get_toe_pos_offset_x(), 0, 0);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmppos(ii));
+                fprintf(fp_thpos, "%f ", tmppos(ii));
                 min_lfoot_pos(ii) = std::min(min_lfoot_pos(ii), tmppos(ii));
                 max_lfoot_pos(ii) = std::max(max_lfoot_pos(ii), tmppos(ii));
             }
             tmppos = rfoot_pos+rfoot_rot*hrp::Vector3(gg->get_heel_pos_offset_x(), 0, 0);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmppos(ii));
+                fprintf(fp_thpos, "%f ", tmppos(ii));
                 min_rfoot_pos(ii) = std::min(min_rfoot_pos(ii), tmppos(ii));
                 max_rfoot_pos(ii) = std::max(max_rfoot_pos(ii), tmppos(ii));
             }
             tmppos = lfoot_pos+lfoot_rot*hrp::Vector3(gg->get_heel_pos_offset_x(), 0, 0);
             for (size_t ii = 0; ii < 3; ii++) {
-                fprintf(fp, "%f ", tmppos(ii));
+                fprintf(fp_thpos, "%f ", tmppos(ii));
                 min_lfoot_pos(ii) = std::min(min_lfoot_pos(ii), tmppos(ii));
                 max_lfoot_pos(ii) = std::max(max_lfoot_pos(ii), tmppos(ii));
             }
-            fprintf(fp, "\n");
+            fprintf(fp_thpos, "\n");
+
             // Swing time
             fprintf(fp_sstime, "%f ", i * dt);
             fprintf(fp_sstime, "%f %f ",
@@ -197,7 +225,6 @@ private:
         /* plot */
         if (use_gnuplot) {
             size_t gpsize = 7;
-            size_t tmp_start = 2;
             FILE* gps[gpsize];
             for (size_t ii = 0; ii < gpsize;ii++) {
                 gps[ii] = popen("gnuplot", "w");
@@ -205,88 +232,89 @@ private:
             {
                 std::ostringstream oss("");
                 std::string gtitle("COG_and_ZMP");
+                size_t tmp_start = 2;
                 oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
                 std::string titles[3] = {"X", "Y", "Z"};
                 for (size_t ii = 0; ii < 3; ii++) {
                     oss << "set xlabel 'Time [s]'" << std::endl;
                     oss << "set ylabel '" << titles[ii] << "[m]'" << std::endl;
                     oss << "plot "
-                        << "'" << fname << "' using 1:" << (tmp_start+ii) << " with lines title 'REFZMP',"
-                        << "'" << fname << "' using 1:" << (tmp_start+3+ii) << " with lines title 'CARTZMP',"
-                        << "'" << fname << "' using 1:" << (tmp_start+6+ii) << " with lines title 'COG'"
+                        << "'" << fname_cogzmp << "' using 1:" << (tmp_start+ii) << " with lines title 'REFZMP',"
+                        << "'" << fname_cogzmp << "' using 1:" << (tmp_start+3+ii) << " with lines title 'CARTZMP',"
+                        << "'" << fname_cogzmp << "' using 1:" << (tmp_start+6+ii) << " with lines title 'COG'"
                         << std::endl;
                 }
                 plot_and_save(gps[0], gtitle, oss.str());
-                tmp_start += 9;
             }
             {
                 std::ostringstream oss("");
                 std::string gtitle("Swing_support_pos");
+                size_t tmp_start = 2;
                 oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
                 std::string titles[3] = {"X", "Y", "Z"};
                 for (size_t ii = 0; ii < 3; ii++) {
                     oss << "set xlabel 'Time [s]'" << std::endl;
                     oss << "set ylabel '" << titles[ii] << "[m]'" << std::endl;
                     oss << "plot "
-                        << "'" << fname << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
-                        << "'" << fname << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
+                        << "'" << fname_fpos << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
+                        << "'" << fname_fpos << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
                         << std::endl;
                 }
                 plot_and_save(gps[1], gtitle, oss.str());
-                tmp_start += 6;
             }
             {
                 std::ostringstream oss("");
                 std::string gtitle("Swing_support_rot");
+                size_t tmp_start = 2;
                 oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
                 std::string titles[3] = {"Roll", "Pitch", "Yaw"};
                 for (size_t ii = 0; ii < 3; ii++) {
                     oss << "set xlabel 'Time [s]'" << std::endl;
                     oss << "set ylabel '" << titles[ii] << "[deg]'" << std::endl;
                     oss << "plot "
-                        << "'" << fname << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
-                        << "'" << fname << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
+                        << "'" << fname_frot << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
+                        << "'" << fname_frot << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
                         << std::endl;
                 }
                 plot_and_save(gps[2], gtitle, oss.str());
-                tmp_start += 6;
             }
             {
                 std::ostringstream oss("");
                 std::string gtitle("Swing_support_zmp_offset");
+                size_t tmp_start = 2;
                 oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
                 std::string titles[3] = {"X", "Y", "Z"};
                 for (size_t ii = 0; ii < 3; ii++) {
                     oss << "set xlabel 'Time [s]'" << std::endl;
                     oss << "set ylabel '" << titles[ii] << "[m]'" << std::endl;
                     oss << "plot "
-                        << "'" << fname << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
-                        << "'" << fname << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
+                        << "'" << fname_zoff << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
+                        << "'" << fname_zoff << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
                         << std::endl;
                 }
                 plot_and_save(gps[3], gtitle, oss.str());
-                tmp_start += 6;
             }
             {
                 std::ostringstream oss("");
                 std::string gtitle("Swing_support_vel");
+                size_t tmp_start = 2;
                 oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
                 std::string titles[3] = {"X", "Y", "Z"};
                 for (size_t ii = 0; ii < 3; ii++) {
                     oss << "set xlabel 'Time [s]'" << std::endl;
                     oss << "set ylabel '" << titles[ii] << "[m]'" << std::endl;
                     oss << "plot "
-                        << "'" << fname << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
-                        << "'" << fname << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
+                        << "'" << fname_fvel << "' using 1:" << (tmp_start+ii) << " with lines title 'rleg',"
+                        << "'" << fname_fvel << "' using 1:" << (tmp_start+3+ii) << " with lines title 'lleg'"
                         << std::endl;
                 }
                 plot_and_save(gps[5], gtitle, oss.str());
-                tmp_start += 6;
             }
             {
                 std::ostringstream oss("");
                 std::string gtitle("Swing_support_pos_trajectory");
                 double min_v[3], max_v[3], range[3];
+                size_t tmp_thpos_start = 2;
                 for (size_t ii = 0; ii < 3; ii++) {
                     min_v[ii] = std::min(min_rfoot_pos(ii), min_lfoot_pos(ii));
                     max_v[ii] = std::max(max_rfoot_pos(ii), max_lfoot_pos(ii));
@@ -303,12 +331,12 @@ private:
                 oss << "plot "
                     << "[" << min_v[0]<< ":" << max_v[0] << "]"
                     << "[" << min_v[2] << ":" << max_v[2] << "]"
-                    << "'" << fname << "' using " << (2+3+3+3+0) << ":" << (2+3+3+3+2)  << " with lines title 'rleg ee',"
-                    << "'" << fname << "' using " << (2+3+3+3+3+0) << ":" << (2+3+3+3+3+2) << " with lines title 'lleg ee',"
-                    << "'" << fname << "' using " << (tmp_start) << ":" << (tmp_start+2)  << " with lines title 'rleg toe',"
-                    << "'" << fname << "' using " << (tmp_start+3) << ":" << (tmp_start+3+2)  << " with lines title 'lleg toe',"
-                    << "'" << fname << "' using " << (tmp_start+3+3) << ":" << (tmp_start+3+3+2)  << " with lines title 'rleg heel',"
-                    << "'" << fname << "' using " << (tmp_start+3+3+3) << ":" << (tmp_start+3+3+3+2)  << " with lines title 'lleg heel'"
+                    << "'" << fname_fpos << "' using " << (2) << ":" << (2+2)  << " with lines title 'rleg ee',"
+                    << "'" << fname_fpos << "' using " << (2+3) << ":" << (2+3+2) << " with lines title 'lleg ee',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start) << ":" << (tmp_thpos_start+2)  << " with lines title 'rleg toe',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3) << ":" << (tmp_thpos_start+3+2)  << " with lines title 'lleg toe',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3+3) << ":" << (tmp_thpos_start+3+3+2)  << " with lines title 'rleg heel',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3+3+3) << ":" << (tmp_thpos_start+3+3+3+2)  << " with lines title 'lleg heel'"
                     << std::endl;
                 //oss << "set title 'Y-Z'" << std::endl;
                 oss << "set size ratio " << range[2]/range[1] << std::endl;
@@ -317,12 +345,12 @@ private:
                 oss << "plot "
                     << "[" << min_v[1]<< ":" << max_v[1] << "]"
                     << "[" << min_v[2] << ":" << max_v[2] << "]"
-                    << "'" << fname << "' using " << (2+3+3+3+1) << ":" << (2+3+3+3+2)  << " with lines title 'rleg ee',"
-                    << "'" << fname << "' using " << (2+3+3+3+3+1) << ":" << (2+3+3+3+3+2) << " with lines title 'lleg ee',"
-                    << "'" << fname << "' using " << (tmp_start+1) << ":" << (tmp_start+2)  << " with lines title 'rleg toe',"
-                    << "'" << fname << "' using " << (tmp_start+3+1) << ":" << (tmp_start+3+2)  << " with lines title 'lleg toe',"
-                    << "'" << fname << "' using " << (tmp_start+3+3+1) << ":" << (tmp_start+3+3+2)  << " with lines title 'rleg heel',"
-                    << "'" << fname << "' using " << (tmp_start+3+3+3+1) << ":" << (tmp_start+3+3+3+2)  << " with lines title 'lleg heel'"
+                    << "'" << fname_fpos << "' using " << (2+1) << ":" << (2+2)  << " with lines title 'rleg ee',"
+                    << "'" << fname_fpos << "' using " << (2+3+1) << ":" << (2+3+2) << " with lines title 'lleg ee',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+1) << ":" << (tmp_thpos_start+2)  << " with lines title 'rleg toe',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3+1) << ":" << (tmp_thpos_start+3+2)  << " with lines title 'lleg toe',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3+3+1) << ":" << (tmp_thpos_start+3+3+2)  << " with lines title 'rleg heel',"
+                    << "'" << fname_thpos << "' using " << (tmp_thpos_start+3+3+3+1) << ":" << (tmp_thpos_start+3+3+3+2)  << " with lines title 'lleg heel'"
                     << std::endl;
                 plot_and_save(gps[6], gtitle, oss.str());
             }
@@ -386,7 +414,12 @@ public:
                           min_rfoot_pos(1e10,1e10,1e10), min_lfoot_pos(1e10,1e10,1e10), max_rfoot_pos(-1e10,-1e10,-1e10), max_lfoot_pos(-1e10,-1e10,-1e10),
                           prev_contact_states(2, true), // RLEG, LLEG
                           prev_swing_support_time(2, 1e2), // RLEG, LLEG
-                          fname("/tmp/plot.dat"), fp(fopen(fname.c_str(), "w")),
+                          fname_cogzmp("/tmp/plot-cogzmp.dat"), fp_cogzmp(fopen(fname_cogzmp.c_str(), "w")),
+                          fname_fpos("/tmp/plot-fpos.dat"), fp_fpos(fopen(fname_fpos.c_str(), "w")),
+                          fname_frot("/tmp/plot-frot.dat"), fp_frot(fopen(fname_frot.c_str(), "w")),
+                          fname_zoff("/tmp/plot-zoff.dat"), fp_zoff(fopen(fname_zoff.c_str(), "w")),
+                          fname_fvel("/tmp/plot-fvel.dat"), fp_fvel(fopen(fname_fvel.c_str(), "w")),
+                          fname_thpos("/tmp/plot-thpos.dat"), fp_thpos(fopen(fname_thpos.c_str(), "w")),
                           fname_sstime("/tmp/plot-sstime.dat"), fp_sstime(fopen(fname_sstime.c_str(), "w"))
     {};
 
@@ -396,7 +429,12 @@ public:
             delete gg;
             gg = NULL;
         }
-        fclose(fp);
+        fclose(fp_cogzmp);
+        fclose(fp_fpos);
+        fclose(fp_frot);
+        fclose(fp_zoff);
+        fclose(fp_fvel);
+        fclose(fp_thpos);
         fclose(fp_sstime);
     };
 

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -721,6 +721,32 @@ public:
         gen_and_plot_walk_pattern();
     };
 
+    void test17 ()
+    {
+        std::cerr << "test17 : Test goVelocity (dx = 0.1, dy = 0.05, dth = 10.0)" << std::endl;
+        /* initialize sample footstep_list */
+        parse_params();
+        gg->clear_footstep_nodes_list();
+        gg->print_param();
+        step_node initial_support_leg_step = step_node(LLEG, coordinates(leg_pos[1]), 0, 0, 0, 0);
+        step_node initial_swing_leg_dst_step = step_node(RLEG, coordinates(leg_pos[0]), 0, 0, 0, 0);
+        coordinates fm_coords;
+        mid_coords(fm_coords, 0.5, initial_swing_leg_dst_step.worldcoords, initial_support_leg_step.worldcoords);
+        gg->initialize_velocity_mode(fm_coords, 0.1, 0.05, 10.0, boost::assign::list_of(RLEG));
+        gg->initialize_gait_parameter(cog, boost::assign::list_of(initial_support_leg_step), boost::assign::list_of(initial_swing_leg_dst_step));
+        while ( !gg->proc_one_tick() );
+        /* make step and dump */
+        size_t i = 0;
+        while ( gg->proc_one_tick() ) {
+            proc_one_walking_motion(i);
+            i++;
+            if ( i > 1*static_cast<size_t>(gg->get_default_step_time()/dt)) {
+                gg->finalize_velocity_mode();
+            }
+        }
+        plot_and_checkparam ();
+    };
+
     void parse_params ()
     {
       for (unsigned int i = 0; i < arg_strs.size(); ++ i) {
@@ -836,6 +862,7 @@ void print_usage ()
     std::cerr << "  --test14 : kick walk" << std::endl;
     std::cerr << "  --test15 : Stair walk down" << std::endl;
     std::cerr << "  --test16 : Set foot steps with param (toe heel contact)" << std::endl;
+    std::cerr << "  --test17 : Test goVelocity (dx = 0.1, dy = 0.05, dth = 10.0)" << std::endl;
 };
 
 int main(int argc, char* argv[])
@@ -880,6 +907,8 @@ int main(int argc, char* argv[])
           tgg.test15();
       } else if (std::string(argv[1]) == "--test16") {
           tgg.test16();
+      } else if (std::string(argv[1]) == "--test17") {
+          tgg.test17();
       } else {
           print_usage();
           ret = 1;

--- a/rtc/ImpedanceController/RatsMatrix.cpp
+++ b/rtc/ImpedanceController/RatsMatrix.cpp
@@ -43,10 +43,10 @@ namespace rats
     ret_dif_rot = self_rot * hrp::Vector3(rats::matrix_log(hrp::Matrix33(self_rot.transpose() * target_rot)));
   }
 
-  void mid_rot(hrp::Matrix33& mid_rot, const double p, const hrp::Matrix33& rot1, const hrp::Matrix33& rot2) {
+  void mid_rot(hrp::Matrix33& mid_rot, const double p, const hrp::Matrix33& rot1, const hrp::Matrix33& rot2, const double eps) {
     hrp::Matrix33 r(rot1.transpose() * rot2);
     hrp::Vector3 omega(matrix_log(r));
-    if (eps_eq(omega.norm(),0.0)) { // c1.rot and c2.rot are same
+    if (eps_eq(omega.norm(),0.0, eps)) { // c1.rot and c2.rot are same
       mid_rot = rot1;
     } else {
       hrp::calcRodrigues(r, omega.normalized(), omega.norm()*p);
@@ -55,9 +55,9 @@ namespace rats
     }
   };
 
-  void mid_coords(coordinates& mid_coords, const double p, const coordinates& c1, const coordinates& c2) {
+  void mid_coords(coordinates& mid_coords, const double p, const coordinates& c1, const coordinates& c2, const double eps) {
     mid_coords.pos = (1 - p) * c1.pos + p * c2.pos;
-    mid_rot(mid_coords.rot, p, c1.rot, c2.rot);
+    mid_rot(mid_coords.rot, p, c1.rot, c2.rot, eps);
   };
 
 }

--- a/rtc/ImpedanceController/RatsMatrix.h
+++ b/rtc/ImpedanceController/RatsMatrix.h
@@ -91,7 +91,7 @@ namespace rats
     }
   };
 
-  void mid_rot(hrp::Matrix33& mid_rot, const double p, const hrp::Matrix33& rot1, const hrp::Matrix33& rot2);
-  void mid_coords(coordinates& mid_coords, const double p, const coordinates& c1, const coordinates& c2);
+  void mid_rot(hrp::Matrix33& mid_rot, const double p, const hrp::Matrix33& rot1, const hrp::Matrix33& rot2, const double eps = 0.001);
+  void mid_coords(coordinates& mid_coords, const double p, const coordinates& c1, const coordinates& c2, const double eps = 0.001);
 };
 #endif /* RATSMATRIX_H */

--- a/rtc/SequencePlayer/interpolator.h
+++ b/rtc/SequencePlayer/interpolator.h
@@ -59,7 +59,7 @@ public:
   //   If remain_t <= 0, do nothing.
   void interpolate(double& remain_t_);
   double deltaT() const { return dt; }
-  double dimension() const { return dim; }
+  int dimension() const { return dim; }
   void setName (const std::string& _name) { name = _name; };
 private:
   // Current interpolation mode


### PR DESCRIPTION
Thanks for @kyawawa

GaitGeneratorで歩行するときにoverritable-footstep-index-offset = 0にする（＝遊脚の着地位置を変更可能にする）と
- 変更時に足先姿勢の補間が不連続になる
- swing support foot mid coords (swing->supportまで連続的に遷移する代表座標)の補間が不連続になる(@kyawawa報告)

の２点があったので、修正して、テストを追加しました。

よろしくお願いします