### PR TITLE
Add resolved momentum control function

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -14,6 +14,7 @@ module OpenHRP
     typedef double DblArray3[3];
     typedef double DblArray4[4];
     typedef double DblArray5[5];
+    typedef double DblArray6[6];
 
     /**
      * @struct Footstep
@@ -146,6 +147,15 @@ module OpenHRP
     enum StrideLimitationType {
       SQUARE,
       CIRCLE
+    };
+
+    /**
+     * @enum IKType
+     * @brief Type of calculation to determine the joint parameters
+     */
+    enum IKType {
+      MODE_IK,
+      MODE_RMC
     };
 
     /**
@@ -327,6 +337,8 @@ module OpenHRP
       DblArray2 limb_stretch_avoidance_vlimit;
       /// Sequence of limb length margin from max limb length [m]
       sequence<double> limb_length_margin;
+      /// IK type
+      IKType default_ik_type;
     };
 
     /**
@@ -464,5 +476,8 @@ module OpenHRP
      * @return true if set successfully, false otherwise
      */
     boolean releaseEmergencyStop();
+    boolean setRMCSelectionMatrix(in DblArray6 Svec);
+    boolean addRMCConstraintLink(in StrSequence link_names);
+    boolean removeRMCConstraintLink(in StrSequence link_names);
   };
 };

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -207,6 +207,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
           root = root->parent;
         }
         fik->ikp.insert(std::pair<std::string, SimpleFullbodyInverseKinematicsSolver::IKparam>(ee_name, tmp_fikp));
+        fik->addRMCConstraintLink(ee_target);
         // Fix for toe joint
         //   Toe joint is defined as end-link joint in the case that end-effector link != force-sensor link
         //   Without toe joints, "end-effector link == force-sensor link" is assumed.
@@ -351,6 +352,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
     sbp_cog_offset = hrp::Vector3(0,0,0);
     //use_force = MODE_NO_FORCE;
     use_force = MODE_REF_FORCE;
+    ik_type = MODE_IK;
 
     if (ikp.find("rleg") != ikp.end() && ikp.find("lleg") != ikp.end()) {
       is_legged_robot = true;
@@ -1080,8 +1082,12 @@ void AutoBalancer::solveFullbodyIK ()
   hrp::Vector3 tmp_input_sbp = hrp::Vector3(0,0,0);
   static_balance_point_proc_one(tmp_input_sbp, ref_zmp(2));
   hrp::Vector3 dif_cog = tmp_input_sbp - ref_cog;
-  // Solve IK
-  fik->solveFullbodyIK (dif_cog, transition_interpolator->isEmpty());
+
+  if (ik_type == MODE_IK) {
+      fik->solveFullbodyIK (dif_cog, transition_interpolator->isEmpty());
+  } else {
+      fik->solveRMC (dif_cog, transition_interpolator->isEmpty());
+  }
 }
 
 
@@ -1316,6 +1322,36 @@ bool AutoBalancer::releaseEmergencyStop ()
       is_stop_mode = false;
   }
   return true;
+}
+
+bool AutoBalancer::setRMCSelectionMatrix(const OpenHRP::AutoBalancerService::DblArray6 Svec)
+{
+  hrp::dvector6 tmp_svec;
+  for (size_t i = 0; i < 6; ++i) {
+   tmp_svec(i) = Svec[i];
+  }
+  setRMCSelectionMatrix(tmp_svec);
+}
+
+bool AutoBalancer::setRMCSelectionMatrix(const hrp::dvector6& Svec)
+{
+  fik->setRMCSelectionMatrix(Svec);
+}
+
+bool AutoBalancer::addRMCConstraintLink(const ::OpenHRP::AutoBalancerService::StrSequence& link_names)
+{
+  for (size_t i = 0; i < link_names.length(); i++) {
+    std::string name(link_names[i]);
+    fik->addRMCConstraintLink(name);
+  }
+}
+
+bool AutoBalancer::removeRMCConstraintLink(const ::OpenHRP::AutoBalancerService::StrSequence& link_names)
+{
+  for (size_t i = 0; i < link_names.length(); i++) {
+    std::string name(link_names[i]);
+    fik->removeRMCConstraintLink(name);
+  }
 }
 
 bool AutoBalancer::setFootSteps(const OpenHRP::AutoBalancerService::FootstepsSequence& fss, CORBA::Long overwrite_fs_idx)
@@ -1656,8 +1692,19 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
     default:
         break;
     }
+    switch (i_param.default_ik_type) {
+    case OpenHRP::AutoBalancerService::MODE_IK:
+        ik_type = MODE_IK;
+        break;
+    case OpenHRP::AutoBalancerService::MODE_RMC:
+        ik_type = MODE_RMC;
+        break;
+    defalut:
+        break;
+    }
   } else {
       std::cerr << "[" << m_profile.instance_name << "]   use_force_mode cannot be changed to [" << i_param.use_force_mode << "] during MODE_ABC, MODE_SYNC_TO_IDLE or MODE_SYNC_TO_ABC." << std::endl;
+      std::cerr << "[" << m_profile.instance_name << "]   ik_type cannot be changed to [" << i_param.default_ik_type << "] during MODE_ABC, MODE_SYNC_TO_IDLE or MODE_SYNC_TO_ABC." << std::endl;
   }
   graspless_manip_mode = i_param.graspless_manip_mode;
   graspless_manip_arm = std::string(i_param.graspless_manip_arm);
@@ -1731,6 +1778,7 @@ bool AutoBalancer::setAutoBalancerParam(const OpenHRP::AutoBalancerService::Auto
   std::cerr << std::endl;
   delete[] default_zmp_offsets_array;
   std::cerr << "[" << m_profile.instance_name << "]   use_force_mode = " << getUseForceModeString() << std::endl;
+  std::cerr << "[" << m_profile.instance_name << "]   ik_type = " << getIKTypeString() << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_mode = " << graspless_manip_mode << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_arm = " << graspless_manip_arm << std::endl;
   std::cerr << "[" << m_profile.instance_name << "]   graspless_manip_p_gain = " << graspless_manip_p_gain.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
@@ -1780,6 +1828,10 @@ bool AutoBalancer::getAutoBalancerParam(OpenHRP::AutoBalancerService::AutoBalanc
   case MODE_REF_FORCE_WITH_FOOT: i_param.use_force_mode = OpenHRP::AutoBalancerService::MODE_REF_FORCE_WITH_FOOT; break;
   case MODE_REF_FORCE_RFU_EXT_MOMENT: i_param.use_force_mode = OpenHRP::AutoBalancerService::MODE_REF_FORCE_RFU_EXT_MOMENT; break;
   default: break;
+  }
+  switch(ik_type) {
+  case MODE_IK: i_param.default_ik_type = OpenHRP::AutoBalancerService::MODE_IK; break;
+  case MODE_RMC: i_param.default_ik_type = OpenHRP::AutoBalancerService::MODE_RMC; break;
   }
   i_param.graspless_manip_mode = graspless_manip_mode;
   i_param.graspless_manip_arm = graspless_manip_arm.c_str();
@@ -2243,6 +2295,18 @@ std::string AutoBalancer::getUseForceModeString ()
         return "MODE_REF_FORCE_WITH_FOOT";
     case OpenHRP::AutoBalancerService::MODE_REF_FORCE_RFU_EXT_MOMENT:
         return "MODE_REF_FORCE_RFU_EXT_MOMENT";
+    default:
+        return "";
+    }
+};
+
+std::string AutoBalancer::getIKTypeString ()
+{
+    switch (ik_type) {
+    case OpenHRP::AutoBalancerService::MODE_IK:
+        return "MODE_IK";
+    case OpenHRP::AutoBalancerService::MODE_RMC:
+        return "MODE_RMC";
     default:
         return "";
     }

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -23,6 +23,7 @@
 #include "../ImpedanceController/JointPathEx.h"
 #include "../ImpedanceController/RatsMatrix.h"
 #include "GaitGenerator.h"
+#include "ResolvedMomentumControl.h"
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 #include "AutoBalancerService_impl.h"
@@ -119,7 +120,7 @@ class AutoBalancer
  protected:
   // Configuration variable declaration
   // <rtc-template block="config_declare">
-  
+
   // </rtc-template>
 
   // DataInPort declaration
@@ -146,7 +147,7 @@ class AutoBalancer
   InPort<TimedPoint3D> m_refFootOriginExtMomentIn;
   // for debug
   TimedPoint3D m_cog;
-  
+
   // </rtc-template>
 
   // DataOutPort declaration
@@ -177,7 +178,7 @@ class AutoBalancer
   std::vector<OutPort<TimedPoint3D> *> m_limbCOPOffsetOut;
   // for debug
   OutPort<TimedPoint3D> m_cogOut;
-  
+
   // </rtc-template>
 
   // CORBA Port declaration
@@ -194,7 +195,7 @@ class AutoBalancer
 
   // Consumer declaration
   // <rtc-template block="consumer_declare">
-  
+
   // </rtc-template>
 
  private:
@@ -243,6 +244,9 @@ class AutoBalancer
   typedef boost::shared_ptr<rats::gait_generator> ggPtr;
   ggPtr gg;
   bool gg_is_walking, gg_solved;
+  // for rmc
+  typedef boost::shared_ptr<rats::RMController> rmcPtr;
+  rmcPtr rmc;
   // for abc
   typedef boost::shared_ptr<SimpleFullbodyInverseKinematicsSolver> fikPtr;
   fikPtr fik;

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -116,6 +116,10 @@ class AutoBalancer
   bool getGoPosFootstepsSequence(const double& x, const double& y, const double& th, OpenHRP::AutoBalancerService::FootstepsSequence_out o_footstep);
   bool releaseEmergencyStop();
   void distributeReferenceZMPToWrenches (const hrp::Vector3& _ref_zmp);
+  bool setRMCSelectionMatrix(const OpenHRP::AutoBalancerService::DblArray6 Svec);
+  bool setRMCSelectionMatrix(const hrp::dvector6& Svec);
+  bool addRMCConstraintLink(const ::OpenHRP::AutoBalancerService::StrSequence& link_names);
+  bool removeRMCConstraintLink(const ::OpenHRP::AutoBalancerService::StrSequence& link_names);
 
  protected:
   // Configuration variable declaration
@@ -239,14 +243,12 @@ class AutoBalancer
   };
   bool calc_inital_support_legs(const double& y, std::vector<rats::coordinates>& initial_support_legs_coords, std::vector<rats::leg_type>& initial_support_legs, rats::coordinates& start_ref_coords);
   std::string getUseForceModeString ();
+  std::string getIKTypeString ();
 
   // for gg
   typedef boost::shared_ptr<rats::gait_generator> ggPtr;
   ggPtr gg;
   bool gg_is_walking, gg_solved;
-  // for rmc
-  typedef boost::shared_ptr<rats::RMController> rmcPtr;
-  rmcPtr rmc;
   // for abc
   typedef boost::shared_ptr<SimpleFullbodyInverseKinematicsSolver> fikPtr;
   fikPtr fik;
@@ -279,6 +281,7 @@ class AutoBalancer
   hrp::Vector3 sbp_offset, sbp_cog_offset;
   enum {MODE_NO_FORCE, MODE_REF_FORCE, MODE_REF_FORCE_WITH_FOOT, MODE_REF_FORCE_RFU_EXT_MOMENT} use_force;
   std::vector<hrp::Vector3> ref_forces;
+  enum {MODE_IK, MODE_RMC} ik_type;
 
   unsigned int m_debugLevel;
   bool is_legged_robot, is_stop_mode, is_hand_fix_mode, is_hand_fix_initial;

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -110,6 +110,21 @@ CORBA::Boolean AutoBalancerService_impl::releaseEmergencyStop()
     return m_autobalancer->releaseEmergencyStop();
 };
 
+CORBA::Boolean AutoBalancerService_impl::setRMCSelectionMatrix(const OpenHRP::AutoBalancerService::DblArray6 Svec)
+{
+    return m_autobalancer->setRMCSelectionMatrix(Svec);
+};
+
+CORBA::Boolean AutoBalancerService_impl::addRMCConstraintLink(const OpenHRP::AutoBalancerService::StrSequence& link_names)
+{
+    return m_autobalancer->addRMCConstraintLink(link_names);
+};
+
+CORBA::Boolean AutoBalancerService_impl::removeRMCConstraintLink(const OpenHRP::AutoBalancerService::StrSequence& link_names)
+{
+    return m_autobalancer->removeRMCConstraintLink(link_names);
+};
+
 void AutoBalancerService_impl::autobalancer(AutoBalancer *i_autobalancer)
 {
   m_autobalancer = i_autobalancer;

--- a/rtc/AutoBalancer/AutoBalancerService_impl.h
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.h
@@ -34,6 +34,9 @@ public:
   CORBA::Boolean getRemainingFootstepSequence(OpenHRP::AutoBalancerService::FootstepSequence_out o_footstep , CORBA::Long& o_current_fs_idx);
   CORBA::Boolean getGoPosFootstepsSequence(CORBA::Double x, CORBA::Double y, CORBA::Double th, OpenHRP::AutoBalancerService::FootstepsSequence_out o_footstep);
   CORBA::Boolean releaseEmergencyStop();
+  CORBA::Boolean setRMCSelectionMatrix(const OpenHRP::AutoBalancerService::DblArray6 Svec);
+  CORBA::Boolean addRMCConstraintLink(const OpenHRP::AutoBalancerService::StrSequence& link_names);
+  CORBA::Boolean removeRMCConstraintLink(const OpenHRP::AutoBalancerService::StrSequence& link_names);
   //
   //
   void autobalancer(AutoBalancer *i_autobalancer);

--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -13,7 +13,6 @@ set_target_properties(testGaitGenerator PROPERTIES COMPILE_DEFINITIONS "FOR_TEST
 
 add_executable(testResolvedMomentumControl testResolvedMomentumControl.cpp ResolvedMomentumControl.cpp)
 target_link_libraries(testResolvedMomentumControl ${libs})
-target_compile_definitions(testResolvedMomentumControl PRIVATE OPENHRP_DIR="${OPENHRP_DIR}")
 
 add_executable(AutoBalancerComp AutoBalancerComp.cpp ${comp_sources})
 target_link_libraries(AutoBalancerComp ${libs})

--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -1,4 +1,4 @@
-set(comp_sources AutoBalancer.cpp AutoBalancerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp ../SequencePlayer/interpolator.cpp PreviewController.cpp GaitGenerator.cpp SimpleFullbodyInverseKinematicsSolver.h ../TorqueFilter/IIRFilter.cpp)
+set(comp_sources AutoBalancer.cpp AutoBalancerService_impl.cpp ../ImpedanceController/JointPathEx.cpp ../ImpedanceController/RatsMatrix.cpp ../SequencePlayer/interpolator.cpp PreviewController.cpp GaitGenerator.cpp SimpleFullbodyInverseKinematicsSolver.h ../TorqueFilter/IIRFilter.cpp ResolvedMomentumControl.cpp)
 set(libs hrpModel-3.1 hrpCollision-3.1 hrpUtil-3.1 hrpsysBaseStub)
 add_library(AutoBalancer SHARED ${comp_sources})
 target_link_libraries(AutoBalancer ${libs})
@@ -11,14 +11,18 @@ add_executable(testGaitGenerator testGaitGenerator.cpp ../ImpedanceController/Ra
 target_link_libraries(testGaitGenerator ${libs})
 set_target_properties(testGaitGenerator PROPERTIES COMPILE_DEFINITIONS "FOR_TESTGAITGENERATOR=1")
 
+add_executable(testResolvedMomentumControl testResolvedMomentumControl.cpp ResolvedMomentumControl.cpp)
+target_link_libraries(testResolvedMomentumControl ${libs})
+
 add_executable(AutoBalancerComp AutoBalancerComp.cpp ${comp_sources})
 target_link_libraries(AutoBalancerComp ${libs})
 
 include_directories(${PROJECT_SOURCE_DIR}/rtc/SequencePlayer)
 
-set(target AutoBalancer AutoBalancerComp testPreviewController testGaitGenerator)
+set(target AutoBalancer AutoBalancerComp testPreviewController testGaitGenerator testResolvedMomentumControl)
 
 add_test(testPreviewControllerNoGP testPreviewController --use-gnuplot false)
+add_test(testResolvedMomentumControlNoGP testResolvedMomentumControl --use-gnuplot false)
 add_test(testGaitGeneratorTest0 testGaitGenerator --test0 --use-gnuplot false)
 add_test(testGaitGeneratorTest1 testGaitGenerator --test1 --use-gnuplot false)
 add_test(testGaitGeneratorTest2 testGaitGenerator --test2 --use-gnuplot false)
@@ -43,4 +47,3 @@ install(TARGETS ${target}
   RUNTIME DESTINATION bin
   LIBRARY DESTINATION lib
 )
-

--- a/rtc/AutoBalancer/CMakeLists.txt
+++ b/rtc/AutoBalancer/CMakeLists.txt
@@ -13,6 +13,7 @@ set_target_properties(testGaitGenerator PROPERTIES COMPILE_DEFINITIONS "FOR_TEST
 
 add_executable(testResolvedMomentumControl testResolvedMomentumControl.cpp ResolvedMomentumControl.cpp)
 target_link_libraries(testResolvedMomentumControl ${libs})
+target_compile_definitions(testResolvedMomentumControl PRIVATE OPENHRP_DIR="${OPENHRP_DIR}")
 
 add_executable(AutoBalancerComp AutoBalancerComp.cpp ${comp_sources})
 target_link_libraries(AutoBalancerComp ${libs})

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -17,12 +17,6 @@ namespace rats
         std::cerr << "[RMC] Updated selection matrix by " << Svec.transpose() << std::endl;
     }
 
-    hrp::dvector6 RMController::getSelectionVector()
-    {
-        hrp::dvector ones = hrp::dvector::Ones(s_.rows());
-        return ones.transpose() * s_;
-    }
-
     bool RMController::addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
     {
         if (constraints_.count(name) == 1) {
@@ -199,7 +193,6 @@ namespace rats
 
         // Step4
         hrp::dvector dq_free(free_dof);
-        // dq_free.resize(free_dof);
         for (size_t i = 0; i < free_dof; ++i) {
             dq_free(i) = m_robot->joint(free_id_[i])->dq; // reference
         }
@@ -210,10 +203,6 @@ namespace rats
             root_v = (ref_basePos - m_robot->rootLink()->p) / dt;
             hrp::Matrix33 dR = m_robot->rootLink()->R.transpose() * ref_baseRot;
             root_omega = hrp::omegaFromRot(dR) / dt;
-            // hrp::dmatrix dRRT = dR / dt * m_robot->rootLink()->R.transpose();
-            // root_omega(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
-            // root_omega(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
-            // root_omega(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
             xi_b << root_v, root_omega; // reference
         }
 

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -1,0 +1,213 @@
+/* -*- coding:utf-8-unix; mode:c++; -*- */
+#include "ResolvedMomentumControl.h"
+
+namespace rats
+{
+    void RMController::setSelectionMatrix(const hrp::dvector6 SVec)
+    {
+        const size_t num_selects = (SVec.array() != 0).count();
+        s_.resize(num_selects, 6);
+        for (size_t i = 0; i < num_selects; ++i) {
+            if (SVec(i) != 0) s_.row(i) = SVec(i) * hrp::dmatrix::Identity(6,6).row(i);
+        }
+    }
+
+    // void RMController::addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &limb)
+    // {
+    //     if (constraints_.count(limb) == 1) {
+    //         std::cerr << limb << "has already been added to constraints_" << std::endl;
+    //         return;
+    //     }
+    //     RTC::Properties& prop =  getProperties();
+    //     size_t prop_num = 10;
+    //     coil::vstring end_effectors_str = coil::split(prop["end_effectors"], ",");
+    //     if (end_effectors_str.size() > 0) {
+    //         size_t num = end_effectors_str.size() / prop_num;
+    //         for (size_t i = 0; i < num; i++) {
+    //             std::string ee_name, ee_target, ee_base;
+    //             coil::stringTo(ee_name, end_effectors_str[i*prop_num].c_str());
+    //             if (ee_name == limb) {
+    //                 ConstraintValue cs;
+    //                 coil::stringTo(ee_target, end_effectors_str[i*prop_num+1].c_str());
+    //                 coil::stringTo(ee_base, end_effectors_str[i*prop_num+2].c_str());
+    //                 hrp::JointPathPtr jpp = hrp::JointPathPtr(new hrp::JointPath(m_robot->link(ee_base), m_robot->link(ee_target)));
+    //                 cs.joint_path = jpp;
+    //                 cs.num_joints = jpp->numJoints();
+    //                 size_t last_id = jpp->endLink()->index - 1;
+    //                 cs.first_id = last_id - (cs.num_joints - 1);
+    //                 constraints_.insert(map<std::string, ConstraintValue>::value_type(ee_name, cs));
+    //                 // free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
+    //                 //                               [] (size_t id) (return (cs.first_id <= id && id <= last_id))), // lambda eq
+    //                 // free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
+    //                 //                               (cs.first_id <= _1 && _1 <= last_id)),
+    //                 //                vec.end());
+    //                 return;
+    //             }
+    //         }
+    //         std::cerr << "Robot doesn't have " << limb << std::endl;
+    //     }
+    // }
+
+    // void RMController::addConstraintLimb(const hrp::BodyPtr m_robot, std::map<std::string, AutoBalancer::ABCIKparam> ikp, const std::string &limb)
+    // {
+    //     if (constraints_.count(limb) == 1) {
+    //         std::cerr << limb << "has already been added to constraints_" << std::endl;
+    //         return;
+    //     }
+
+    //     if (ikp.find(limb)) {
+    //         ConstraintValue cs;
+    //         // hrp::JointPathPtr jpp = hrp::JointPathPtr(new hrp::JointPath(m_robot->link(ee_base), m_robot->link(ee_target)));
+    //         hrp::JointPathExPtr jpp = ikp[limb].manip;
+    //         cs.joint_path = jpp;
+    //         cs.num_joints = jpp->numJoints();
+    //         size_t last_id = jpp->endLink()->index - 1;
+    //         cs.first_id = last_id - (cs.num_joints - 1);
+    //         constraints_.insert(map<std::string, ConstraintValue>::value_type(limb, cs));
+    //         // free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
+    //         //                               [] (size_t id) (return (cs.first_id <= id && id <= last_id))), // lambda eq
+    //         free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
+    //                                       (cs.first_id <= boost::lambda::_1 && boost::lambda::_1 <= last_id)),
+    //                        free_id_.end());
+    //         return;
+    //     }
+    //     std::cerr << "Robot doesn't have " << limb << std::endl;
+    // }
+
+    void RMController::addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
+    {
+        if (constraints_.count(name) == 1) {
+            std::cerr << name << " has already been added to constraints_" << std::endl;
+            return;
+        }
+
+        hrp::Link* link = m_robot->link(name);
+        if (!link) {
+            std::cerr << "Robot doesn't have " << name << std::endl;
+            return;
+        }
+
+        hrp::Link* root = link;
+        while (!root->isRoot()) root = root->parent;
+        ConstraintValue cs;
+        hrp::JointPathPtr jpp = hrp::JointPathPtr(new hrp::JointPath(root, link));
+        cs.joint_path = jpp;
+        cs.num_joints = jpp->numJoints();
+        size_t last_id = jpp->endLink()->index - 1;
+        cs.first_id = last_id - (cs.num_joints - 1);
+        constraints_.insert(std::map<std::string, ConstraintValue>::value_type(name, cs));
+        free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
+                                      (cs.first_id <= boost::lambda::_1 && boost::lambda::_1 <= last_id)),
+                       free_id_.end());
+        std::cerr << "Succeeded to add " << name << " to constraints_" << std::endl;
+    }
+
+    void RMController::removeConstraintLimb(const std::string &limb)
+    {
+
+    }
+
+    void RMController::calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl)
+    {
+        std::map<std::string, ConstraintValue>::iterator it = constraints_.begin();
+        while (it != constraints_.end()) {
+            (*it).second.jacobian_inv = ((*it).second.joint_path->Jacobian()).inverse(); // 6自由度以上のときにどうするか
+            (*it).second.inertia_mat = Jpl.block(0, (*it).second.first_id, 6, (*it).second.num_joints) * (*it).second.jacobian_inv;
+            // ワールドで見ていないんじゃないか
+            (*it).second.r << hrp::Matrix33::Identity(), -hrp::hat(root_p - (*it).second.joint_path->endLink()->p),
+                hrp::Matrix33::Zero(), hrp::Matrix33::Identity();
+            ++it;
+        }
+    }
+
+    void RMController::rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
+                                 const hrp::dvector6 vref, hrp::Vector3 &ref_basePos, hrp::Matrix33 &ref_baseRot,
+                                 const double dt)
+
+    {
+        // Step2, Step3
+        hrp::dmatrix Jp;
+        hrp::dmatrix Jl;
+        m_robot->calcCMJacobian(NULL, Jp); // Eq.1 upper [M/m E r]
+        m_robot->calcAngularMomentumJacobian(NULL, Jl); // Eq.1 lower [H 0 I]
+        Jp *= m_robot->totalMass();
+        hrp::dmatrix Jpl(Jp.rows() + Jl.rows(), Jp.cols());
+        Jpl << Jp, Jl;
+        hrp::dvector refmom(6);
+        refmom << Pref, Lref;
+
+        calcConstraintMatrix(m_robot->rootLink()->p, Jpl);
+        hrp::dmatrix MHb = Jpl.block(0, m_robot->numJoints(), 6, 6);
+        std::map<std::string, ConstraintValue>::iterator it = constraints_.begin();
+        while (it != constraints_.end()) {
+            MHb -= (*it).second.inertia_mat * (*it).second.r;
+            // refmom -= (*it).second.inertia_mat * (*it).second.xi_ref;
+            refmom -= (*it).second.inertia_mat * vref;
+            ++it;
+        }
+
+        size_t free_dof = free_id_.size();
+        hrp::dmatrix MHfree(6, free_dof);
+        for (size_t i = 0; i < free_dof; ++i) {
+            MHfree.col(i) = Jpl.col(free_id_[i]);
+        }
+        hrp::dmatrix MHbf(6, 6 + free_dof);
+        MHbf << MHb, MHfree;
+
+        hrp::dmatrix A;
+        hrp::dvector y;
+        A = s_ * MHbf;
+        y = s_ * refmom;
+
+        // Step4
+        hrp::dvector dq_free;
+        dq_free.resize(free_dof);
+        for(size_t i = 0; i < free_dof; ++i) {
+            dq_free(i) = m_robot->joint(free_id_[i])->dq; // reference
+        }
+
+        hrp::dvector xi_b(6);
+        xi_b << m_robot->rootLink()->v, m_robot->rootLink()->w; // reference
+
+        hrp::dvector val_vec(6 + free_dof);
+        val_vec << xi_b, dq_free;
+
+        hrp::dmatrix Ainv;
+        hrp::calcPseudoInverse(A, Ainv);
+        val_vec = Ainv * y + (hrp::dmatrix::Identity(6 + free_dof, 6 + free_dof) - Ainv * A) * val_vec;
+
+        xi_b = val_vec.segment(0, 6);
+        dq_free = val_vec.segment(6, free_dof);
+
+        // Step5
+        it = constraints_.begin();
+        while (it != constraints_.end()) {
+            // (*it).second.dq = (*it).second.jacobian_inv * ((*it).second.xi_ref - (*it).second.r * xi_b);
+            (*it).second.dq = (*it).second.jacobian_inv * (vref - (*it).second.r * xi_b);
+            ++it;
+        }
+
+        // Step6
+        hrp::dvector dq(m_robot->numJoints());
+        // free
+        for (size_t i = 0; i < free_dof; ++i) {
+            dq(free_id_[i]) = dq_free(i);
+        }
+
+        // constraints
+        it = constraints_.begin();
+        while (it != constraints_.end()) {
+            dq.segment((*it).second.first_id, (*it).second.num_joints) = (*it).second.dq;
+            ++it;
+        }
+
+        ref_basePos = m_robot->rootLink()->p + xi_b.segment(0, 3) * dt;
+        hrp::Vector3 omega = xi_b.segment(3, 3);
+        if (omega.norm() != 0) ref_baseRot = m_robot->rootLink()->R * hrp::rodrigues(omega.normalized(), omega.norm() * dt);
+
+        for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+            m_robot->joint(i)->q += dq(i) * dt;
+        }
+        std::cerr << "dq: " << dq.transpose() << std::endl; // debug
+    }
+}

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -136,8 +136,8 @@ namespace rats
     }
 
     void RMController::rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                                 const std::map<std::string, hrp::dvector6> xi_ref, const hrp::Vector3 ref_basePos,
-                                 const hrp::Matrix33 ref_baseRot, const double dt)
+                                 const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 ref_basePos,
+                                 const hrp::Matrix33 &ref_baseRot, const double dt)
 
     {
         const double EPS = 1e-6;
@@ -200,9 +200,9 @@ namespace rats
         hrp::dvector xi_b(6);
         {
             hrp::Vector3 root_v, root_omega;
-            root_v = (ref_basePos - m_robot->rootLink()->p) / dt;
+            root_v = (ref_basePos - m_robot->rootLink()->p);
             hrp::Matrix33 dR = m_robot->rootLink()->R.transpose() * ref_baseRot;
-            root_omega = hrp::omegaFromRot(dR) / dt;
+            root_omega = hrp::omegaFromRot(dR);
             xi_b << root_v, root_omega; // reference
         }
 
@@ -250,12 +250,12 @@ namespace rats
             }
         }
 
-        m_robot->rootLink()->p += xi_b.segment(0, 3) * dt;
+        m_robot->rootLink()->p += xi_b.segment(0, 3);
         hrp::Vector3 omega = xi_b.segment(3, 3);
-        if (omega.norm() > EPS) m_robot->rootLink()->R *= hrp::rodrigues(omega.normalized(), omega.norm() * dt);
+        if (omega.norm() > EPS) m_robot->rootLink()->R *= hrp::rodrigues(omega.normalized(), omega.norm());
 
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-            m_robot->joint(i)->q += dq(i) * dt;
+            m_robot->joint(i)->q += dq(i);
         }
         m_robot->calcForwardKinematics();
     }

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -137,7 +137,7 @@ namespace rats
 
     void RMController::rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 &Pref, const hrp::Vector3 &Lref,
                                  const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 &ref_basePos,
-                                 const hrp::Matrix33 &ref_baseRot, const double dt)
+                                 const hrp::Matrix33 &ref_baseRot, const hrp::dvector &dq_ref, const double dt)
 
     {
         const double EPS = 1e-6;
@@ -166,7 +166,7 @@ namespace rats
             // set reference velocity of constraint joints
             for (size_t i = 0, j = 0; i < (*it).second.num_joints; ++i) {
                 if ((*it).second.joint_id[i].second == unique) {
-                    (*it).second.dq(j++) = m_robot->joint((*it).second.joint_id[i].first)->dq * dt;
+                    (*it).second.dq(j++) = dq_ref((*it).second.joint_id[i].first);
                 }
             }
 
@@ -194,7 +194,7 @@ namespace rats
         // Step4
         hrp::dvector dq_free(free_dof);
         for (size_t i = 0; i < free_dof; ++i) {
-            dq_free(i) = 0;
+            dq_free(i) = dq_ref(free_id_[i]); // reference joint velocity
         }
 
         hrp::dvector xi_b(6);

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -3,13 +3,14 @@
 
 namespace rats
 {
-    void RMController::setSelectionMatrix(const hrp::dvector6 SVec)
+    void RMController::setSelectionMatrix(const hrp::dvector6 Svec)
     {
-        const size_t num_selects = (SVec.array() != 0).count();
+        const size_t num_selects = (Svec.array() != 0).count();
         s_.resize(num_selects, 6);
         for (size_t i = 0; i < num_selects; ++i) {
-            if (SVec(i) != 0) s_.row(i) = SVec(i) * hrp::dmatrix::Identity(6,6).row(i);
+            if (Svec(i) != 0) s_.row(i) = Svec(i) * hrp::dmatrix::Identity(6,6).row(i);
         }
+        std::cerr << "[RMC] Updated selection matrix" << std::endl;
     }
 
     // void RMController::addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &limb)
@@ -74,17 +75,17 @@ namespace rats
     //     std::cerr << "Robot doesn't have " << limb << std::endl;
     // }
 
-    void RMController::addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
+    bool RMController::addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
     {
         if (constraints_.count(name) == 1) {
-            std::cerr << name << " has already been added to constraints_" << std::endl;
-            return;
+            std::cerr << "[RMC] " << name << " has already been added to constraints_" << std::endl;
+            return false;
         }
 
         hrp::Link* link = m_robot->link(name);
         if (!link) {
-            std::cerr << "Robot doesn't have " << name << std::endl;
-            return;
+            std::cerr << "[RMC] Robot doesn't have " << name << std::endl;
+            return false;
         }
 
         hrp::Link* root = link;
@@ -95,36 +96,67 @@ namespace rats
         cs.num_joints = jpp->numJoints();
         size_t last_id = jpp->endLink()->index - 1;
         cs.first_id = last_id - (cs.num_joints - 1);
+        cs.r.resize(6, 6);
+
         constraints_.insert(std::map<std::string, ConstraintValue>::value_type(name, cs));
         free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
                                       (cs.first_id <= boost::lambda::_1 && boost::lambda::_1 <= last_id)),
                        free_id_.end());
-        std::cerr << "Succeeded to add " << name << " to constraints_" << std::endl;
+        std::cerr << "[RMC] Succeeded to add " << name << " to constraints_" << std::endl;
+        return true;
     }
 
-    void RMController::removeConstraintLimb(const std::string &limb)
-    {
+    // bool RMController::removeConstraintLimb(const std::string &name)
+    // {
 
+    // }
+
+    bool RMController::removeConstraintLink(const std::string &name)
+    {
+        if (constraints_.count(name) == 0) {
+            std::cerr << "[RMC] " << name << " hasn't been added to constraints_" << std::endl;
+            return false;
+        }
+
+        std::vector<size_t> id;
+        for (size_t i = constraints_[name].first_id, j = 0; j < constraints_[name].num_joints; ++i, ++j) {
+            id.push_back(i);
+        }
+
+        std::vector<size_t>::iterator it = free_id_.begin();
+        while (*it < *(id.begin())) ++it;
+        free_id_.insert(it, id.begin(), id.end());
+
+        constraints_.erase(name);
+        std::cerr << "[RMC] Succeeded to remove " << name << " from constraints_" << std::endl;
+        return true;
+    }
+
+    bool RMController::removeConstraintLink(const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref)
+    {
+        if (removeConstraintLink(name)) {
+            xi_ref.erase(name);
+            return true;
+        }
+        return false;
     }
 
     void RMController::calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl)
     {
-        std::map<std::string, ConstraintValue>::iterator it = constraints_.begin();
-        while (it != constraints_.end()) {
+        for (std::map<std::string, ConstraintValue>::iterator it = constraints_.begin(); it != constraints_.end(); ++it) {
             (*it).second.jacobian_inv = ((*it).second.joint_path->Jacobian()).inverse(); // 6自由度以上のときにどうするか
             (*it).second.inertia_mat = Jpl.block(0, (*it).second.first_id, 6, (*it).second.num_joints) * (*it).second.jacobian_inv;
-            // ワールドで見ていないんじゃないか
             (*it).second.r << hrp::Matrix33::Identity(), -hrp::hat(root_p - (*it).second.joint_path->endLink()->p),
-                hrp::Matrix33::Zero(), hrp::Matrix33::Identity();
-            ++it;
+                              hrp::Matrix33::Zero(), hrp::Matrix33::Identity();
         }
     }
 
     void RMController::rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                                 const hrp::dvector6 vref, hrp::Vector3 &ref_basePos, hrp::Matrix33 &ref_baseRot,
-                                 const double dt)
+                                 const std::map<std::string, hrp::dvector6> xi_ref, hrp::Vector3 &ref_basePos,
+                                 hrp::Matrix33 &ref_baseRot, const double dt)
 
     {
+        const double EPS = 1e-6;
         // Step2, Step3
         hrp::dmatrix Jp;
         hrp::dmatrix Jl;
@@ -133,16 +165,15 @@ namespace rats
         Jp *= m_robot->totalMass();
         hrp::dmatrix Jpl(Jp.rows() + Jl.rows(), Jp.cols());
         Jpl << Jp, Jl;
-        hrp::dvector refmom(6);
+        hrp::dvector6 refmom;
         refmom << Pref, Lref;
 
         calcConstraintMatrix(m_robot->rootLink()->p, Jpl);
         hrp::dmatrix MHb = Jpl.block(0, m_robot->numJoints(), 6, 6);
-        std::map<std::string, ConstraintValue>::iterator it = constraints_.begin();
-        while (it != constraints_.end()) {
+        std::map<std::string, ConstraintValue>::iterator it;
+        for (it = constraints_.begin(); it != constraints_.end(); ++it) {
             MHb -= (*it).second.inertia_mat * (*it).second.r;
-            // refmom -= (*it).second.inertia_mat * (*it).second.xi_ref;
-            refmom -= (*it).second.inertia_mat * vref;
+            refmom -= (*it).second.inertia_mat * xi_ref.at((*it).first);
             ++it;
         }
 
@@ -166,8 +197,17 @@ namespace rats
             dq_free(i) = m_robot->joint(free_id_[i])->dq; // reference
         }
 
-        hrp::dvector xi_b(6);
-        xi_b << m_robot->rootLink()->v, m_robot->rootLink()->w; // reference
+        hrp::dvector xi_b(6); // updated
+        {
+            hrp::Vector3 root_v, root_w;
+            root_v = (ref_basePos - m_robot->rootLink()->p) / dt;
+            hrp::dmatrix dRRT = ((ref_baseRot - m_robot->rootLink()->R) / dt) * (m_robot->rootLink()->R).transpose();
+            root_w(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
+            root_w(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
+            root_w(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
+
+            xi_b << root_v, root_w; // reference
+        }
 
         hrp::dvector val_vec(6 + free_dof);
         val_vec << xi_b, dq_free;
@@ -179,13 +219,18 @@ namespace rats
         xi_b = val_vec.segment(0, 6);
         dq_free = val_vec.segment(6, free_dof);
 
-        // Step5
         it = constraints_.begin();
-        while (it != constraints_.end()) {
-            // (*it).second.dq = (*it).second.jacobian_inv * ((*it).second.xi_ref - (*it).second.r * xi_b);
-            (*it).second.dq = (*it).second.jacobian_inv * (vref - (*it).second.r * xi_b);
-            ++it;
+        // std::cerr << "xi_b: " << xi_b.transpose() << std::endl;
+        // std::cerr << "eq.(6) right: " << (MHbf * val_vec + (*it).second.inertia_mat * xi_ref.at((*it).first) + (*(++it)).second.inertia_mat * xi_ref.at((*it).first)).transpose() << std::endl;
+
+        // Step5
+        for (it = constraints_.begin(); it != constraints_.end(); ++it) {
+            (*it).second.dq = (*it).second.jacobian_inv * (xi_ref.at((*it).first) - (*it).second.r * xi_b);
         }
+
+        it = constraints_.begin();
+        std::cerr << "ee speed(eq.3): " << ((*it).second.jacobian_inv * (*it).second.dq + (*it).second.r * xi_b).transpose() << std::endl;
+        // std::cerr << "eq.13 right: " << (xi_ref.at((*it).first) - (*it).second.r * xi_b).transpose() << std::endl;
 
         // Step6
         hrp::dvector dq(m_robot->numJoints());
@@ -195,19 +240,17 @@ namespace rats
         }
 
         // constraints
-        it = constraints_.begin();
-        while (it != constraints_.end()) {
+        for (it = constraints_.begin(); it != constraints_.end(); ++it) {
             dq.segment((*it).second.first_id, (*it).second.num_joints) = (*it).second.dq;
-            ++it;
         }
 
         ref_basePos = m_robot->rootLink()->p + xi_b.segment(0, 3) * dt;
+        ref_baseRot = m_robot->rootLink()->R;
         hrp::Vector3 omega = xi_b.segment(3, 3);
-        if (omega.norm() != 0) ref_baseRot = m_robot->rootLink()->R * hrp::rodrigues(omega.normalized(), omega.norm() * dt);
+        if (omega.norm() > EPS) ref_baseRot *= hrp::rodrigues(omega.normalized(), omega.norm() * dt);
 
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
             m_robot->joint(i)->q += dq(i) * dt;
         }
-        std::cerr << "dq: " << dq.transpose() << std::endl; // debug
     }
 }

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -8,9 +8,15 @@ namespace rats
         const size_t num_selects = (Svec.array() != 0).count();
         s_.resize(num_selects, 6);
         for (size_t i = 0; i < num_selects; ++i) {
-            if (Svec(i) != 0) s_.row(i) = Svec(i) * hrp::dmatrix::Identity(6,6).row(i);
+            if (Svec(i) != 0) s_.row(i) = Svec(i) * hrp::dmatrix::Identity(6, 6).row(i);
         }
-        std::cerr << "[RMC] Updated selection matrix" << std::endl;
+        std::cerr << "[RMC] Updated selection matrix " << Svec.transpose() << std::endl;
+    }
+
+    hrp::dvector6 RMController::getSelectionVector()
+    {
+        hrp::dvector ones = hrp::dvector::Ones(s_.rows());
+        return ones.transpose() * s_;
     }
 
     bool RMController::addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
@@ -29,42 +35,77 @@ namespace rats
         ConstraintValue cs;
         cs.joint_path = hrp::JointPathPtr(new hrp::JointPath(m_robot->rootLink(), link));
         cs.num_joints = cs.joint_path->numJoints();
-        size_t last_id = cs.joint_path->endLink()->index - 1;
-        cs.first_id = last_id - (cs.num_joints - 1);
+        cs.num_shared = 0;
+
+        for (hrp::Link* added_limb = m_robot->link(name); !added_limb->isRoot(); added_limb = added_limb->parent) {
+            // Strage shared joint id
+            JointShared tmp_shared = unique;
+            bool is_shared = false;
+            for (std::map<std::string, ConstraintValue>::iterator it = constraints_.begin(); it != constraints_.end(); ++it) {
+                size_t i = 0;
+                while (i < (*it).second.num_joints && (*it).second.joint_id[i].first != added_limb->jointId) ++i;
+                if (i != (*it).second.num_joints) {
+                    if ((*it).second.joint_id[i].second == unique) ++(*it).second.num_shared;
+                    (*it).second.joint_id[i].second = tmp_shared = shared;
+                }
+                (*it).second.jacobian.resize(6, (*it).second.num_joints - (*it).second.num_shared);
+                (*it).second.jacobian_pinv.resize((*it).second.num_joints - (*it).second.num_shared, 6);
+                (*it).second.jacobian_shared.resize(6, (*it).second.num_shared);
+                (*it).second.jacobian_pinv_shared.resize((*it).second.num_shared, 6);
+                (*it).second.MH.resize(6, (*it).second.num_joints - (*it).second.num_shared);
+                (*it).second.dq.resize((*it).second.num_joints - (*it).second.num_shared);
+            }
+
+            cs.joint_id.push_back(std::make_pair(added_limb->jointId, tmp_shared));
+            free_id_.erase(std::remove(free_id_.begin(), free_id_.end(), added_limb->jointId), free_id_.end());
+            if (tmp_shared == shared) {
+                ++cs.num_shared;
+                free_id_.push_back(added_limb->jointId);
+            }
+            std::sort(free_id_.begin(), free_id_.end());
+        }
+
         cs.r.resize(6, 6);
+        cs.jacobian.resize(6, cs.num_joints - cs.num_shared);
+        cs.jacobian_pinv.resize(cs.num_joints - cs.num_shared, 6);
+        cs.jacobian_shared.resize(6, cs.num_shared);
+        cs.jacobian_pinv_shared.resize(cs.num_shared, 6);
+        std::sort(cs.joint_id.begin(), cs.joint_id.end());
+        cs.MH.resize(6, cs.num_joints - cs.num_shared);
+        cs.dq.resize(cs.num_joints - cs.num_shared);
 
         constraints_.insert(std::map<std::string, ConstraintValue>::value_type(name, cs));
-        free_id_.erase(std::remove_if(free_id_.begin(), free_id_.end(),
-                                      (cs.first_id <= boost::lambda::_1 && boost::lambda::_1 <= last_id)),
-                       free_id_.end());
         std::cerr << "[RMC] Succeeded to add " << name << " to constraints_" << std::endl;
         return true;
     }
 
-    bool RMController::removeConstraintLink(const std::string &name)
+    bool RMController::removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name)
     {
         if (constraints_.count(name) == 0) {
             std::cerr << "[RMC] " << name << " hasn't been added to constraints_" << std::endl;
             return false;
         }
 
-        std::vector<size_t> id;
-        for (size_t i = constraints_[name].first_id, j = 0; j < constraints_[name].num_joints; ++i, ++j) {
-            id.push_back(i);
+        std::vector<std::string> constraint_list;
+        for (std::map<std::string, ConstraintValue>::iterator it = constraints_.begin(); it != constraints_.end(); ++it) {
+            if ((*it).first != name) constraint_list.push_back((*it).first);
+        }
+        free_id_.clear();
+        constraints_.clear();
+        for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+            free_id_.push_back(i);
+        }
+        for (size_t i = 0; i < constraint_list.size(); ++i) {
+            addConstraintLink(m_robot, constraint_list[i]);
         }
 
-        std::vector<size_t>::iterator it = free_id_.begin();
-        while (*it < *(id.begin())) ++it;
-        free_id_.insert(it, id.begin(), id.end());
-
-        constraints_.erase(name);
         std::cerr << "[RMC] Succeeded to remove " << name << " from constraints_" << std::endl;
         return true;
     }
 
-    bool RMController::removeConstraintLink(const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref)
+    bool RMController::removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref)
     {
-        if (removeConstraintLink(name)) {
+        if (removeConstraintLink(m_robot, name)) {
             xi_ref.erase(name);
             return true;
         }
@@ -74,8 +115,23 @@ namespace rats
     void RMController::calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl)
     {
         for (std::map<std::string, ConstraintValue>::iterator it = constraints_.begin(); it != constraints_.end(); ++it) {
-            (*it).second.jacobian_inv = ((*it).second.joint_path->Jacobian()).inverse(); // 6自由度以上のときにどうするか
-            (*it).second.inertia_mat = Jpl.block(0, (*it).second.first_id, 6, (*it).second.num_joints) * (*it).second.jacobian_inv;
+            hrp::dmatrix jointpath_jacobian = (*it).second.joint_path->Jacobian();
+            hrp::dmatrix pinv;
+            hrp::calcPseudoInverse(jointpath_jacobian, pinv);
+            size_t u = 0, s = 0;
+            for (size_t i = 0; i < (*it).second.num_joints; ++i) {
+                if ((*it).second.joint_id[i].second == unique) {
+                    (*it).second.jacobian.col(u) = jointpath_jacobian.col(i);
+                    (*it).second.jacobian_pinv.row(u) = pinv.row(i);
+                    (*it).second.MH.col(u) = Jpl.col((*it).second.joint_id[i].first);
+                    ++u;
+                } else {
+                    (*it).second.jacobian_shared.col(s) = jointpath_jacobian.col(i);
+                    (*it).second.jacobian_pinv_shared.row(s) = pinv.row(i);
+                    ++s;
+                }
+            }
+            (*it).second.MHpinv = (*it).second.MH * (*it).second.jacobian_pinv;
             (*it).second.r << hrp::Matrix33::Identity(), -hrp::hat((*it).second.joint_path->endLink()->p - root_p),
                               hrp::Matrix33::Zero(), hrp::Matrix33::Identity();
         }
@@ -90,7 +146,8 @@ namespace rats
         // Step2, Step3
         hrp::dmatrix Jp;
         hrp::dmatrix Jl;
-        m_robot->calcCMJacobian(NULL, Jp); // Eq.1 upper [M/m E r]
+        m_robot->calcCM();
+        m_robot->calcCMJacobian(NULL, Jp); // Eq.1 upper [M/m E -r]
         m_robot->calcAngularMomentumJacobian(NULL, Jl); // Eq.1 lower [H 0 I]
         Jp *= m_robot->totalMass();
         hrp::dmatrix Jpl(Jp.rows() + Jl.rows(), Jp.cols());
@@ -99,20 +156,37 @@ namespace rats
         refmom << Pref, Lref;
 
         calcConstraintMatrix(m_robot->rootLink()->p, Jpl);
-        hrp::dmatrix MHb = Jpl.block(0, m_robot->numJoints(), 6, 6);
-        std::map<std::string, ConstraintValue>::iterator it;
-        for (it = constraints_.begin(); it != constraints_.end(); ++it) {
-            MHb -= (*it).second.inertia_mat * (*it).second.r;
-            refmom -= (*it).second.inertia_mat * xi_ref.at((*it).first);
-        }
-
+        hrp::dmatrix MHbody = Jpl.block(0, m_robot->numJoints(), 6, 6);
         size_t free_dof = free_id_.size();
         hrp::dmatrix MHfree(6, free_dof);
         for (size_t i = 0; i < free_dof; ++i) {
             MHfree.col(i) = Jpl.col(free_id_[i]);
         }
+
+        std::map<std::string, ConstraintValue>::iterator it;
+        for (it = constraints_.begin(); it != constraints_.end(); ++it) {
+            // set reference velocity of constraint joints
+            for (size_t i = 0, j = 0; i < (*it).second.num_joints; ++i) {
+                if ((*it).second.joint_id[i].second == unique) {
+                    (*it).second.dq(j++) = m_robot->joint((*it).second.joint_id[i].first)->dq; // reference
+                }
+            }
+
+            MHbody -= (*it).second.MHpinv * (*it).second.r;
+            refmom -= ((*it).second.MHpinv * xi_ref.at((*it).first) + ((*it).second.MH - (*it).second.MHpinv * (*it).second.jacobian) * (*it).second.dq);
+            hrp::dmatrix MHshared = (*it).second.MHpinv * (*it).second.jacobian_shared;
+
+            for (size_t i = 0, j = 0; i < (*it).second.num_joints; ++i) {
+                if ((*it).second.joint_id[j].second == shared) {
+                    size_t k = 0;
+                    while ((*it).second.joint_id[i].first != free_id_[k]) ++k;
+                    MHfree.col(k) -= MHshared.col(j++);
+                }
+            }
+        }
+
         hrp::dmatrix MHbf(6, 6 + free_dof);
-        MHbf << MHb, MHfree;
+        MHbf << MHbody, MHfree;
 
         hrp::dmatrix A;
         hrp::dvector y;
@@ -120,44 +194,53 @@ namespace rats
         y = s_ * refmom;
 
         // Step4
-        hrp::dvector dq_free;
-        dq_free.resize(free_dof);
-        for(size_t i = 0; i < free_dof; ++i) {
+        hrp::dvector dq_free(free_dof);
+        // dq_free.resize(free_dof);
+        for (size_t i = 0; i < free_dof; ++i) {
             dq_free(i) = m_robot->joint(free_id_[i])->dq; // reference
         }
 
-        hrp::dvector xi_b(6); // updated
+        hrp::dvector xi_b(6);
         {
-            hrp::Vector3 root_v, root_w;
+            hrp::Vector3 root_v, root_omega;
             root_v = (ref_basePos - m_robot->rootLink()->p) / dt;
-            hrp::dmatrix dRRT = ((ref_baseRot - m_robot->rootLink()->R) / dt) * (m_robot->rootLink()->R).transpose();
-            root_w(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
-            root_w(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
-            root_w(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
-
-            xi_b << root_v, root_w; // reference
+            hrp::Matrix33 dR = m_robot->rootLink()->R.transpose() * ref_baseRot;
+            root_omega = hrp::omegaFromRot(dR) / dt;
+            // hrp::dmatrix dRRT = dR / dt * m_robot->rootLink()->R.transpose();
+            // root_omega(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
+            // root_omega(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
+            // root_omega(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
+            xi_b << root_v, root_omega; // reference
         }
 
         hrp::dvector val_vec(6 + free_dof);
         val_vec << xi_b, dq_free;
 
-        hrp::dmatrix Ainv;
-        hrp::calcPseudoInverse(A, Ainv);
-        val_vec = Ainv * y + (hrp::dmatrix::Identity(6 + free_dof, 6 + free_dof) - Ainv * A) * val_vec;
+        hrp::dmatrix Apinv;
+        hrp::calcPseudoInverse(A, Apinv);
+        val_vec = Apinv * y + (hrp::dmatrix::Identity(6 + free_dof, 6 + free_dof) - Apinv * A) * val_vec;
 
         xi_b = val_vec.segment(0, 6);
         dq_free = val_vec.segment(6, free_dof);
 
-        // std::cerr << "xi_b: " << xi_b.transpose() << std::endl;
-        // std::cerr << "eq.(6) right: " << (MHbf * val_vec + (*it).second.inertia_mat * xi_ref.at((*it).first) + (*(++it)).second.inertia_mat * xi_ref.at((*it).first)).transpose() << std::endl;
-
         // Step5
         for (it = constraints_.begin(); it != constraints_.end(); ++it) {
-            (*it).second.dq = (*it).second.jacobian_inv * (xi_ref.at((*it).first) - (*it).second.r * xi_b);
-        }
+            size_t i = 0;
+            hrp::dvector dq_shared((*it).second.num_shared);
 
-        // std::cerr << "ee speed(eq.3): " << ((*it).second.jacobian_inv * (*it).second.dq + (*it).second.r * xi_b).transpose() << std::endl;
-        // std::cerr << "eq.13 right: " << (xi_ref.at((*it).first) - (*it).second.r * xi_b).transpose() << std::endl;
+            for (size_t j = 0; j < (*it).second.num_joints; ++j) {
+                if ((*it).second.joint_id[j].second == shared) {
+                    size_t k = 0;
+                    while ((*it).second.joint_id[j].first != free_id_[k]) ++k;
+                    dq_shared(i++) = dq_free(k);
+                }
+            }
+
+            if ((*it).second.num_shared == 0) (*it).second.dq = (*it).second.jacobian_pinv * (xi_ref.at((*it).first) - (*it).second.r * xi_b) +
+                                                  (hrp::dmatrix::Identity((*it).second.num_joints, (*it).second.num_joints) - (*it).second.jacobian_pinv * (*it).second.jacobian) * (*it).second.dq;
+            else (*it).second.dq = (*it).second.jacobian_pinv * (xi_ref.at((*it).first) - (*it).second.r * xi_b - (*it).second.jacobian_shared * dq_shared) +
+                     (hrp::dmatrix::Identity((*it).second.num_joints - (*it).second.num_shared, (*it).second.num_joints - (*it).second.num_shared) - (*it).second.jacobian_pinv * (*it).second.jacobian) * (*it).second.dq;
+        }
 
         // Step6
         hrp::dvector dq(m_robot->numJoints());
@@ -168,7 +251,10 @@ namespace rats
 
         // constraints
         for (it = constraints_.begin(); it != constraints_.end(); ++it) {
-            dq.segment((*it).second.first_id, (*it).second.num_joints) = (*it).second.dq;
+            size_t i = 0;
+            for (size_t j = 0; j < (*it).second.num_joints; ++j) {
+                if ((*it).second.joint_id[j].second == unique) dq((*it).second.joint_id[j].first) = (*it).second.dq[i++];
+            }
         }
 
         m_robot->rootLink()->p += xi_b.segment(0, 3) * dt;

--- a/rtc/AutoBalancer/ResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.cpp
@@ -6,11 +6,15 @@ namespace rats
     void RMController::setSelectionMatrix(const hrp::dvector6 Svec)
     {
         const size_t num_selects = (Svec.array() != 0).count();
-        s_.resize(num_selects, 6);
-        for (size_t i = 0; i < num_selects; ++i) {
-            if (Svec(i) != 0) s_.row(i) = Svec(i) * hrp::dmatrix::Identity(6, 6).row(i);
+        s_ = hrp::dmatrix::Zero(num_selects, 6);
+        size_t i = 0;
+        for (size_t j = 0; j < 6; ++j) {
+            if (Svec(j) != 0) {
+                s_(i, j) = Svec(j);
+                ++i;
+            }
         }
-        std::cerr << "[RMC] Updated selection matrix " << Svec.transpose() << std::endl;
+        std::cerr << "[RMC] Updated selection matrix by " << Svec.transpose() << std::endl;
     }
 
     hrp::dvector6 RMController::getSelectionVector()

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -1,4 +1,4 @@
-/* -*- coding:utf-8-unix mode:c++ -*- */
+/* -*- coding:utf-8-unix; mode:c++; -*- */
 #ifndef RMC_H_
 #define RMC_H_
 #include <iostream>

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -48,7 +48,7 @@ namespace rats
         std::vector<size_t> free_id_; // initialize to 0 ~ numjoints-1
     public:
         void setSelectionMatrix(const hrp::dvector6 Svec);
-        hrp::dvector6 getSelectionVector();
+        hrp::dvector6 getSelectionVector() { return hrp::dvector::Ones(s_.rows()).transpose() * s_; }
         bool addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
         bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
         bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -54,8 +54,8 @@ namespace rats
         bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
         void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
         void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                       const std::map<std::string, hrp::dvector6> xi_ref, const hrp::Vector3 ref_basePos,
-                       const hrp::Matrix33 ref_baseRot, const double dt);
+                       const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 ref_basePos,
+                       const hrp::Matrix33 &ref_baseRot, const double dt);
         RMController(const hrp::BodyPtr m_robot)
         {
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -14,15 +14,31 @@
 
 namespace rats
 {
+    enum JointShared {unique, shared};
     struct ConstraintValue {
         hrp::JointPathPtr joint_path;
-        size_t first_id;
         size_t num_joints;
-        hrp::dmatrix jacobian_inv;
-        hrp::dmatrix inertia_mat;
+        size_t num_shared;
+        std::vector<std::pair<size_t, JointShared> > joint_id;
+        hrp::dmatrix jacobian;
+        hrp::dmatrix jacobian_pinv;
+        hrp::dmatrix jacobian_shared;
+        hrp::dmatrix jacobian_pinv_shared;
+        hrp::dmatrix MH;
+        hrp::dmatrix MHpinv;
         hrp::dmatrix r;
         hrp::dvector dq;
+        // hrp::dvector dq_shared;
     };
+
+    template<class T>
+    void printVector(const std::vector<T> &v)
+    {
+        for (int i = 0; i < v.size(); ++i) {
+            std::cout << v[i] << " ";
+        }
+        std::cout << std::endl;
+    }
 
     class RMController
     {
@@ -32,9 +48,10 @@ namespace rats
         std::vector<size_t> free_id_; // initialize to 0 ~ numjoints-1
     public:
         void setSelectionMatrix(const hrp::dvector6 Svec);
+        hrp::dvector6 getSelectionVector();
         bool addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
-        bool removeConstraintLink(const std::string &name);
-        bool removeConstraintLink(const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
+        bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
+        bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
         void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
         void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
                        const std::map<std::string, hrp::dvector6> xi_ref, const hrp::Vector3 ref_basePos,

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -1,0 +1,63 @@
+/* -*- coding:utf-8-unix mode:c++ -*- */
+#ifndef RMC_H_
+#define RMC_H_
+#include <cmath>
+#include <iostream>
+#include <vector>
+#include <map>
+#include <algorithm>
+#include <boost/assign.hpp>
+#include <boost/lambda/lambda.hpp>
+#include <boost/shared_ptr.hpp>
+#include <hrpUtil/MatrixSolvers.h>
+#include "../ImpedanceController/JointPathEx.h"
+
+namespace rats
+{
+    struct ConstraintValue {
+        hrp::JointPathPtr joint_path;
+        size_t first_id;
+        size_t num_joints;
+        hrp::dvector6 xi_ref;
+        hrp::dmatrix jacobian_inv;
+        hrp::dmatrix inertia_mat;
+        // hrp::dmatrix r;
+        Eigen::Matrix<double, 6, 6> r;
+        hrp::dvector dq;
+    };
+
+    class RMController
+    {
+    private:
+        hrp::dmatrix s_;
+        std::map<std::string, ConstraintValue> constraints_;
+        std::vector<size_t> free_id_; // 0 ~ numjoints-1 で初期化
+    public:
+        RMController(const hrp::BodyPtr m_robot, const hrp::dvector6 SVec)//, const std::string &limb)
+        {
+            // initSelectionVector(m_robot);
+            // setSelectionMatrix(Svec);
+            // addConstraintLimb(limb);
+            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+                free_id_.push_back(i);
+            }
+            const int num_selects = (SVec.array() != 0).count();
+            s_.resize(num_selects, 6);
+            for (size_t i = 0; i < num_selects; ++i) {
+                if (SVec(i) != 0) s_.row(i) = SVec(i) * hrp::dmatrix::Identity(6,6).row(i);
+            }
+        };
+        ~RMController() {};
+        void setSelectionMatrix(const hrp::dvector6 SVec);
+        void addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &name);
+        void addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
+        void removeConstraintLimb(const std::string &limb);
+        void removeConstraintLink(const std::string &link);
+        void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
+        void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
+                       const hrp::dvector6 vref, hrp::Vector3 &ref_basePos, hrp::Matrix33 &ref_baseRot,
+                       const double dt);
+
+    };
+}
+#endif /*RMC_H_*/

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -28,17 +28,7 @@ namespace rats
         hrp::dmatrix MHpinv;
         hrp::dmatrix r;
         hrp::dvector dq;
-        // hrp::dvector dq_shared;
     };
-
-    template<class T>
-    void printVector(const std::vector<T> &v)
-    {
-        for (int i = 0; i < v.size(); ++i) {
-            std::cout << v[i] << " ";
-        }
-        std::cout << std::endl;
-    }
 
     class RMController
     {
@@ -47,14 +37,14 @@ namespace rats
         std::map<std::string, ConstraintValue> constraints_;
         std::vector<size_t> free_id_; // initialize to 0 ~ numjoints-1
     public:
-        void setSelectionMatrix(const hrp::dvector6 Svec);
+        void setSelectionMatrix(const hrp::dvector6 &Svec);
         hrp::dvector6 getSelectionVector() { return hrp::dvector::Ones(s_.rows()).transpose() * s_; }
         bool addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
         bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
         bool removeConstraintLink(const hrp::BodyPtr m_robot, const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
-        void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
-        void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                       const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 ref_basePos,
+        void calcConstraintMatrix(const hrp::Vector3 &root_p, const hrp::dmatrix &Jpl);
+        void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 &Pref, const hrp::Vector3 &Lref,
+                       const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 &ref_basePos,
                        const hrp::Matrix33 &ref_baseRot, const double dt);
         RMController(const hrp::BodyPtr m_robot)
         {
@@ -62,7 +52,7 @@ namespace rats
                 free_id_.push_back(i);
             }
         };
-        RMController(const hrp::BodyPtr m_robot, const hrp::dvector6 Svec)
+        RMController(const hrp::BodyPtr m_robot, const hrp::dvector6 &Svec)
         {
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
                 free_id_.push_back(i);

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -32,15 +32,13 @@ namespace rats
         std::vector<size_t> free_id_; // initialize to 0 ~ numjoints-1
     public:
         void setSelectionMatrix(const hrp::dvector6 Svec);
-        bool addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &name);
         bool addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
-        bool removeConstraintLimb(const std::string &name);
         bool removeConstraintLink(const std::string &name);
         bool removeConstraintLink(const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
         void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
         void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                       const std::map<std::string, hrp::dvector6> xi_ref, hrp::Vector3 &ref_basePos,
-                       hrp::Matrix33 &ref_baseRot, const double dt);
+                       const std::map<std::string, hrp::dvector6> xi_ref, const hrp::Vector3 ref_basePos,
+                       const hrp::Matrix33 ref_baseRot, const double dt);
         RMController(const hrp::BodyPtr m_robot)
         {
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -1,16 +1,16 @@
 /* -*- coding:utf-8-unix mode:c++ -*- */
 #ifndef RMC_H_
 #define RMC_H_
-#include <cmath>
 #include <iostream>
 #include <vector>
 #include <map>
 #include <algorithm>
-#include <boost/assign.hpp>
 #include <boost/lambda/lambda.hpp>
 #include <boost/shared_ptr.hpp>
 #include <hrpUtil/MatrixSolvers.h>
-#include "../ImpedanceController/JointPathEx.h"
+#include <hrpModel/Body.h>
+#include <hrpModel/Link.h>
+#include <hrpModel/JointPath.h>
 
 namespace rats
 {
@@ -18,11 +18,9 @@ namespace rats
         hrp::JointPathPtr joint_path;
         size_t first_id;
         size_t num_joints;
-        hrp::dvector6 xi_ref;
         hrp::dmatrix jacobian_inv;
         hrp::dmatrix inertia_mat;
-        // hrp::dmatrix r;
-        Eigen::Matrix<double, 6, 6> r;
+        hrp::dmatrix r;
         hrp::dvector dq;
     };
 
@@ -31,32 +29,32 @@ namespace rats
     private:
         hrp::dmatrix s_;
         std::map<std::string, ConstraintValue> constraints_;
-        std::vector<size_t> free_id_; // 0 ~ numjoints-1 で初期化
+        std::vector<size_t> free_id_; // initialize to 0 ~ numjoints-1
     public:
-        RMController(const hrp::BodyPtr m_robot, const hrp::dvector6 SVec)//, const std::string &limb)
+        void setSelectionMatrix(const hrp::dvector6 Svec);
+        bool addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &name);
+        bool addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
+        bool removeConstraintLimb(const std::string &name);
+        bool removeConstraintLink(const std::string &name);
+        bool removeConstraintLink(const std::string &name, std::map<std::string, hrp::dvector6> &xi_ref);
+        void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
+        void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
+                       const std::map<std::string, hrp::dvector6> xi_ref, hrp::Vector3 &ref_basePos,
+                       hrp::Matrix33 &ref_baseRot, const double dt);
+        RMController(const hrp::BodyPtr m_robot)
         {
-            // initSelectionVector(m_robot);
-            // setSelectionMatrix(Svec);
-            // addConstraintLimb(limb);
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
                 free_id_.push_back(i);
             }
-            const int num_selects = (SVec.array() != 0).count();
-            s_.resize(num_selects, 6);
-            for (size_t i = 0; i < num_selects; ++i) {
-                if (SVec(i) != 0) s_.row(i) = SVec(i) * hrp::dmatrix::Identity(6,6).row(i);
+        };
+        RMController(const hrp::BodyPtr m_robot, const hrp::dvector6 Svec)
+        {
+            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+                free_id_.push_back(i);
             }
+            setSelectionMatrix(Svec);
         };
         ~RMController() {};
-        void setSelectionMatrix(const hrp::dvector6 SVec);
-        void addConstraintLimb(const hrp::BodyPtr m_robot, const std::string &name);
-        void addConstraintLink(const hrp::BodyPtr m_robot, const std::string &name);
-        void removeConstraintLimb(const std::string &limb);
-        void removeConstraintLink(const std::string &link);
-        void calcConstraintMatrix(const hrp::Vector3 root_p, const hrp::dmatrix Jpl);
-        void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 Pref, const hrp::Vector3 Lref,
-                       const hrp::dvector6 vref, hrp::Vector3 &ref_basePos, hrp::Matrix33 &ref_baseRot,
-                       const double dt);
 
     };
 }

--- a/rtc/AutoBalancer/ResolvedMomentumControl.h
+++ b/rtc/AutoBalancer/ResolvedMomentumControl.h
@@ -45,7 +45,7 @@ namespace rats
         void calcConstraintMatrix(const hrp::Vector3 &root_p, const hrp::dmatrix &Jpl);
         void rmControl(hrp::BodyPtr &m_robot, const hrp::Vector3 &Pref, const hrp::Vector3 &Lref,
                        const std::map<std::string, hrp::dvector6> &xi_ref, const hrp::Vector3 &ref_basePos,
-                       const hrp::Matrix33 &ref_baseRot, const double dt);
+                       const hrp::Matrix33 &ref_baseRot, const hrp::dvector &dq_ref, const double dt);
         RMController(const hrp::BodyPtr m_robot)
         {
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -53,17 +53,19 @@ private:
     {
         fprintf(gp, "%s\n unset multiplot\n", plot_str.c_str());
         fprintf(gp, "set terminal postscript eps color\nset output '/tmp/%s.eps'\n", graph_fname.c_str());
-        fprintf(gp, "%s\n unset multiplot\n", plot_str.c_str());
         fflush(gp);
     }
 
     void executeAndPlot(const double max_tm, calcReferenceParameter* calcRef)
     {
         std::string fname("/tmp/plot.dat");
-        // FILE* fp = fopen(fname.c_str(), "w");
         std::ofstream fp(fname.c_str());
         hrp::Vector3 Pref, Lref, cur_basePos, ref_basePos, P, L, CM;
         hrp::Matrix33 cur_baseRot, ref_baseRot;
+        hrp::dvector cur_q(m_robot->numJoints());
+        std::map<std::string, hrp::Vector3> p_constraint;
+        std::map<std::string, hrp::Matrix33> R_constraint;
+        std::map<std::string, hrp::dvector6> xi;
 
         for (double tm = 0; tm < max_tm; tm += dt) {
             Pref = calcRef->calcPref(m_robot, tm, max_tm);
@@ -72,32 +74,24 @@ private:
             for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
                 (*it).second = calcRef->calcXiref(m_robot, (*it).first, tm, max_tm);
             }
-
-            hrp::dvector dq(m_robot->numJoints());
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-                dq(i) = -m_robot->joint(i)->q;
+                cur_q(i) = m_robot->joint(i)->q;
             }
-
+            for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+                p_constraint[(*it).first] = m_robot->link((*it).first)->p;
+                R_constraint[(*it).first] = m_robot->link((*it).first)->R;
+            }
             cur_basePos = m_robot->rootLink()->p;
             cur_baseRot = m_robot->rootLink()->R;
-
             ref_basePos = cur_basePos + Pref / m_robot->totalMass() * dt;
             ref_baseRot = cur_baseRot;
 
+            // execute RMC
             rmc->rmControl(m_robot, Pref, Lref, xi_ref, ref_basePos, ref_baseRot, dt);
 
             m_robot->rootLink()->v = (m_robot->rootLink()->p - cur_basePos) / dt;
             hrp::Matrix33 dR = cur_baseRot.transpose() * m_robot->rootLink()->R;
             m_robot->rootLink()->w = hrp::omegaFromRot(dR) / dt;
-
-            // std::cerr << (m_robot->rootLink()->v).transpose() << std::endl;
-            // std::cerr << (m_robot->rootLink()->w).transpose() << std::endl;
-
-            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-                dq(i) += m_robot->joint(i)->q;
-                dq(i) /= dt;
-                m_robot->joint(i)->dq = dq(i);
-            }
 
             hrp::dvector tmpPL(6);
             tmpPL << Pref, Lref;
@@ -108,24 +102,14 @@ private:
             CM = m_robot->calcCM();
             m_robot->calcTotalMomentumFromJacobian(P, L);
 
-            // fprintf(fp, "%f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
-            //         tm,
-            //         Pref(0),
-            //         P(0),
-            //         Pref(1),
-            //         P(1),
-            //         Pref(2),
-            //         P(2),
-            //         Lref(0),
-            //         L(0),
-            //         Lref(1),
-            //         L(1),
-            //         Lref(2),
-            //         L(2),
-            //         CM(0),
-            //         CM(1),
-            //         CM(2)
-            //         );
+            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+                m_robot->joint(i)->dq = (m_robot->joint(i)->q - cur_q(i)) / dt;
+            }
+            for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+                xi[(*it).first].segment(0, 3) = (m_robot->link((*it).first)->p - p_constraint[(*it).first]) / dt;
+                xi[(*it).first].segment(3, 3) = hrp::omegaFromRot(R_constraint[(*it).first].transpose() * m_robot->link((*it).first)->R) / dt;
+            }
+
             fp << std::fixed;
             fp << tm
                << " " << Pref(0)
@@ -140,19 +124,20 @@ private:
                << " " << L(1)
                << " " << Lref(2)
                << " " << L(2);
-            // for (size_t i = 0; i < dq.size(); ++i) {
-            //     fp << " " << dq(i);
+            // for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+            //     fp << " " << m_robot->joint(i)->dq;
             // }
+            for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+                for (size_t i = 0; i < 6; ++i) {
+                    fp << " " << (*it).second(i)
+                       << " " << xi[(*it).first](i);
+                }
+            }
             fp << "\n";
         }
 
-        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
-            rmc->removeConstraintLink(m_robot, (*it).first, xi_ref);
-        }
-        delete calcRef;
-        // fclose(fp);
-
-        size_t gpsize = 2;
+        size_t gpsize = 2 + xi_ref.size() * 2; // P, L, xi_p, xi_R
+        size_t gp_count = 0;
         size_t start = 2;
         FILE* gps[gpsize];
         for (size_t ii = 0; ii < gpsize; ii++) {
@@ -166,13 +151,13 @@ private:
             std::string titles[3] = {"X", "Y", "Z"};
             for (size_t ii = 0; ii < 3; ii++) {
                 oss << "set xlabel 'Time [s]'" << std::endl;
-                oss << "set ylabel '" << titles[ii] << "[kg m/s]'" << std::endl;
+                oss << "set ylabel '" << titles[ii] << "[Ns]'" << std::endl;
                 oss << "plot "
-                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.1 title 'Pref',"
-                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.1 title 'P'"
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.2 title 'Pref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.2 title 'P'"
                     << std::endl;
             }
-            plot_and_save(gps[0], gtitle, oss.str());
+            plot_and_save(gps[gp_count++], gtitle, oss.str());
             start += 6;
         }
         // L
@@ -185,11 +170,11 @@ private:
                 oss << "set xlabel 'Time [s]'" << std::endl;
                 oss << "set ylabel '" << titles[ii] << "[mNs]'" << std::endl;
                 oss << "plot "
-                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.1 title 'Lref',"
-                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.1 title 'L'"
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.2 title 'Lref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.2 title 'L'"
                     << std::endl;
             }
-            plot_and_save(gps[1], gtitle, oss.str());
+            plot_and_save(gps[gp_count++], gtitle, oss.str());
             start += 6;
         }
         // // CoM
@@ -223,6 +208,47 @@ private:
         //     oss << std::endl;
         //     plot_and_save(gps[2], gtitle, oss.str());
         // }
+
+        // xi
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            // p
+            std::ostringstream oss("");
+            std::string gtitle("xi_p " + (*it).first);
+            oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+            std::string titles[3] = {"X", "Y", "Z"};
+            for (size_t ii = 0; ii < 3; ii++) {
+                oss << "set xlabel 'Time [s]'" << std::endl;
+                oss << "set ylabel '" << titles[ii] << "[m/s]'" << std::endl;
+                oss << "plot "
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.2 title 'xi_p ref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.2 title 'xi_p'"
+                    << std::endl;
+            }
+            plot_and_save(gps[gp_count++], gtitle, oss.str());
+            start += 6;
+
+            // R
+            oss.str("");
+            oss.clear();
+            gtitle = "xi_R " + (*it).first;
+            oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+            // std::string titles[3] = {"X", "Y", "Z"};
+            for (size_t ii = 0; ii < 3; ii++) {
+                oss << "set xlabel 'Time [s]'" << std::endl;
+                oss << "set ylabel '" << titles[ii] << "[rad/s]'" << std::endl;
+                oss << "plot "
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with points ps 0.2 title 'xi_R ref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with points ps 0.2 title 'xi_R'"
+                    << std::endl;
+            }
+            plot_and_save(gps[gp_count++], gtitle, oss.str());
+            start += 6;
+        }
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->removeConstraintLink(m_robot, (*it).first, xi_ref);
+        }
+        delete calcRef;
 
         double tmp;
         std::cin >> tmp;
@@ -290,6 +316,7 @@ public:
                 Lref(2) = 0.2 * sin(tm * M_PI / max_tm * 4);
                 return Lref;
             }
+
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
             {
                 hrp::dvector6 xi_ref = hrp::dvector6::Zero();
@@ -304,7 +331,7 @@ public:
 
     void test1()
     {
-        std::cerr << "test1 : Control All Momentum with lleg and rarm constraint" << std::endl;
+        std::cerr << "test1 : Control all momentum with lleg and rarm constraint" << std::endl;
         setResetPose();
 
         double max_tm = 4.0;
@@ -339,6 +366,7 @@ public:
                 Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
+
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
             {
                 hrp::dvector6 xi_ref = hrp::dvector6::Zero();
@@ -352,7 +380,7 @@ public:
 
     void test2()
     {
-        std::cerr << "test2 : Control All Momentum with arms constraints" << std::endl;
+        std::cerr << "test2 : Control all momentum with arms constraints" << std::endl;
         setResetPose();
 
         double max_tm = 4.0;
@@ -387,6 +415,7 @@ public:
                 Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
+
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
             {
                 hrp::dvector6 xi_ref = hrp::dvector6::Zero();
@@ -395,6 +424,55 @@ public:
         };
 
         calcRefParamTest2* calcRef = new calcRefParamTest2();
+        executeAndPlot(max_tm, calcRef);
+    }
+
+    void test3()
+    {
+        std::cerr << "test3 : Control pitch and yaw axis angular momentum with leg constraints" << std::endl;
+        setResetPose();
+
+        double max_tm = 4.0;
+        hrp::dvector6 Svec;
+        Svec << 0, 0, 0, 1, 0, 1;
+        rmc->setSelectionMatrix(Svec);
+        xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->addConstraintLink(m_robot, (*it).first);
+        }
+
+        class calcRefParamTest3 : public calcReferenceParameter
+        {
+        public:
+            hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Pref;
+                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Pref *= m_robot->totalMass();
+                return Pref;
+            }
+
+            hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Lref;
+                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
+                return Lref;
+            }
+
+            hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
+            {
+                hrp::dvector6 xi_ref = hrp::dvector6::Zero();
+                return xi_ref;
+            }
+        };
+
+        calcRefParamTest3* calcRef = new calcRefParamTest3();
         executeAndPlot(max_tm, calcRef);
     }
 
@@ -426,7 +504,7 @@ protected:
                                       17.835600, 9.137590, 6.611880, -36.456000, 0.000000, 0.000000, 0.000000,
                                       0.000000, 0.000000, 0.000000};
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-            m_robot->joint(i)->q += deg2rad(reset_pose_angles[i]);
+            m_robot->joint(i)->q = deg2rad(reset_pose_angles[i]);
         }
         m_robot->calcForwardKinematics();
     }
@@ -456,6 +534,7 @@ void print_usage ()
     std::cerr << "  --test0 : Control All Momentum with legs constraint" << std::endl;
     std::cerr << "  --test1 : Control All Momentum with lleg and rarm constraint" << std::endl;
     std::cerr << "  --test2 : Control All Momentum with arms constraints" << std::endl;
+    std::cerr << "  --test3 : Control pitch and yaw axis angular momentum with leg constraints" << std::endl;
 }
 
 int main(int argc, char* argv[])
@@ -472,6 +551,8 @@ int main(int argc, char* argv[])
           trmc.test1();
       } else if (std::string(argv[1]) == "--test2") {
           trmc.test2();
+      } else if (std::string(argv[1]) == "--test3") {
+          trmc.test3();
       } else {
           print_usage();
           ret = 1;

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -83,15 +83,15 @@ private:
             }
             cur_basePos = m_robot->rootLink()->p;
             cur_baseRot = m_robot->rootLink()->R;
-            ref_basePos = cur_basePos + Pref / m_robot->totalMass() * dt;
+            ref_basePos = cur_basePos + Pref / m_robot->totalMass();
             ref_baseRot = cur_baseRot;
 
             // execute RMC
             rmc->rmControl(m_robot, Pref, Lref, xi_ref, ref_basePos, ref_baseRot, dt);
 
-            m_robot->rootLink()->v = (m_robot->rootLink()->p - cur_basePos) / dt;
+            m_robot->rootLink()->v = (m_robot->rootLink()->p - cur_basePos);
             hrp::Matrix33 dR = cur_baseRot.transpose() * m_robot->rootLink()->R;
-            m_robot->rootLink()->w = hrp::omegaFromRot(dR) / dt;
+            m_robot->rootLink()->w = hrp::omegaFromRot(dR);
 
             hrp::dvector tmpPL(6);
             tmpPL << Pref, Lref;
@@ -103,11 +103,11 @@ private:
             m_robot->calcTotalMomentumFromJacobian(P, L);
 
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-                m_robot->joint(i)->dq = (m_robot->joint(i)->q - cur_q(i)) / dt;
+                m_robot->joint(i)->dq = (m_robot->joint(i)->q - cur_q(i));
             }
             for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
-                xi[(*it).first].segment(0, 3) = (m_robot->link((*it).first)->p - p_constraint[(*it).first]) / dt;
-                xi[(*it).first].segment(3, 3) = hrp::omegaFromRot(R_constraint[(*it).first].transpose() * m_robot->link((*it).first)->R) / dt;
+                xi[(*it).first].segment(0, 3) = (m_robot->link((*it).first)->p - p_constraint[(*it).first]);
+                xi[(*it).first].segment(3, 3) = hrp::omegaFromRot(R_constraint[(*it).first].transpose() * m_robot->link((*it).first)->R);
             }
 
             fp << std::fixed;
@@ -147,6 +147,7 @@ private:
         {
             std::ostringstream oss("");
             std::string gtitle("P");
+            // oss << "set term wxt size 2560, 1600" << std::endl;
             oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
             std::string titles[3] = {"X", "Y", "Z"};
             for (size_t ii = 0; ii < 3; ii++) {
@@ -164,6 +165,7 @@ private:
         {
             std::ostringstream oss("");
             std::string gtitle("L");
+            // oss << "set term wxt size 2560, 1600" << std::endl;
             oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
             std::string titles[3] = {"X", "Y", "Z"};
             for (size_t ii = 0; ii < 3; ii++) {
@@ -214,6 +216,8 @@ private:
             // p
             std::ostringstream oss("");
             std::string gtitle("xi_p " + (*it).first);
+            // oss << "set term wxt size 2560, 1600" << std::endl;
+            oss << "set termoption noenhanced" << std::endl;
             oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
             std::string titles[3] = {"X", "Y", "Z"};
             for (size_t ii = 0; ii < 3; ii++) {
@@ -231,6 +235,8 @@ private:
             oss.str("");
             oss.clear();
             gtitle = "xi_R " + (*it).first;
+            // oss << "set term wxt size 2560, 1600" << std::endl;
+            oss << "set termoption noenhanced" << std::endl;
             oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
             // std::string titles[3] = {"X", "Y", "Z"};
             for (size_t ii = 0; ii < 3; ii++) {
@@ -284,7 +290,7 @@ public:
         std::cerr << "test0 : Control All Momentum with legs constraints" << std::endl;
         setResetPose();
 
-        double max_tm = 4.0;
+        double max_tm = 120.0;
         hrp::dvector6 Svec;
         Svec << 1, 1, 1, 1, 1, 1;
         rmc->setSelectionMatrix(Svec);
@@ -301,9 +307,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.02 * sin(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.00001 * sin(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.00001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.00002 * sin(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -311,9 +317,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.1 * sin(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.2 * sin(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.0002 * sin(tm * M_PI / max_tm * 4);
                 return Lref;
             }
 
@@ -334,7 +340,7 @@ public:
         std::cerr << "test1 : Control all momentum with lleg and rarm constraint" << std::endl;
         setResetPose();
 
-        double max_tm = 4.0;
+        double max_tm = 120.0;
         hrp::dvector6 Svec;
         Svec << 1, 1, 1, 1, 1, 1;
         rmc->setSelectionMatrix(Svec);
@@ -351,9 +357,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.0001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.0002 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -361,9 +367,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
 
@@ -400,9 +406,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.0001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.0002 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -410,9 +416,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
 
@@ -449,9 +455,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.0001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.0002 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -459,9 +465,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
 
@@ -473,6 +479,56 @@ public:
         };
 
         calcRefParamTest3* calcRef = new calcRefParamTest3();
+        executeAndPlot(max_tm, calcRef);
+    }
+
+    void test4()
+    {
+        std::cerr << "test4 : Control All Momentum with Raising Legs" << std::endl;
+        setResetPose();
+
+        double max_tm = 4.0;
+        hrp::dvector6 Svec;
+        Svec << 1, 1, 1, 1, 1, 1;
+        rmc->setSelectionMatrix(Svec);
+        xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->addConstraintLink(m_robot, (*it).first);
+        }
+
+        class calcRefParamTest4 : public calcReferenceParameter
+        {
+        public:
+            hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Pref;
+                Pref(0) = 0.0001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.0001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.0002 * cos(tm * M_PI / max_tm * 4);
+                Pref *= m_robot->totalMass();
+                return Pref;
+            }
+
+            hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Lref;
+                Lref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
+                return Lref;
+            }
+
+            hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
+            {
+                hrp::dvector6 xi_ref = hrp::dvector6::Zero();
+                xi_ref(2) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                return xi_ref;
+            }
+        };
+
+        calcRefParamTest4* calcRef = new calcRefParamTest4();
         executeAndPlot(max_tm, calcRef);
     }
 

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -1,0 +1,106 @@
+/* -*- coding:utf-8-unix; mode:c++; -*- */
+#include "ResolvedMomentumControl.h"
+#include <rtm/Manager.h>
+#include <rtm/CorbaNaming.h>
+#include <hrpModel/ModelLoaderUtil.h>
+#include <cmath>
+
+inline double deg2rad (double deg) { return deg * M_PI / 180.0; }
+
+int main(int argc, char* argv[])
+{
+    bool use_gnuplot = true;
+    if (argc >= 2) {
+        if ( std::string(argv[1])== "--use-gnuplot" ) {
+            use_gnuplot = (std::string(argv[2])=="true");
+        }
+    }
+
+    hrp::BodyPtr m_robot = hrp::BodyPtr(new hrp::Body());
+    RTC::Manager& rtcManager = RTC::Manager::instance();
+    std::string nameServer = rtcManager.getConfig()["corba.nameservers"];
+    int comPos = nameServer.find(",");
+    if (comPos < 0){
+        comPos = nameServer.length();
+    }
+    nameServer = nameServer.substr(0, comPos);
+    RTC::CorbaNaming naming(rtcManager.getORB(), nameServer.c_str());
+    if (!loadBodyFromModelLoader(m_robot, "file:///home/ishikawa/ros/indigo/src/rtm-ros-robotics/rtmros_hrp2/jsk_models/CHIDORI/CHIDORImain.wrl",
+                                 CosNaming::NamingContext::_duplicate(naming.getRootContext()))) {
+        std::cerr << "Failed to load model"  << std::endl;
+    }
+
+    // Reset Pose
+    m_robot->joint(2)->q = deg2rad(-20);
+    m_robot->joint(3)->q = deg2rad(40);
+    m_robot->joint(4)->q = deg2rad(-20);
+    m_robot->joint(8)->q = deg2rad(40);
+    m_robot->joint(9)->q = deg2rad(-20);
+    m_robot->joint(10)->q = deg2rad(-20);
+    m_robot->calcForwardKinematics();
+
+    // hrp::JointPath jp(m_robot->rootLink(), m_robot->joint(5));
+    // std::cerr << "Debug" << std::endl;
+    // std::cerr << (m_robot->rootLink()->p).transpose() << std::endl;
+    // std::cerr <<  m_robot->totalMass() << std::endl;
+    // std::cerr << (m_robot->rootLink()->v).transpose() << ", " <<  (m_robot->rootLink()->w).transpose() << std::endl; // reference
+    // std::cerr <<  (m_robot->joint(5)->p).transpose() << std::endl;
+    // std::cerr << jp.Jacobian() << std::endl;
+    // std::cerr << jp.Jacobian().inverse() << std::endl;
+
+    double dt = 0.01, max_tm = 8.0;
+
+    hrp::dvector6 SVec;
+    SVec << 1, 1, 1, 1, 1, 1;
+    rats::RMController rmc(m_robot, SVec);
+    rmc.addConstraintLink(m_robot, "RLEG_JOINT5");
+    rmc.addConstraintLink(m_robot, "LLEG_JOINT5");
+
+    std::string fname("/tmp/plot.dat");
+    FILE* fp = fopen(fname.c_str(), "w");
+    double tm = 0;
+    hrp::Vector3 Pref, Lref, ref_basePos, P, L;
+    hrp::Matrix33 ref_baseRot;
+    Lref = hrp::Vector3::Zero();
+    while (tm < max_tm) {
+        // Pref(1) = -3 * cos(tm * M_PI / max_tm * 2);
+        // Pref(2) = 3 * sin(tm * M_PI / max_tm * 4);
+        Pref(0) = 0;
+        Pref(1) = 0;
+        Pref(2) = 0.3 * cos(tm * M_PI / max_tm * 2);
+        rmc.rmControl(m_robot, Pref, Lref, hrp::dvector6::Zero(6, 1), ref_basePos, ref_baseRot, dt);
+        P = m_robot->totalMass() * (ref_basePos - m_robot->rootLink()->p) / dt;
+        m_robot->calcForwardKinematics();
+        fprintf(fp, "%f %f %f %f %f %f %f %f %f %f\n",
+                    tm,
+                    Pref(0),
+                    P(0),
+                    Lref(0),
+                    Pref(1),
+                    P(1),
+                    Lref(1),
+                    Pref(2),
+                    P(2),
+                    Lref(2)
+                    );
+        tm += dt;
+    }
+
+    fclose(fp);
+    if (use_gnuplot) {
+        FILE* gp[3];
+        std::string titles[3] = {"X", "Y", "Z"};
+        for (size_t ii = 0; ii < 3; ii++) {
+            gp[ii] = popen("gnuplot", "w");
+            fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
+            fprintf(gp[ii], "plot \"%s\" using 1:%zu with lines title \"Pref\"\n", fname.c_str(), ( ii * 3 + 2));
+            fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"P\"\n", fname.c_str(), ( ii * 3 + 3));
+            // fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"refzmp\"\n", fname.c_str(), ( ii * 3 + 4));
+            fflush(gp[ii]);
+        }
+        double tmp;
+        std::cin >> tmp;
+        for (size_t j = 0; j < 3; j++) pclose(gp[j]);
+    }
+    return 0;
+}

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -7,100 +7,424 @@
 
 inline double deg2rad (double deg) { return deg * M_PI / 180.0; }
 
-int main(int argc, char* argv[])
+class testResolvedMomentumControl
 {
-    bool use_gnuplot = true;
-    if (argc >= 2) {
-        if ( std::string(argv[1])== "--use-gnuplot" ) {
-            use_gnuplot = (std::string(argv[2])=="true");
+protected:
+    double dt; /* [s] */
+    rats::RMController* rmc;
+    hrp::BodyPtr m_robot;
+    std::map<std::string, hrp::dvector6> xi_ref;
+    std::map<std::string, std::string> end_effectors;
+    bool use_gnuplot;
+    virtual void setResetPose() {};
+
+    void loadModel(const char *file_path)
+    {
+        RTC::Manager& rtcManager = RTC::Manager::instance();
+        std::string nameServer = rtcManager.getConfig()["corba.nameservers"];
+        int comPos = nameServer.find(",");
+        if (comPos < 0){
+            comPos = nameServer.length();
+        }
+        nameServer = nameServer.substr(0, comPos);
+        RTC::CorbaNaming naming(rtcManager.getORB(), nameServer.c_str());
+        if (!loadBodyFromModelLoader(m_robot, file_path,
+                                     CosNaming::NamingContext::_duplicate(naming.getRootContext()))) {
+            std::cerr << "Failed to load model"  << std::endl;
+            std::cerr << "Please check if openhrp-model-loader is running"  << std::endl;
+            exit(1);
         }
     }
 
-    hrp::BodyPtr m_robot = hrp::BodyPtr(new hrp::Body());
-    RTC::Manager& rtcManager = RTC::Manager::instance();
-    std::string nameServer = rtcManager.getConfig()["corba.nameservers"];
-    int comPos = nameServer.find(",");
-    if (comPos < 0){
-        comPos = nameServer.length();
-    }
-    nameServer = nameServer.substr(0, comPos);
-    RTC::CorbaNaming naming(rtcManager.getORB(), nameServer.c_str());
-    if (!loadBodyFromModelLoader(m_robot, "file:///home/ishikawa/ros/indigo/src/rtm-ros-robotics/rtmros_hrp2/jsk_models/CHIDORI/CHIDORImain.wrl",
-                                 CosNaming::NamingContext::_duplicate(naming.getRootContext()))) {
-        std::cerr << "Failed to load model"  << std::endl;
+private:
+    void plot_and_save(FILE* gp, const std::string graph_fname, const std::string plot_str)
+    {
+        fprintf(gp, "%s\n unset multiplot\n", plot_str.c_str());
+        fprintf(gp, "set terminal postscript eps color\nset output '/tmp/%s.eps'\n", graph_fname.c_str());
+        fprintf(gp, "%s\n unset multiplot\n", plot_str.c_str());
+        fflush(gp);
     }
 
-    // Reset Pose
-    m_robot->joint(2)->q = deg2rad(-20);
-    m_robot->joint(3)->q = deg2rad(40);
-    m_robot->joint(4)->q = deg2rad(-20);
-    m_robot->joint(8)->q = deg2rad(40);
-    m_robot->joint(9)->q = deg2rad(-20);
-    m_robot->joint(10)->q = deg2rad(-20);
-    m_robot->calcForwardKinematics();
+    template<class Functor1, class Functor2>
+    void executeAndPlot(const double max_tm, Functor1 calcP, Functor2 calcL)
+    {
+        std::string fname("/tmp/plot.dat");
+        FILE* fp = fopen(fname.c_str(), "w");
+        hrp::Vector3 Pref, Lref, ref_basePos, P, L, CM_old, CM, CMref;
+        hrp::Matrix33 ref_baseRot;
 
-    // hrp::JointPath jp(m_robot->rootLink(), m_robot->joint(5));
-    // std::cerr << "Debug" << std::endl;
-    // std::cerr << (m_robot->rootLink()->p).transpose() << std::endl;
-    // std::cerr <<  m_robot->totalMass() << std::endl;
-    // std::cerr << (m_robot->rootLink()->v).transpose() << ", " <<  (m_robot->rootLink()->w).transpose() << std::endl; // reference
-    // std::cerr <<  (m_robot->joint(5)->p).transpose() << std::endl;
-    // std::cerr << jp.Jacobian() << std::endl;
-    // std::cerr << jp.Jacobian().inverse() << std::endl;
+        for (double tm = 0; tm < max_tm; tm += dt) {
+            Pref = calcP(m_robot, tm, max_tm);
+            Lref = calcL(m_robot, tm, max_tm);
+            CM_old = m_robot->calcCM();
 
-    double dt = 0.01, max_tm = 8.0;
+            if (tm < 0.2) std::cout << "root_p: " << (m_robot->rootLink()->p).transpose() << std::endl << "root_R: " << std::endl << (m_robot->rootLink()->R) << std::endl;
+            std::cout << "CM_old: " << CM_old.transpose() << std::endl;
 
-    hrp::dvector6 SVec;
-    SVec << 1, 1, 1, 1, 1, 1;
-    rats::RMController rmc(m_robot, SVec);
-    rmc.addConstraintLink(m_robot, "RLEG_JOINT5");
-    rmc.addConstraintLink(m_robot, "LLEG_JOINT5");
+            hrp::dvector dq(m_robot->numJoints());
+            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+                dq(i) = -m_robot->joint(i)->q;
+            }
 
-    std::string fname("/tmp/plot.dat");
-    FILE* fp = fopen(fname.c_str(), "w");
-    double tm = 0;
-    hrp::Vector3 Pref, Lref, ref_basePos, P, L;
-    hrp::Matrix33 ref_baseRot;
-    Lref = hrp::Vector3::Zero();
-    while (tm < max_tm) {
-        // Pref(1) = -3 * cos(tm * M_PI / max_tm * 2);
-        // Pref(2) = 3 * sin(tm * M_PI / max_tm * 4);
-        Pref(0) = 0;
-        Pref(1) = 0;
-        Pref(2) = 0.3 * cos(tm * M_PI / max_tm * 2);
-        rmc.rmControl(m_robot, Pref, Lref, hrp::dvector6::Zero(6, 1), ref_basePos, ref_baseRot, dt);
-        P = m_robot->totalMass() * (ref_basePos - m_robot->rootLink()->p) / dt;
-        m_robot->calcForwardKinematics();
-        fprintf(fp, "%f %f %f %f %f %f %f %f %f %f\n",
+            ref_basePos = m_robot->rootLink()->p + Pref / m_robot->totalMass();
+            ref_baseRot = m_robot->rootLink()->R;
+
+            rmc->rmControl(m_robot, Pref, Lref, xi_ref, ref_basePos, ref_baseRot, dt);
+
+            hrp::Vector3 omega;
+            hrp::dmatrix dRRT = ((ref_baseRot - m_robot->rootLink()->R) / dt) * (m_robot->rootLink()->R).transpose();
+            omega(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
+            omega(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
+            omega(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
+
+            std::cerr << "dif root_p: " << (ref_basePos - m_robot->rootLink()->p).transpose() << std::endl;
+
+            m_robot->rootLink()->p = ref_basePos;
+            m_robot->rootLink()->R = ref_baseRot;
+            m_robot->calcForwardKinematics();
+            // P
+            CM = m_robot->calcCM();
+            P = m_robot->totalMass() * (CM - CM_old) / dt;
+            // L
+            hrp::dmatrix Jl;
+            m_robot->calcAngularMomentumJacobian(NULL, Jl); // Eq.1 lower [H 0 I]
+            for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+                dq(i) += m_robot->joint(i)->q;
+                dq(i) /= dt;
+            }
+            hrp::dvector v_vec(6 + m_robot->numJoints());
+            v_vec << dq, hrp::Vector3::Zero(), omega;
+            L = Jl * v_vec;
+
+            fprintf(fp, "%f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
                     tm,
                     Pref(0),
                     P(0),
-                    Lref(0),
                     Pref(1),
                     P(1),
-                    Lref(1),
                     Pref(2),
                     P(2),
-                    Lref(2)
+                    Lref(0),
+                    L(0),
+                    Lref(1),
+                    L(1),
+                    Lref(2),
+                    L(2),
+                    CM(0),
+                    CM(1),
+                    CM(2)
                     );
-        tm += dt;
-    }
-
-    fclose(fp);
-    if (use_gnuplot) {
-        FILE* gp[3];
-        std::string titles[3] = {"X", "Y", "Z"};
-        for (size_t ii = 0; ii < 3; ii++) {
-            gp[ii] = popen("gnuplot", "w");
-            fprintf(gp[ii], "set title \"%s\"\n", titles[ii].c_str());
-            fprintf(gp[ii], "plot \"%s\" using 1:%zu with lines title \"Pref\"\n", fname.c_str(), ( ii * 3 + 2));
-            fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"P\"\n", fname.c_str(), ( ii * 3 + 3));
-            // fprintf(gp[ii], "replot \"%s\" using 1:%zu with lines title \"refzmp\"\n", fname.c_str(), ( ii * 3 + 4));
-            fflush(gp[ii]);
         }
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->removeConstraintLink((*it).first, xi_ref);
+        }
+        fclose(fp);
+
+        size_t gpsize = 3;
+        size_t start = 2;
+        FILE* gps[gpsize];
+        for (size_t ii = 0; ii < gpsize;ii++) {
+            gps[ii] = popen("gnuplot", "w");
+        }
+        // P
+        {
+            std::ostringstream oss("");
+            std::string gtitle("P");
+            oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+            std::string titles[3] = {"X", "Y", "Z"};
+            for (size_t ii = 0; ii < 3; ii++) {
+                oss << "set xlabel 'Time [s]'" << std::endl;
+                oss << "set ylabel '" << titles[ii] << "[kg m/s]'" << std::endl;
+                oss << "plot "
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with lines title 'Pref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with lines title 'P'"
+                    << std::endl;
+            }
+            plot_and_save(gps[0], gtitle, oss.str());
+            start += 6;
+        }
+        // L
+        {
+            std::ostringstream oss("");
+            std::string gtitle("L");
+            oss << "set multiplot layout 3, 1 title '" << gtitle << "'" << std::endl;
+            std::string titles[3] = {"X", "Y", "Z"};
+            for (size_t ii = 0; ii < 3; ii++) {
+                oss << "set xlabel 'Time [s]'" << std::endl;
+                oss << "set ylabel '" << titles[ii] << "[mNs]'" << std::endl;
+                oss << "plot "
+                    << "'" << fname << "' using 1:" << (start + ii * 2) << " with lines title 'Lref',"
+                    << "'" << fname << "' using 1:" << (start + ii * 2 + 1) << " with lines title 'L'"
+                    << std::endl;
+            }
+            plot_and_save(gps[1], gtitle, oss.str());
+            start += 6;
+        }
+        // CoM
+        {
+            std::ostringstream oss("");
+            std::string gtitle("CoM");
+            oss << "set multiplot layout 1, 1 title '" << gtitle << "'" << std::endl;
+            oss << "set xlabel 'Time [s]'" << std::endl;
+            oss << "set ylabel '" << "Position [m]'" << std::endl;
+            oss << "plot "
+                << "'" << fname << "' using 1:" << (start) << " with lines title 'X',"
+                << "'" << fname << "' using 1:" << (start + 1) << " with lines title 'Y',"
+                << "'" << fname << "' using 1:" << (start + 2) << " with lines title 'Z'"
+                << std::endl;
+            plot_and_save(gps[2], gtitle, oss.str());
+        }
+
         double tmp;
         std::cin >> tmp;
-        for (size_t j = 0; j < 3; j++) pclose(gp[j]);
+        for (size_t ii = 0; ii < gpsize; ii++) {
+            fprintf(gps[ii], "exit\n");
+            fflush(gps[ii]);
+            pclose(gps[ii]);
+        }
+        // std::cerr << "Checking" << std::endl;
+        // std::cerr << "  ZMP error : " << is_small_zmp_error << std::endl;
+        // std::cerr << "  ZMP diff : " << is_small_zmp_diff << std::endl;
+        // std::cerr << "  Contact states & swing support time validity : " << is_contact_states_swing_support_time_validity << std::endl;
     }
-    return 0;
+
+    void setEndeffectorConstraint(std::string &limb)
+    {
+        rmc->addConstraintLink(m_robot, end_effectors[limb]);
+    }
+
+public:
+    std::vector<std::string> arg_strs;
+    testResolvedMomentumControl() : use_gnuplot(true)
+    {
+        m_robot = hrp::BodyPtr(new hrp::Body());
+    }
+
+    virtual ~testResolvedMomentumControl()
+    {
+        if (rmc != NULL) {
+            delete rmc;
+            rmc = NULL;
+        }
+    }
+
+    void test0()
+    {
+        std::cerr << "test0 : Control All Momentum" << std::endl;
+        setResetPose();
+
+        double max_tm = 8.0;
+        hrp::dvector6 Svec;
+        Svec << 1, 1, 1, 1, 1, 1;
+        rmc->setSelectionMatrix(Svec);
+        xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->addConstraintLink(m_robot, (*it).first);
+        }
+
+        struct P {
+            static hrp::Vector3 calcP(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Pref;
+                Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
+                Pref *= m_robot->totalMass();
+                return Pref;
+            }
+        };
+
+
+        struct L {
+            static hrp::Vector3 calcL(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Lref;
+                Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                return Lref;
+            }
+        };
+        executeAndPlot(max_tm, P::calcP, L::calcL);
+    }
+
+    void test1()
+    {
+        std::cerr << "test1 : Move only P_z" << std::endl;
+        setResetPose();
+
+        double max_tm = 8.0;
+        hrp::dvector6 Svec;
+        Svec << 1, 1, 1, 1, 1, 1;
+        rmc->setSelectionMatrix(Svec);
+        xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->addConstraintLink(m_robot, (*it).first);
+        }
+
+        struct P {
+            static hrp::Vector3 calcP(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Pref;
+                Pref(0) = 0;
+                Pref(1) = 0;
+                Pref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                Pref *= m_robot->totalMass();
+                return Pref;
+            }
+        };
+
+
+        struct L {
+            static hrp::Vector3 calcL(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Lref;
+                Lref(0) = 0;//.2 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0;
+                Lref(2) = 0;
+                return Lref;
+            }
+        };
+
+        executeAndPlot(max_tm, P::calcP, L::calcL);
+    }
+
+    void test2()
+    {
+        // std::cerr << "test2 : Control All Momentum" << std::endl;
+        // double max_tm = 8.0;
+        // hrp::dvector6 Svec;
+        // Svec << 1, 1, 1, 1, 1, 1;
+        // rmc->setSelectionMatrix(Svec);
+        // xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
+        // xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+
+        // for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+        //     rmc->addConstraintLink(m_robot, (*it).first);
+        // }
+
+        // struct P {
+        //     hrp::Vector3 operator() (const double tm, const double max_tm)
+        //     {
+        //         hrp::Vector3 Pref;
+        //         Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+        //         Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+        //         Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
+        //         Pref *= m_robot->totalMass();
+        //         return Pref;
+        //     }
+        // };
+
+        // struct L {
+        //     hrp::Vector3 operator() (const double tm, const double max_tm)
+        //     {
+        //         hrp::Vector3 Lref;
+        //         Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+        //         Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+        //         Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+        //         return Lref;
+        //     }
+        // };
+
+        // executeAndPlot(max_tm, P(), L());
+    }
+
+    void parseParams()
+    {
+        for (int i = 0; i < arg_strs.size(); ++ i) {
+            if ( arg_strs[i]== "--use-gnuplot" ) {
+                if (++i < arg_strs.size()) use_gnuplot = (arg_strs[i]=="true");
+            }
+        }
+    }
+
+    bool check_all_results ()
+    {
+        // return is_small_zmp_error && is_small_zmp_diff && is_contact_states_swing_support_time_validity;
+        return true;
+    }
+};
+
+class testResolvedMomentumControlSampleRobot : public testResolvedMomentumControl
+{
+protected:
+    void setResetPose()
+    {
+        // Reset Pose
+        double reset_pose_joints[] = {-0.004457, -21.692900, -0.012020, 47.672300, -25.930000, 0.014025,
+                                      17.835600, -9.137590, -6.611880, -36.456000, 0.000000, 0.000000, 0.000000,
+                                      -0.004457, -21.692900, -0.012020, 47.672300, -25.930000, 0.014025,
+                                      17.835600, 9.137590, 6.611880, -36.456000, 0.000000, 0.000000, 0.000000,
+                                      0.000000, 0.000000, 0.000000};
+        for (size_t i = 0; i < m_robot->numJoints(); ++i) {
+            m_robot->joint(i)->q += deg2rad(reset_pose_joints[i]);
+        }
+        m_robot->calcForwardKinematics();
+    }
+public:
+    testResolvedMomentumControlSampleRobot ()
+    {
+        dt = 0.004;
+        end_effectors["rleg"] = "RLEG_ANKLE_R";
+        end_effectors["lleg"] = "LLEG_ANKLE_R";
+        end_effectors["rarm"] = "RARM_WRIST_P";
+        end_effectors["larm"] = "LARM_WRIST_P";
+        loadModel("file://../share/openhrp3/share/OpenHRP-3.1/sample/model/sample1.wrl");
+        rmc = new rats::RMController(m_robot);
+    }
+};
+
+class testResolvedMomentumControlHRP2JSK : public testResolvedMomentumControl
+{
+public:
+    testResolvedMomentumControlHRP2JSK ()
+    {
+        dt = 0.004;
+        end_effectors["rleg"] = "RLEG_JOINT5";
+        end_effectors["lleg"] = "LLEG_JOINT5";
+        end_effectors["rarm"] = "RARM_JOINT6";
+        end_effectors["larm"] = "LARM_JOINT6";
+        loadModel("file://../share/openhrp3/share/OpenHRP-3.1/sample/model/sample1.wrl");
+        rmc = new rats::RMController(m_robot);
+    };
+};
+
+void print_usage ()
+{
+    std::cerr << "Usage : testResolvedMomentumControl [option]" << std::endl;
+    std::cerr << " [option] should be:" << std::endl;
+    std::cerr << "  --test0 : Control All Momentum" << std::endl;
+    std::cerr << "  --test1 : Control All Momentum" << std::endl;
+    std::cerr << "  --test2 : Control All Momentum" << std::endl;
+}
+
+int main(int argc, char* argv[])
+{
+  int ret = 0;
+  if (argc >= 2) {
+      testResolvedMomentumControlSampleRobot trmc;
+      for (int i = 1; i < argc; ++ i) {
+          trmc.arg_strs.push_back(std::string(argv[i]));
+      }
+      if (std::string(argv[1]) == "--test0") {
+          trmc.test0();
+      } else if (std::string(argv[1]) == "--test1") {
+          trmc.test1();
+      } else if (std::string(argv[1]) == "--test2") {
+          trmc.test2();
+      } else {
+          print_usage();
+          ret = 1;
+      }
+      ret = (trmc.check_all_results() ? 0 : 2);
+  } else {
+      print_usage();
+      ret = 1;
+  }
+  return ret;
 }

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -2,8 +2,11 @@
 #include "ResolvedMomentumControl.h"
 #include <rtm/Manager.h>
 #include <rtm/CorbaNaming.h>
+#include <hrpModel/Config.h>
 #include <hrpModel/ModelLoaderUtil.h>
 #include <cmath>
+#include <fstream>
+#include <iostream>
 // #include <boost/filesystem.hpp>
 
 inline double deg2rad (double deg) { return deg * M_PI / 180.0; }
@@ -38,6 +41,14 @@ protected:
     }
 
 private:
+    class calcReferenceParameter
+    {
+    public:
+        virtual hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm) {};
+        virtual hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm) {};
+        virtual hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm) {};
+    };
+
     void plot_and_save(FILE* gp, const std::string graph_fname, const std::string plot_str)
     {
         fprintf(gp, "%s\n unset multiplot\n", plot_str.c_str());
@@ -46,24 +57,29 @@ private:
         fflush(gp);
     }
 
-    template<class Functor1, class Functor2>
-    void executeAndPlot(const double max_tm, Functor1 calcP, Functor2 calcL)
+    void executeAndPlot(const double max_tm, calcReferenceParameter* calcRef)
     {
         std::string fname("/tmp/plot.dat");
-        FILE* fp = fopen(fname.c_str(), "w");
+        // FILE* fp = fopen(fname.c_str(), "w");
+        std::ofstream fp("/tmp/plot.dat");
         hrp::Vector3 Pref, Lref, cur_basePos, ref_basePos, P, L, CM;
         hrp::Matrix33 cur_baseRot, ref_baseRot;
 
         for (double tm = 0; tm < max_tm; tm += dt) {
-            cur_basePos = m_robot->rootLink()->p;
-            cur_baseRot = m_robot->rootLink()->R;
-            Pref = calcP(m_robot, tm, max_tm);
-            Lref = calcL(m_robot, tm, max_tm);
+            Pref = calcRef->calcPref(m_robot, tm, max_tm);
+            Lref = calcRef->calcLref(m_robot, tm, max_tm);
+
+            for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+                (*it).second = calcRef->calcXiref(m_robot, (*it).first, tm, max_tm);
+            }
 
             hrp::dvector dq(m_robot->numJoints());
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
                 dq(i) = -m_robot->joint(i)->q;
             }
+
+            cur_basePos = m_robot->rootLink()->p;
+            cur_baseRot = m_robot->rootLink()->R;
 
             ref_basePos = cur_basePos + Pref / m_robot->totalMass() * dt;
             ref_baseRot = cur_baseRot;
@@ -71,10 +87,11 @@ private:
             rmc->rmControl(m_robot, Pref, Lref, xi_ref, ref_basePos, ref_baseRot, dt);
 
             m_robot->rootLink()->v = (m_robot->rootLink()->p - cur_basePos) / dt;
-            hrp::dmatrix dRRT = ((m_robot->rootLink()->R - cur_baseRot) / dt) * (cur_baseRot).transpose();
-            m_robot->rootLink()->w(0) = (-dRRT(1, 2) + dRRT(2, 1)) / 2.0;
-            m_robot->rootLink()->w(1) = (-dRRT(2, 0) + dRRT(0, 2)) / 2.0;
-            m_robot->rootLink()->w(2) = (-dRRT(0, 1) + dRRT(1, 0)) / 2.0;
+            hrp::Matrix33 dR = cur_baseRot.transpose() * m_robot->rootLink()->R;
+            m_robot->rootLink()->w = hrp::omegaFromRot(dR) / dt;
+
+            // std::cerr << (m_robot->rootLink()->v).transpose() << std::endl;
+            // std::cerr << (m_robot->rootLink()->w).transpose() << std::endl;
 
             for (size_t i = 0; i < m_robot->numJoints(); ++i) {
                 dq(i) += m_robot->joint(i)->q;
@@ -82,50 +99,63 @@ private:
                 m_robot->joint(i)->dq = dq(i);
             }
 
+            hrp::dvector tmpPL(6);
+            tmpPL << Pref, Lref;
+            tmpPL = tmpPL.cwiseProduct(rmc->getSelectionVector());
+            Pref = tmpPL.segment(0, 3);
+            Lref = tmpPL.segment(3, 3);
+            m_robot->calcForwardKinematics(true);
+            CM = m_robot->calcCM();
             m_robot->calcTotalMomentumFromJacobian(P, L);
-            // // P
-            // CM = m_robot->calcCM();
-            // P = m_robot->totalMass() * (CM - CM_old) / dt;
-            // // L
-            // hrp::dmatrix Jl;
-            // m_robot->calcAngularMomentumJacobian(NULL, Jl); // Eq.1 lower [H 0 I]
-            // for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-            //     dq(i) += m_robot->joint(i)->q;
-            //     dq(i) /= dt;
-            // }
-            // hrp::dvector v_vec(6 + m_robot->numJoints());
-            // v_vec << dq, hrp::Vector3::Zero(), omega;
-            // L = Jl * v_vec;
 
-            fprintf(fp, "%f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
-                    tm,
-                    Pref(0),
-                    P(0),
-                    Pref(1),
-                    P(1),
-                    Pref(2),
-                    P(2),
-                    Lref(0),
-                    L(0),
-                    Lref(1),
-                    L(1),
-                    Lref(2),
-                    L(2),
-                    CM(0),
-                    CM(1),
-                    CM(2)
-                    );
+            // fprintf(fp, "%f %f %f %f %f %f %f %f %f %f %f %f %f %f %f %f\n",
+            //         tm,
+            //         Pref(0),
+            //         P(0),
+            //         Pref(1),
+            //         P(1),
+            //         Pref(2),
+            //         P(2),
+            //         Lref(0),
+            //         L(0),
+            //         Lref(1),
+            //         L(1),
+            //         Lref(2),
+            //         L(2),
+            //         CM(0),
+            //         CM(1),
+            //         CM(2)
+            //         );
+            fp << std::fixed;
+            fp << tm
+               << " " << Pref(0)
+               << " " << P(0)
+               << " " << Pref(1)
+               << " " << P(1)
+               << " " << Pref(2)
+               << " " << P(2)
+               << " " << Lref(0)
+               << " " << L(0)
+               << " " << Lref(1)
+               << " " << L(1)
+               << " " << Lref(2)
+               << " " << L(2);
+            for (size_t i = 0; i < dq.size(); ++i) {
+                fp << " " << dq(i);
+            }
+            fp << "\n";
         }
 
         for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
-            rmc->removeConstraintLink((*it).first, xi_ref);
+            rmc->removeConstraintLink(m_robot, (*it).first, xi_ref);
         }
-        fclose(fp);
+        delete(calcRef);
+        // fclose(fp);
 
         size_t gpsize = 3;
         size_t start = 2;
         FILE* gps[gpsize];
-        for (size_t ii = 0; ii < gpsize;ii++) {
+        for (size_t ii = 0; ii < gpsize; ii++) {
             gps[ii] = popen("gnuplot", "w");
         }
         // P
@@ -162,18 +192,35 @@ private:
             plot_and_save(gps[1], gtitle, oss.str());
             start += 6;
         }
-        // CoM
+        // // CoM
+        // {
+        //     std::ostringstream oss("");
+        //     std::string gtitle("CoM");
+        //     oss << "set multiplot layout 1, 1 title '" << gtitle << "'" << std::endl;
+        //     oss << "set xlabel 'Time [s]'" << std::endl;
+        //     oss << "set ylabel '" << "Position [m]'" << std::endl;
+        //     oss << "plot "
+        //         << "'" << fname << "' using 1:" << (start) << " with lines title 'X',"
+        //         << "'" << fname << "' using 1:" << (start + 1) << " with lines title 'Y',"
+        //         << "'" << fname << "' using 1:" << (start + 2) << " with lines title 'Z'"
+        //         << std::endl;
+        //     plot_and_save(gps[2], gtitle, oss.str());
+        // }
+
+        // dq
         {
             std::ostringstream oss("");
-            std::string gtitle("CoM");
+            std::string gtitle("dq");
             oss << "set multiplot layout 1, 1 title '" << gtitle << "'" << std::endl;
             oss << "set xlabel 'Time [s]'" << std::endl;
-            oss << "set ylabel '" << "Position [m]'" << std::endl;
-            oss << "plot "
-                << "'" << fname << "' using 1:" << (start) << " with lines title 'X',"
-                << "'" << fname << "' using 1:" << (start + 1) << " with lines title 'Y',"
-                << "'" << fname << "' using 1:" << (start + 2) << " with lines title 'Z'"
-                << std::endl;
+            oss << "set ylabel '" << "[rad / s]'" << std::endl;
+            oss << "plot ";
+            size_t i;
+            for (i = 0; i < m_robot->numJoints() - 1; ++i) {
+                oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "',";
+            }
+            oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "'";
+            oss << std::endl;
             plot_and_save(gps[2], gtitle, oss.str());
         }
 
@@ -208,7 +255,7 @@ public:
 
     void test0()
     {
-        std::cerr << "test0 : Control All Momentum" << std::endl;
+        std::cerr << "test0 : Control All Momentum with legs constraints" << std::endl;
         setResetPose();
 
         double max_tm = 4.0;
@@ -222,8 +269,59 @@ public:
             rmc->addConstraintLink(m_robot, (*it).first);
         }
 
-        struct P {
-            static hrp::Vector3 calcP(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+        class calcRefParamTest0 : public calcReferenceParameter
+        {
+        public:
+            hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Pref;
+                Pref(0) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                Pref *= m_robot->totalMass();
+                return Pref;
+            }
+
+            hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            {
+                hrp::Vector3 Lref;
+                Lref(0) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                return Lref;
+            }
+            hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
+            {
+                hrp::dvector6 xi_ref = hrp::dvector6::Zero();
+                // xi_ref(2) = 0.00 * sin(tm * M_PI / max_tm * 4);
+                return xi_ref;
+            }
+        };
+
+        calcRefParamTest0* calcRef = new calcRefParamTest0();
+        executeAndPlot(max_tm, calcRef);
+    }
+
+    void test1()
+    {
+        std::cerr << "test1 : Control All Momentum with lleg and rarm constraint" << std::endl;
+        setResetPose();
+
+        double max_tm = 4.0;
+        hrp::dvector6 Svec;
+        Svec << 1, 1, 1, 1, 1, 1;
+        rmc->setSelectionMatrix(Svec);
+        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["rarm"]] = hrp::dvector6::Zero(6, 1);
+
+        for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
+            rmc->addConstraintLink(m_robot, (*it).first);
+        }
+
+        class calcRefParamTest1 : public calcReferenceParameter
+        {
+        public:
+            hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
                 Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
@@ -232,11 +330,8 @@ public:
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
-        };
 
-
-        struct L {
-            static hrp::Vector3 calcL(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
                 Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
@@ -244,91 +339,63 @@ public:
                 Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
+            hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
+            {
+                hrp::dvector6 xi_ref = hrp::dvector6::Zero();
+                return xi_ref;
+            }
         };
-        executeAndPlot(max_tm, P::calcP, L::calcL);
+
+        calcRefParamTest1* calcRef = new calcRefParamTest1();
+        executeAndPlot(max_tm, calcRef);
     }
 
-    void test1()
+    void test2()
     {
-        std::cerr << "test1 : Move only P_z" << std::endl;
+        std::cerr << "test2 : Control All Momentum with arms constraints" << std::endl;
         setResetPose();
 
         double max_tm = 4.0;
         hrp::dvector6 Svec;
         Svec << 1, 1, 1, 1, 1, 1;
         rmc->setSelectionMatrix(Svec);
-        xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
-        xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["rarm"]] = hrp::dvector6::Zero(6, 1);
+        xi_ref[end_effectors["larm"]] = hrp::dvector6::Zero(6, 1);
 
         for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
             rmc->addConstraintLink(m_robot, (*it).first);
         }
 
-        struct P {
-            static hrp::Vector3 calcP(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+        class calcRefParamTest2 : public calcReferenceParameter
+        {
+        public:
+            hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0;
-                Pref(1) = 0;
-                Pref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
-        };
 
-
-        struct L {
-            static hrp::Vector3 calcL(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
+            hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0;//.2 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0;
-                Lref(2) = 0;
+                Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
+            }
+            hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
+            {
+                hrp::dvector6 xi_ref = hrp::dvector6::Zero();
+                return xi_ref;
             }
         };
 
-        executeAndPlot(max_tm, P::calcP, L::calcL);
-    }
-
-    void test2()
-    {
-        // std::cerr << "test2 : Control All Momentum" << std::endl;
-        // double max_tm = 8.0;
-        // hrp::dvector6 Svec;
-        // Svec << 1, 1, 1, 1, 1, 1;
-        // rmc->setSelectionMatrix(Svec);
-        // xi_ref[end_effectors["rleg"]] = hrp::dvector6::Zero(6, 1);
-        // xi_ref[end_effectors["lleg"]] = hrp::dvector6::Zero(6, 1);
-
-        // for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
-        //     rmc->addConstraintLink(m_robot, (*it).first);
-        // }
-
-        // struct P {
-        //     hrp::Vector3 operator() (const double tm, const double max_tm)
-        //     {
-        //         hrp::Vector3 Pref;
-        //         Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
-        //         Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
-        //         Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
-        //         Pref *= m_robot->totalMass();
-        //         return Pref;
-        //     }
-        // };
-
-        // struct L {
-        //     hrp::Vector3 operator() (const double tm, const double max_tm)
-        //     {
-        //         hrp::Vector3 Lref;
-        //         Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-        //         Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-        //         Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
-        //         return Lref;
-        //     }
-        // };
-
-        // executeAndPlot(max_tm, P(), L());
+        calcRefParamTest2* calcRef = new calcRefParamTest2();
+        executeAndPlot(max_tm, calcRef);
     }
 
     void parseParams()
@@ -353,13 +420,13 @@ protected:
     void setResetPose()
     {
         // Reset Pose
-        double reset_pose_joints[] = {-0.004457, -21.692900, -0.012020, 47.672300, -25.930000, 0.014025,
+        double reset_pose_angles[] = {-0.004457, -21.692900, -0.012020, 47.672300, -25.930000, 0.014025,
                                       17.835600, -9.137590, -6.611880, -36.456000, 0.000000, 0.000000, 0.000000,
                                       -0.004457, -21.692900, -0.012020, 47.672300, -25.930000, 0.014025,
                                       17.835600, 9.137590, 6.611880, -36.456000, 0.000000, 0.000000, 0.000000,
                                       0.000000, 0.000000, 0.000000};
         for (size_t i = 0; i < m_robot->numJoints(); ++i) {
-            m_robot->joint(i)->q += deg2rad(reset_pose_joints[i]);
+            m_robot->joint(i)->q += deg2rad(reset_pose_angles[i]);
         }
         m_robot->calcForwardKinematics();
     }
@@ -386,9 +453,9 @@ void print_usage ()
 {
     std::cerr << "Usage : testResolvedMomentumControl [option]" << std::endl;
     std::cerr << " [option] should be:" << std::endl;
-    std::cerr << "  --test0 : Control All Momentum" << std::endl;
-    std::cerr << "  --test1 : Control All Momentum" << std::endl;
-    std::cerr << "  --test2 : Control All Momentum" << std::endl;
+    std::cerr << "  --test0 : Control All Momentum with legs constraint" << std::endl;
+    std::cerr << "  --test1 : Control All Momentum with lleg and rarm constraint" << std::endl;
+    std::cerr << "  --test2 : Control All Momentum with arms constraints" << std::endl;
 }
 
 int main(int argc, char* argv[])

--- a/rtc/AutoBalancer/testResolvedMomentumControl.cpp
+++ b/rtc/AutoBalancer/testResolvedMomentumControl.cpp
@@ -61,7 +61,7 @@ private:
     {
         std::string fname("/tmp/plot.dat");
         // FILE* fp = fopen(fname.c_str(), "w");
-        std::ofstream fp("/tmp/plot.dat");
+        std::ofstream fp(fname.c_str());
         hrp::Vector3 Pref, Lref, cur_basePos, ref_basePos, P, L, CM;
         hrp::Matrix33 cur_baseRot, ref_baseRot;
 
@@ -140,19 +140,19 @@ private:
                << " " << L(1)
                << " " << Lref(2)
                << " " << L(2);
-            for (size_t i = 0; i < dq.size(); ++i) {
-                fp << " " << dq(i);
-            }
+            // for (size_t i = 0; i < dq.size(); ++i) {
+            //     fp << " " << dq(i);
+            // }
             fp << "\n";
         }
 
         for (std::map<std::string, hrp::dvector6>::iterator it = xi_ref.begin(); it != xi_ref.end(); ++it) {
             rmc->removeConstraintLink(m_robot, (*it).first, xi_ref);
         }
-        delete(calcRef);
+        delete calcRef;
         // fclose(fp);
 
-        size_t gpsize = 3;
+        size_t gpsize = 2;
         size_t start = 2;
         FILE* gps[gpsize];
         for (size_t ii = 0; ii < gpsize; ii++) {
@@ -208,21 +208,21 @@ private:
         // }
 
         // dq
-        {
-            std::ostringstream oss("");
-            std::string gtitle("dq");
-            oss << "set multiplot layout 1, 1 title '" << gtitle << "'" << std::endl;
-            oss << "set xlabel 'Time [s]'" << std::endl;
-            oss << "set ylabel '" << "[rad / s]'" << std::endl;
-            oss << "plot ";
-            size_t i;
-            for (i = 0; i < m_robot->numJoints() - 1; ++i) {
-                oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "',";
-            }
-            oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "'";
-            oss << std::endl;
-            plot_and_save(gps[2], gtitle, oss.str());
-        }
+        // {
+        //     std::ostringstream oss("");
+        //     std::string gtitle("dq");
+        //     oss << "set multiplot layout 1, 1 title '" << gtitle << "'" << std::endl;
+        //     oss << "set xlabel 'Time [s]'" << std::endl;
+        //     oss << "set ylabel '" << "[rad / s]'" << std::endl;
+        //     oss << "plot ";
+        //     size_t i;
+        //     for (i = 0; i < m_robot->numJoints() - 1; ++i) {
+        //         oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "',";
+        //     }
+        //     oss << "'" << fname << "' using 1:" << (start + i) << " with lines title '" << m_robot->joint(i)->name << "'";
+        //     oss << std::endl;
+        //     plot_and_save(gps[2], gtitle, oss.str());
+        // }
 
         double tmp;
         std::cin >> tmp;
@@ -275,9 +275,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.02 * sin(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -285,9 +285,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.002 * sin(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.1 * sin(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.2 * sin(tm * M_PI / max_tm * 4);
                 return Lref;
             }
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
@@ -324,9 +324,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -334,9 +334,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)
@@ -372,9 +372,9 @@ public:
             hrp::Vector3 calcPref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Pref;
-                Pref(0) = 0.001 * cos(tm * M_PI / max_tm * 4);
-                Pref(1) = 0.001 * sin(tm * M_PI / max_tm * 4);
-                Pref(2) = 0.002 * cos(tm * M_PI / max_tm * 4);
+                Pref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
+                Pref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
+                Pref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
                 Pref *= m_robot->totalMass();
                 return Pref;
             }
@@ -382,9 +382,9 @@ public:
             hrp::Vector3 calcLref(const hrp::BodyPtr m_robot, const double tm, const double max_tm)
             {
                 hrp::Vector3 Lref;
-                Lref(0) = 0.01 * cos(tm * M_PI / max_tm * 4);
-                Lref(1) = 0.01 * sin(tm * M_PI / max_tm * 4);
-                Lref(2) = 0.02 * cos(tm * M_PI / max_tm * 4);
+                Lref(0) = 0.1 * cos(tm * M_PI / max_tm * 4);
+                Lref(1) = 0.1 * sin(tm * M_PI / max_tm * 4);
+                Lref(2) = 0.2 * cos(tm * M_PI / max_tm * 4);
                 return Lref;
             }
             hrp::dvector6 calcXiref(const hrp::BodyPtr m_robot, const std::string &constraint, const double tm, const double max_tm)


### PR DESCRIPTION
分解運動量制御の実装と，AutoBalancerでIKの代わりに使うことができるようなインターフェースを書きました．
デフォルトではIKのままで，AutoBalancerを切った状態でdefault_ik_typeを変えることでRMCを使用することができます．
つま先関節などについて対応しきれていないので使用には注意が必要ですが，一度PRを送らせていただきます．