### PR TITLE
[rtc/AutoBalancer/GaitGenerator.h] set initial state to modify bug of leg coords generator at walk with no double support phase

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -443,6 +443,15 @@ namespace rats
       };
       void get_trajectory_point (hrp::Vector3& ret, const hrp::Vector3& start, const hrp::Vector3& goal, const double height)
       {
+        if ( current_count <= double_support_count_before ) { // first double support phase
+          pos = start;
+          vel = hrp::Vector3::Zero();
+          acc = hrp::Vector3::Zero();
+        } else if ( current_count >= one_step_count - double_support_count_after ) { // last double support phase
+          pos = goal;
+          vel = hrp::Vector3::Zero();
+          acc = hrp::Vector3::Zero();
+        }
         if ( double_support_count_before <= current_count && current_count < one_step_count - double_support_count_after ) { // swing phase
           size_t swing_remain_count = one_step_count - current_count - double_support_count_after;
           size_t swing_one_step_count = one_step_count - double_support_count_before - double_support_count_after;
@@ -470,14 +479,6 @@ namespace rats
           } else {
             pos(2) = goal(2);
           }
-        } else if ( current_count < double_support_count_before ) { // first double support phase
-          pos = start;
-          vel = hrp::Vector3::Zero();
-          acc = hrp::Vector3::Zero();
-        } else { // last double support phase
-          pos = goal;
-          vel = hrp::Vector3::Zero();
-          acc = hrp::Vector3::Zero();
         }
         ret = pos;
         current_count++;


### PR DESCRIPTION
get_trajectory_point関数を使う脚軌道の時に両脚支持期を0にすると脚軌道の最初のpos等がsetされず値が飛ぶbugがあり，それを直すPRです．