### PR TITLE
[py] Add a warning inline doc for setJointAngles.

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -1067,6 +1067,11 @@ class HrpsysConfigurator(object):
               been thrown by hrpsys so that there's no way to catch on this python client. 
               Worthwhile opening an enhancement ticket at designated issue tracker.
         \endverbatim
+        @attention: You should not mix using setJointAngles and some other
+                    methods that takes kinematics group as an arg, such as
+                    setTargetPose, clearOfGroup etc., which interpolates by the
+                    specified group while setJointAngles does so for the full
+                    body. See more at https://github.com/tork-a/rtmros_nextage/issues/332#issuecomment-303735640
         @param angles list of float: In degree.
         @param tm float: Time to complete.
         @rtype bool


### PR DESCRIPTION
Inline で書いている通り，https://github.com/tork-a/rtmros_nextage/issues/332#issuecomment-303735640 の指摘を python の inline doc に追加しています．プログラマティックな作用は一切無いです．

指摘中にある"やってはいけない"を抑止する効果を追加しようとすると Python よりも上流で何かする必要があるんだと思いますが，ちょっと私にはわかりません．