### PR TITLE
Update footorigincoords in OCTD and ABC/ST static balance point calculation

### DIFF
--- a/python/hrpsys_config.py
+++ b/python/hrpsys_config.py
@@ -406,6 +406,8 @@ class HrpsysConfigurator(object):
             if self.rfu:
                 connectPorts(self.st.port("diffFootOriginExtMoment"), self.rfu.port("diffFootOriginExtMoment"))
                 connectPorts(self.rfu.port("refFootOriginExtMoment"), self.abc.port("refFootOriginExtMoment"))
+            if self.octd:
+                connectPorts(self.abc.port("contactStates"), self.octd.port("contactStates"))
 
         # ref force moment connection
         for sen in self.getForceSensorNames():

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -2010,19 +2010,14 @@ void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point,
   for (size_t j = 0; j < 2; j++) {
     nume(j) = mg * tmpcog(j);
     denom(j) = mg;
-    for (size_t i = 0; i < sensor_names.size(); i++) {
-      if ( sensor_names[i].find("hsensor") != std::string::npos || sensor_names[i].find("asensor") != std::string::npos ) { // tempolary to get arm force coords
-          hrp::Link* parentlink;
-          hrp::ForceSensor* sensor = m_robot->sensor<hrp::ForceSensor>(sensor_names[i]);
-          if (sensor) parentlink = sensor->link;
-          else parentlink = m_vfs[sensor_names[i]].link;
-          for ( std::map<std::string, ABCIKparam>::iterator it = ikp.begin(); it != ikp.end(); it++ ) {
-              if (it->second.target_link->name == parentlink->name) {
-                  hrp::Vector3 fpos = parentlink->p + parentlink->R * it->second.localPos;
-                  nume(j) += ( (fpos(2) - ref_com_height) * tmp_forces[i](j) - fpos(j) * tmp_forces[i](2) );
-                  denom(j) -= tmp_forces[i](2);
-              }
-          }
+    for ( std::map<std::string, ABCIKparam>::iterator it = ikp.begin(); it != ikp.end(); it++ ) {
+      // Check leg_names. leg_names is assumed to be support limb for locomotion, cannot be used for manipulation. If it->first is not included in leg_names, use it for manipulation and static balance point calculation.
+      if (std::find(leg_names.begin(), leg_names.end(), it->first) == leg_names.end()) {
+        size_t idx = contact_states_index_map[it->first];
+        // Force applied point is assumed as end effector
+        hrp::Vector3 fpos = it->second.target_link->p + it->second.target_link->R * it->second.localPos;
+        nume(j) += ( (fpos(2) - ref_com_height) * tmp_forces[idx](j) - fpos(j) * tmp_forces[idx](2) );
+        denom(j) -= tmp_forces[idx](2);
       }
     }
     if ( use_force == MODE_REF_FORCE_WITH_FOOT ) {

--- a/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.cpp
+++ b/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.cpp
@@ -43,6 +43,7 @@ ObjectContactTurnaroundDetector::ObjectContactTurnaroundDetector(RTC::Manager* m
       // <rtc-template block="initializer">
       m_qCurrentIn("qCurrent", m_qCurrent),
       m_rpyIn("rpy", m_rpy),
+      m_contactStatesIn("contactStates", m_contactStates),
       m_otdDataOut("otdData", m_otdData),
       m_ObjectContactTurnaroundDetectorServicePort("ObjectContactTurnaroundDetectorService"),
       // </rtc-template>
@@ -68,6 +69,7 @@ RTC::ReturnCode_t ObjectContactTurnaroundDetector::onInitialize()
     // Set InPort buffers
     addInPort("qCurrent", m_qCurrentIn);
     addInPort("rpy", m_rpyIn);
+    addInPort("contactStates", m_contactStatesIn);
 
     // Set OutPort buffer
     addOutPort("otdData", m_otdDataOut);
@@ -156,6 +158,7 @@ RTC::ReturnCode_t ObjectContactTurnaroundDetector::onInitialize()
             }
             eet.localR = Eigen::AngleAxis<double>(tmpv[3], hrp::Vector3(tmpv[0], tmpv[1], tmpv[2])).toRotationMatrix(); // rotation in VRML is represented by axis + angle
             eet.target_name = ee_target;
+            eet.index = i;
             ee_map.insert(std::pair<std::string, ee_trans>(ee_name , eet));
             base_name_map.insert(std::pair<std::string, std::string>(ee_name, ee_base));
             std::cerr << "[" << m_profile.instance_name << "] End Effector [" << ee_name << "]" << ee_target << " " << ee_base << std::endl;
@@ -163,6 +166,7 @@ RTC::ReturnCode_t ObjectContactTurnaroundDetector::onInitialize()
             std::cerr << "[" << m_profile.instance_name << "]   localPos = " << eet.localPos.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << "[m]" << std::endl;
             std::cerr << "[" << m_profile.instance_name << "]   localR = " << eet.localR.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", "\n", "    [", "]")) << std::endl;
         }
+        m_contactStates.data.length(num);
     }
 
     // initialize sensor_names
@@ -263,6 +267,9 @@ RTC::ReturnCode_t ObjectContactTurnaroundDetector::onExecute(RTC::UniqueId ec_id
       m_qCurrentIn.read();
       m_otdData.tm = m_qCurrent.tm;
     }
+    if (m_contactStatesIn.isNew()) {
+      m_contactStatesIn.read();
+    }
     if ( m_qCurrent.data.length() ==  m_robot->numJoints() &&
          ee_map.find("rleg") != ee_map.end() && ee_map.find("lleg") != ee_map.end() ) { // if legged robot
         Guard guard(m_mutex);
@@ -326,7 +333,11 @@ void ObjectContactTurnaroundDetector::calcFootOriginCoords (hrp::Vector3& foot_o
   std::vector<rats::coordinates> leg_c_v;
   hrp::Vector3 ez = hrp::Vector3::UnitZ();
   hrp::Vector3 ex = hrp::Vector3::UnitX();
-  std::vector<std::string> leg_names = boost::assign::list_of("rleg")("lleg");
+  std::vector<std::string> leg_names;
+  for ( std::map<std::string, ee_trans>::iterator it = ee_map.begin(); it != ee_map.end(); it++ ) {
+      // If rleg or lleg, and if reference contact states is true
+      if (it->first.find("leg") != std::string::npos && m_contactStates.data[it->second.index]) leg_names.push_back(it->first);
+  }
   for (size_t i = 0; i < leg_names.size(); i++) {
     hrp::Link* target_link = m_robot->link(ee_map[leg_names[i]].target_name);
     rats::coordinates leg_c(hrp::Vector3(target_link->p + target_link->R * ee_map[leg_names[i]].localPos), hrp::Matrix33(target_link->R * ee_map[leg_names[i]].localR));
@@ -339,10 +350,15 @@ void ObjectContactTurnaroundDetector::calcFootOriginCoords (hrp::Vector3& foot_o
     leg_c.rot(0,2) = ez(0); leg_c.rot(1,2) = ez(1); leg_c.rot(2,2) = ez(2);
     leg_c_v.push_back(leg_c);
   }
-  rats::coordinates tmpc;
-  rats::mid_coords(tmpc, 0.5, leg_c_v[0], leg_c_v[1]);
-  foot_origin_pos = tmpc.pos;
-  foot_origin_rot = tmpc.rot;
+  if (leg_names.size() == 2) {
+    rats::coordinates tmpc;
+    rats::mid_coords(tmpc, 0.5, leg_c_v[0], leg_c_v[1]);
+    foot_origin_pos = tmpc.pos;
+    foot_origin_rot = tmpc.rot;
+  } else { // size = 1
+    foot_origin_pos = leg_c_v[0].pos;
+    foot_origin_rot = leg_c_v[0].rot;
+  }
 }
 
 void ObjectContactTurnaroundDetector::calcObjectContactTurnaroundDetectorState()

--- a/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.cpp
+++ b/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.cpp
@@ -321,6 +321,30 @@ void ObjectContactTurnaroundDetector::calcFootMidCoords (hrp::Vector3& new_foot_
   rats::mid_rot(new_foot_mid_rot, 0.5, foot_rot[0], foot_rot[1]);
 }
 
+void ObjectContactTurnaroundDetector::calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matrix33& foot_origin_rot)
+{
+  std::vector<rats::coordinates> leg_c_v;
+  hrp::Vector3 ez = hrp::Vector3::UnitZ();
+  hrp::Vector3 ex = hrp::Vector3::UnitX();
+  std::vector<std::string> leg_names = boost::assign::list_of("rleg")("lleg");
+  for (size_t i = 0; i < leg_names.size(); i++) {
+    hrp::Link* target_link = m_robot->link(ee_map[leg_names[i]].target_name);
+    rats::coordinates leg_c(hrp::Vector3(target_link->p + target_link->R * ee_map[leg_names[i]].localPos), hrp::Matrix33(target_link->R * ee_map[leg_names[i]].localR));
+    hrp::Vector3 xv1(leg_c.rot * ex);
+    xv1(2)=0.0;
+    xv1.normalize();
+    hrp::Vector3 yv1(ez.cross(xv1));
+    leg_c.rot(0,0) = xv1(0); leg_c.rot(1,0) = xv1(1); leg_c.rot(2,0) = xv1(2);
+    leg_c.rot(0,1) = yv1(0); leg_c.rot(1,1) = yv1(1); leg_c.rot(2,1) = yv1(2);
+    leg_c.rot(0,2) = ez(0); leg_c.rot(1,2) = ez(1); leg_c.rot(2,2) = ez(2);
+    leg_c_v.push_back(leg_c);
+  }
+  rats::coordinates tmpc;
+  rats::mid_coords(tmpc, 0.5, leg_c_v[0], leg_c_v[1]);
+  foot_origin_pos = tmpc.pos;
+  foot_origin_rot = tmpc.rot;
+}
+
 void ObjectContactTurnaroundDetector::calcObjectContactTurnaroundDetectorState()
 {
     // TODO
@@ -335,7 +359,8 @@ void ObjectContactTurnaroundDetector::calcObjectContactTurnaroundDetectorState()
     std::vector<hrp::Vector3> otd_fmv, otd_hposv;
     hrp::Vector3 fmpos;
     hrp::Matrix33 fmrot, fmrotT;
-    calcFootMidCoords(fmpos, fmrot);
+    //calcFootMidCoords(fmpos, fmrot);
+    calcFootOriginCoords(fmpos, fmrot);
     fmrotT = fmrot.transpose();
     for (unsigned int i=0; i<m_forceIn.size(); i++) {
         std::string sensor_name = m_forceIn[i]->name();

--- a/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.h
+++ b/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.h
@@ -147,6 +147,7 @@ class ObjectContactTurnaroundDetector
 
   void updateRootLinkPosRot (TimedOrientation3D tmprpy);
   void calcFootMidCoords (hrp::Vector3& new_foot_mid_pos, hrp::Matrix33& new_foot_mid_rot);
+  void calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matrix33& foot_origin_rot);
   void calcObjectContactTurnaroundDetectorState();
 
   std::map<std::string, ee_trans> ee_map;

--- a/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.h
+++ b/rtc/ObjectContactTurnaroundDetector/ObjectContactTurnaroundDetector.h
@@ -110,6 +110,8 @@ class ObjectContactTurnaroundDetector
   std::vector<InPort<TimedDoubleSeq> *> m_forceIn;
   TimedOrientation3D m_rpy;
   InPort<TimedOrientation3D> m_rpyIn;
+  TimedBooleanSeq m_contactStates;
+  InPort<TimedBooleanSeq> m_contactStatesIn;
   
   // </rtc-template>
 
@@ -143,6 +145,7 @@ class ObjectContactTurnaroundDetector
     std::string target_name, sensor_name;
     hrp::Vector3 localPos;
     hrp::Matrix33 localR;
+    size_t index;
   };
 
   void updateRootLinkPosRot (TimedOrientation3D tmprpy);

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -87,7 +87,11 @@ public:
     };
     inline bool is_inside_support_polygon (Eigen::Vector2d& p, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot, const std::vector<std::string>& ee_name, const leg_type& support_leg, const std::vector<double>& tmp_margin = std::vector<double>(), const hrp::Vector3& offset = hrp::Vector3(0.0, 0.0, 0.0), bool calc_nearest_point = false)
     {
+      // vector size zero check
       if (ee_pos.size() == 0 || ee_rot.size() == 0 || ee_name.size() == 0 ) return true;
+      // vector size check
+      //   TODO : currently 2 feet is supported.
+      if ( !(ee_pos.size() == 2 && ee_rot.size() == 2 && ee_name.size() == 2) ) return true;
       size_t l_idx, r_idx;
       for (size_t i = 0; i < ee_name.size(); i++) {
         if (ee_name[i]=="rleg") r_idx = i;


### PR DESCRIPTION
OCTD/ABC/STのいくつかの変更をまとめました。
- OCTD
支持足座標系を実姿勢を反映するfootorigin coords計算のものを使うようにしました(https://github.com/snozawa/hrpsys-base/commit/023db8750883978708669e8e714be90cda056b0a)
支持足をABCがだすrefrenceなcontact statesで計算するようにしました(https://github.com/snozawa/hrpsys-base/commit/258b18164bd010c24308fecb708628d225e8404b)
- ST/ABC
片足立ちでも良いように修正しました。

よろしくお願いします。