### PR TITLE
readDataPort、writeDataPort関数で毎回コネクタを生成しないようにする変更

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -757,7 +757,7 @@ def readDataPort(port, timeout=1.0, disconnect=True):
 ##
 # \brief 
 #
-def delete_all_connector_list():
+def deleteAllConnector():
     global connector_list
     for port in connector_list:
         port["port"].disconnect(port["prof"].connector_id)


### PR DESCRIPTION
readDataPort、writeDataPort関数でコネクタを毎回生成しないように変更しました。
OpenRTM-aistのポートプロファイルに送信データを格納する機能は1.2.0では無くなることになったので、"dataport.data_value"のプロパティからデータを取得する部分は削除しました。
