### PR TITLE
Truncate zmp

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -235,6 +235,8 @@ module OpenHRP
       double detection_time_to_air;
       /// Limit of compensation for difference between ref-act root rot [rad].
       DblArray2 root_rot_compensation_limit;
+      /// Whether truncate zmp according to foot support polygon or not
+      boolean use_zmp_truncation;
     };
 
     /**

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -407,6 +407,7 @@ RTC::ReturnCode_t Stabilizer::onInitialize()
   is_estop_while_walking = false;
   sbp_cog_offset = hrp::Vector3(0.0, 0.0, 0.0);
   use_limb_stretch_avoidance = false;
+  use_zmp_truncation = false;
   limb_stretch_avoidance_time_const = 1.5;
   limb_stretch_avoidance_vlimit[0] = -100 * 1e-3 * dt; // lower limit
   limb_stretch_avoidance_vlimit[1] = 50 * 1e-3 * dt; // upper limit
@@ -945,6 +946,18 @@ void Stabilizer::getActualParameters ()
               tmpp = foot_origin_rot.transpose()*(cop_pos[i]-foot_origin_pos);
               std::cerr << ", cop_pos (" << ee_name[i] << ")    = " << hrp::Vector3(tmpp*1e3).format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "[", "]")) << "[mm]" << std::endl;
           }
+      }
+
+      // truncate ZMP
+      if (use_zmp_truncation) {
+        Eigen::Vector2d tmp_new_refzmp(new_refzmp.head(2));
+        SimpleZMPDistributor::leg_type support_leg;
+        if (ref_contact_states[contact_states_index_map["rleg"]] && ref_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::BOTH;
+        else if (ref_contact_states[contact_states_index_map["rleg"]]) support_leg = SimpleZMPDistributor::RLEG;
+        else if (ref_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::LLEG;
+        if (!szd->is_inside_support_polygon(tmp_new_refzmp, ee_pos, ee_rot, ee_name, support_leg, std::vector<double>(), hrp::Vector3(0.0, 0.0, 0.0), true)){
+          new_refzmp.head(2) = tmp_new_refzmp;
+        }
       }
 
       // Distribute ZMP into each EE force/moment at each COP
@@ -2008,6 +2021,7 @@ void Stabilizer::getParameter(OpenHRP::StabilizerService::stParam& i_stp)
   i_stp.emergency_check_mode = emergency_check_mode;
   i_stp.end_effector_list.length(stikp.size());
   i_stp.use_limb_stretch_avoidance = use_limb_stretch_avoidance;
+  i_stp.use_zmp_truncation = use_zmp_truncation;
   i_stp.limb_stretch_avoidance_time_const = limb_stretch_avoidance_time_const;
   i_stp.limb_length_margin.length(stikp.size());
   i_stp.detection_time_to_air = detection_count_to_air * dt;
@@ -2185,6 +2199,7 @@ void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
   contact_decision_threshold = i_stp.contact_decision_threshold;
   is_estop_while_walking = i_stp.is_estop_while_walking;
   use_limb_stretch_avoidance = i_stp.use_limb_stretch_avoidance;
+  use_zmp_truncation = i_stp.use_zmp_truncation;
   limb_stretch_avoidance_time_const = i_stp.limb_stretch_avoidance_time_const;
   for (size_t i = 0; i < 2; i++) {
     limb_stretch_avoidance_vlimit[i] = i_stp.limb_stretch_avoidance_vlimit[i];

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -295,7 +295,7 @@ class Stabilizer
   int m_is_falling_counter;
   std::vector<int> m_will_fall_counter;
   int is_air_counter, detection_count_to_air;
-  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_limb_stretch_avoidance;
+  bool is_legged_robot, on_ground, is_emergency, is_seq_interpolating, reset_emergency_flag, eefm_use_force_difference_control, eefm_use_swing_damping, initial_cp_too_large_error, use_limb_stretch_avoidance, use_zmp_truncation;
   bool is_walking, is_estop_while_walking;
   hrp::Vector3 current_root_p, target_root_p;
   hrp::Matrix33 current_root_R, target_root_R, prev_act_foot_origin_rot, prev_ref_foot_origin_rot, target_foot_origin_rot, ref_foot_origin_rot;

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -85,7 +85,7 @@ public:
         else if (support_leg == BOTH) return (cp(1) <= (leg_outside_margin + offset - margin)) && (cp(1) >= (-1 * (leg_outside_margin + offset) + margin)) && (cp(0) <= (leg_front_margin - margin)) && (cp(0) >= (-1 * leg_rear_margin + margin));
         else return true;
     };
-    inline bool is_inside_support_polygon (Eigen::Vector2d& p, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot, const std::vector<std::string>& ee_name, const leg_type& support_leg, const std::vector<double>& tmp_margin = std::vector<double>(), const hrp::Vector3& offset = hrp::Vector3(0.0, 0.0, 0.0))
+    inline bool is_inside_support_polygon (Eigen::Vector2d& p, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot, const std::vector<std::string>& ee_name, const leg_type& support_leg, const std::vector<double>& tmp_margin = std::vector<double>(), const hrp::Vector3& offset = hrp::Vector3(0.0, 0.0, 0.0), bool calc_nearest_point = false)
     {
       if (ee_pos.size() == 0 || ee_rot.size() == 0 || ee_name.size() == 0 ) return true;
       size_t l_idx, r_idx;
@@ -127,11 +127,51 @@ public:
         convex_vertices = lleg_vertices;
       }
       // check whether p is inside support polygon
-      for (size_t i = 0; i < convex_vertices.size() - 1; i++) {
-        if (calcCrossProduct(p, convex_vertices[i + 1], convex_vertices[i]) < 0) return false;
+      if (!calc_nearest_point) {
+        for (size_t i = 0; i < convex_vertices.size() - 1; i++) {
+          if (calcCrossProduct(p, convex_vertices[i + 1], convex_vertices[i]) < 0) return false;
+        }
+        if (calcCrossProduct(p, convex_vertices.front(), convex_vertices.back()) < 0) return false;
+        return true;
       }
-      if (calcCrossProduct(p, convex_vertices.front(), convex_vertices.back()) < 0) return false;
-      return true;
+      // calc nearest point
+      bool is_inside = true;
+      double cur_nearest_dist, nearest_dist;
+      Eigen::Vector2d cur_nearest_point, nearest_point;
+      if (calcCrossProduct(p, convex_vertices.front(), convex_vertices.back()) < 0) { // is outside
+        if (calcProjectedPoint(cur_nearest_point, p, convex_vertices.front(), convex_vertices.back())) { // projected point is on line
+          p = cur_nearest_point;
+          return false;
+        } else { // projected point is not on line
+          nearest_dist = (cur_nearest_point - p).norm();
+          nearest_point = cur_nearest_point;
+        }
+        is_inside = false;
+      }
+      for (size_t i = 0; i < convex_vertices.size() - 1; i++) {
+        if (calcCrossProduct(p, convex_vertices[i + 1], convex_vertices[i]) < 0) { // is outside
+          if (calcProjectedPoint(cur_nearest_point, p, convex_vertices[i + 1], convex_vertices[i])) { // projected point is on line
+            p = cur_nearest_point;
+            return false;
+          } else { // projected point is not on line
+            cur_nearest_dist = (cur_nearest_point - p).norm();
+            if (is_inside || i == 0) { // first set
+              nearest_dist = cur_nearest_dist;
+              nearest_point = cur_nearest_point;
+            } else if (cur_nearest_dist < nearest_dist) { // update nearest candidate
+              nearest_dist = cur_nearest_dist;
+              nearest_point = cur_nearest_point;
+            }
+          }
+          is_inside = false;
+        }
+      }
+      if (is_inside) {
+          return true;
+        } else {
+          p = nearest_point;
+          return false;
+      }
     };
     void print_params (const std::string& str)
     {
@@ -1064,6 +1104,28 @@ public:
   double calcCrossProduct(Eigen::Vector2d& a, Eigen::Vector2d& b, Eigen::Vector2d& o)
   {
     return (a(0) - o(0)) * (b(1) - o(1)) - (a(1) - o(1)) * (b(0) - o(0));
+  };
+
+  bool calcProjectedPoint(Eigen::Vector2d& ret, Eigen::Vector2d& target, Eigen::Vector2d& a, Eigen::Vector2d& b){
+    Eigen::Vector2d v1 = target - b;
+    Eigen::Vector2d v2 = a - b;
+    double v2_norm = v2.norm();
+    if ( v2_norm = 0 ) {
+        ret = a;
+        return false;
+    } else {
+        double ratio = v1.dot(v2) / (v2_norm * v2_norm);
+        if (ratio < 0){
+            ret = b;
+            return false;
+        } else if (ratio > 1){
+            ret = a;
+            return false;
+        } else {
+            ret = b + ratio * v2;
+            return true;
+        }
+    }
   };
 
   // assume that vertices are listed in clockwise order


### PR DESCRIPTION
new ref zmp (足裏反力分配の時に用いる，目標ZMPに逆システムをかけた修正目標ZMP)が目標の支持領域を出た時に支持領域の近傍点に修正するオプションを追加しました．

デフォルトの挙動は変わりません．