### PR TITLE
Add inside limitation

### DIFF
--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -199,7 +199,7 @@ module OpenHRP
       /// Ratio of double support period after swing. Ratio is included in (0, 1).
       double default_double_support_ratio_swing_after;
       /// Stride limitation of forward x[m], y[m], theta[deg], and backward x[m] for goPos
-      sequence<double, 4> stride_parameter;
+      sequence<double, 6> stride_parameter;
       /// Stride limitation when generating footsteps with stride limitation type CIRCLE (forward, outside, theta, backward, inside) [m]
       DblArray5 stride_limitation_for_circle_type;
       /// Default OrbitType

--- a/idl/AutoBalancerService.idl
+++ b/idl/AutoBalancerService.idl
@@ -198,7 +198,7 @@ module OpenHRP
       double default_double_support_ratio_swing_before;
       /// Ratio of double support period after swing. Ratio is included in (0, 1).
       double default_double_support_ratio_swing_after;
-      /// Stride limitation of forward x[m], y[m], theta[deg], and backward x[m] for goPos
+      /// Stride limitation of forward x[m], outside y[m], outside theta[deg], backward x[m], inside y[m], inside theta[deg] for goPos and goVelocity
       sequence<double, 6> stride_parameter;
       /// Stride limitation when generating footsteps with stride limitation type CIRCLE (forward, outside, theta, backward, inside) [m]
       DblArray5 stride_limitation_for_circle_type;

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -279,15 +279,15 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
 
     // setting stride limitations from conf file
     double stride_fwd_x_limit = 0.15;
-    double stride_y_limit = 0.05;
-    double stride_th_limit = 10;
+    double stride_outside_y_limit = 0.05;
+    double stride_outside_th_limit = 10;
     double stride_bwd_x_limit = 0.05;
-    std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_y_limit << "[m], " << stride_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
+    std::cerr << "[" << m_profile.instance_name << "] abc_stride_parameter : " << stride_fwd_x_limit << "[m], " << stride_outside_y_limit << "[m], " << stride_outside_th_limit << "[deg], " << stride_bwd_x_limit << "[m]" << std::endl;
     if (default_zmp_offsets.size() == 0) {
       for (size_t i = 0; i < ikp.size(); i++) default_zmp_offsets.push_back(hrp::Vector3::Zero());
     }
     if (leg_offset_str.size() > 0) {
-      gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, leg_names, stride_fwd_x_limit/*[m]*/, stride_y_limit/*[m]*/, stride_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
+      gg = ggPtr(new rats::gait_generator(m_dt, leg_pos, leg_names, stride_fwd_x_limit/*[m]*/, stride_outside_y_limit/*[m]*/, stride_outside_th_limit/*[deg]*/, stride_bwd_x_limit/*[m]*/));
       gg->set_default_zmp_offsets(default_zmp_offsets);
     }
     gg_is_walking = gg_solved = false;

--- a/rtc/AutoBalancer/AutoBalancerService_impl.cpp
+++ b/rtc/AutoBalancer/AutoBalancerService_impl.cpp
@@ -67,7 +67,7 @@ CORBA::Boolean AutoBalancerService_impl::setGaitGeneratorParam(const OpenHRP::Au
 CORBA::Boolean AutoBalancerService_impl::getGaitGeneratorParam(OpenHRP::AutoBalancerService::GaitGeneratorParam_out i_param)
 {
   i_param = new OpenHRP::AutoBalancerService::GaitGeneratorParam();
-  i_param->stride_parameter.length(4);
+  i_param->stride_parameter.length(6);
   i_param->toe_heel_phase_ratio.length(7);
   i_param->zmp_weight_map.length(4);
   return m_autobalancer->getGaitGeneratorParam(*i_param);

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -993,13 +993,13 @@ namespace rats
     dth = cur_vel_param.velocity_theta + offset_vel_param.velocity_theta;
     /* velocity limitation by stride parameters <- this should be based on footstep candidates */
     if (default_stride_limitation_type == SQUARE) {
-      dth = std::max(-1 * footstep_param.stride_theta / default_step_time, std::min(footstep_param.stride_theta / default_step_time, dth));
+      dth = std::max(-1 * footstep_param.stride_outside_theta / default_step_time, std::min(footstep_param.stride_outside_theta / default_step_time, dth));
     } else if (default_stride_limitation_type == CIRCLE) {
       dth = std::max(-1 * stride_limitation_for_circle_type[2] / default_step_time, std::min(stride_limitation_for_circle_type[2] / default_step_time, dth));
     }
     if (default_stride_limitation_type == SQUARE) {
       dx  = std::max(-1 * footstep_param.stride_bwd_x / default_step_time, std::min(footstep_param.stride_fwd_x / default_step_time, dx ));
-      dy  = std::max(-1 * footstep_param.stride_y     / default_step_time, std::min(footstep_param.stride_y     / default_step_time, dy ));
+      dy  = std::max(-1 * footstep_param.stride_outside_y     / default_step_time, std::min(footstep_param.stride_outside_y     / default_step_time, dy ));
       /* inside step limitation */
       if (use_inside_step_limitation) {
         if (dy > 0) {

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -991,6 +991,7 @@ namespace rats
     ref_coords.pos += ref_coords.rot * tmpv;
     double dx = cur_vel_param.velocity_x + offset_vel_param.velocity_x, dy = cur_vel_param.velocity_y + offset_vel_param.velocity_y;
     dth = cur_vel_param.velocity_theta + offset_vel_param.velocity_theta;
+    //std::cerr << "Before limit dx " << dx << " dy " << dy << " dth " << dth << std::endl;
     /* velocity limitation by stride parameters <- this should be based on footstep candidates */
     if (default_stride_limitation_type == SQUARE) {
       dth = std::max(-1 * footstep_param.stride_outside_theta / default_step_time, std::min(footstep_param.stride_outside_theta / default_step_time, dth));
@@ -1003,17 +1004,30 @@ namespace rats
       /* inside step limitation */
       if (use_inside_step_limitation) {
         if (dy > 0) {
-            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dy *= 0.5;
+            // If dy>0 (== leftward step) and LLEG/LARM support, do inside limitation
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) {
+                dy  = std::min(footstep_param.stride_inside_y     / default_step_time, dy);
+            }
         } else {
-            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dy *= 0.5;
+            // If dy<=0 (== rightward step) and RLEG/RARM support, do inside limitation
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) {
+                dy  = std::max(-1 * footstep_param.stride_inside_y     / default_step_time, dy);
+            }
         }
         if (dth > 0) {
-            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) dth *= 0.5;
+            // If dth>0 (== leftward turn step) and LLEG/LARM support, do inside limitation
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == LLEG || &boost::lambda::_1->* &step_node::l_r == LARM)) > 0) {
+                dth = std::min(footstep_param.stride_inside_theta / default_step_time, dth);
+            }
         } else {
-            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) dth *= 0.5;
+            // If dth<=0 (== rightward turn step) and RLEG/RARM support, do inside limitation
+            if (std::count_if(sup_fns.begin(), sup_fns.end(), (&boost::lambda::_1->* &step_node::l_r == RLEG || &boost::lambda::_1->* &step_node::l_r == RARM)) > 0) {
+                dth = std::max(-1 * footstep_param.stride_inside_theta / default_step_time, dth);
+            }
         }
       }
     }
+    //std::cerr << "After Limit dx " << dx << " dy " << dy << " dth " << dth << std::endl;
     trans = hrp::Vector3(dx * default_step_time, dy * default_step_time, 0);
     dth = deg2rad(dth * default_step_time);
   };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -75,11 +75,13 @@ namespace rats
          */
         std::vector<hrp::Vector3> leg_default_translate_pos;
         /* stride params indicate max stride ( [mm], [mm], [deg] ) */
-        double stride_fwd_x, stride_outside_y, stride_outside_theta, stride_bwd_x;
+        double stride_fwd_x, stride_outside_y, stride_outside_theta, stride_bwd_x, stride_inside_y, stride_inside_theta;
         footstep_parameter (const std::vector<hrp::Vector3>& _leg_pos,
-                            const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
+                            const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta,
+                            const double _stride_bwd_x, const double _stride_inside_y, const double _stride_inside_theta)
             : leg_default_translate_pos(_leg_pos),
-              stride_fwd_x(_stride_fwd_x), stride_outside_y(_stride_outside_y), stride_outside_theta(_stride_outside_theta), stride_bwd_x(_stride_bwd_x) {};
+              stride_fwd_x(_stride_fwd_x), stride_outside_y(_stride_outside_y), stride_outside_theta(_stride_outside_theta),
+              stride_bwd_x(_stride_bwd_x), stride_inside_y(_stride_inside_y), stride_inside_theta(_stride_inside_theta) {};
     };
 
     /* velocity parameter for velocity mode */
@@ -1101,9 +1103,10 @@ namespace rats
     gait_generator (double _dt,
                     /* arguments for footstep_parameter */
                     const std::vector<hrp::Vector3>& _leg_pos, std::vector<std::string> _all_limbs,
-                    const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
+                    const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta,
+                    const double _stride_bwd_x, const double _stride_inside_y, const double _stride_inside_theta)
         : footstep_nodes_list(), overwrite_footstep_nodes_list(), rg(_dt), lcg(_dt),
-        footstep_param(_leg_pos, _stride_fwd_x, _stride_outside_y, _stride_outside_theta, _stride_bwd_x),
+        footstep_param(_leg_pos, _stride_fwd_x, _stride_outside_y, _stride_outside_theta, _stride_bwd_x, _stride_inside_y, _stride_inside_theta),
         vel_param(), offset_vel_param(), thtc(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()), diff_cp(hrp::Vector3::Zero()), modified_d_footstep(hrp::Vector3::Zero()),
         dt(_dt), all_limbs(_all_limbs), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0), overwritable_footstep_index_offset(1),
@@ -1224,12 +1227,15 @@ namespace rats
     {
       offset_vel_param.set(vel_x, vel_y, vel_theta);
     };
-    void set_stride_parameters (const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
+    void set_stride_parameters (const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta,
+                                const double _stride_bwd_x, const double _stride_inside_y, const double _stride_inside_theta)
     {
       footstep_param.stride_fwd_x = _stride_fwd_x;
       footstep_param.stride_outside_y = _stride_outside_y;
       footstep_param.stride_outside_theta = _stride_outside_theta;
       footstep_param.stride_bwd_x = _stride_bwd_x;
+      footstep_param.stride_inside_y = _stride_inside_y;
+      footstep_param.stride_inside_theta = _stride_inside_theta;
     };
     void set_use_inside_step_limitation(const bool uu) { use_inside_step_limitation = uu; };
     void set_default_orbit_type (const orbit_type type) { lcg.set_default_orbit_type(type); };
@@ -1421,12 +1427,15 @@ namespace rats
       return tmp;
     };
     void get_swing_support_mid_coords(coordinates& ret) const { lcg.get_swing_support_mid_coords(ret); };
-    void get_stride_parameters (double& _stride_fwd_x, double& _stride_outside_y, double& _stride_outside_theta, double& _stride_bwd_x) const
+    void get_stride_parameters (double& _stride_fwd_x, double& _stride_outside_y, double& _stride_outside_theta,
+                                double& _stride_bwd_x, double& _stride_inside_y, double& _stride_inside_theta) const
     {
       _stride_fwd_x = footstep_param.stride_fwd_x;
       _stride_outside_y = footstep_param.stride_outside_y;
       _stride_outside_theta = footstep_param.stride_outside_theta;
       _stride_bwd_x = footstep_param.stride_bwd_x;
+      _stride_inside_y = footstep_param.stride_inside_y;
+      _stride_inside_theta = footstep_param.stride_inside_theta;
     };
     size_t get_footstep_index() const { return lcg.get_footstep_index(); };
     size_t get_lcg_count() const { return lcg.get_lcg_count(); };
@@ -1537,9 +1546,10 @@ namespace rats
 #endif // FOR_TESTGAITGENERATOR
     void print_param (const std::string& print_str = "") const
     {
-        double stride_fwd_x, stride_y, stride_th, stride_bwd_x;
-        get_stride_parameters(stride_fwd_x, stride_y, stride_th, stride_bwd_x);
-        std::cerr << "[" << print_str << "]   stride_parameter = " << stride_fwd_x << "[m], " << stride_y << "[m], " << stride_th << "[deg], " << stride_bwd_x << "[m]" << std::endl;
+        double stride_fwd_x, stride_outside_y, stride_outside_th, stride_bwd_x, stride_inside_y, stride_inside_th;
+        get_stride_parameters(stride_fwd_x, stride_outside_y, stride_outside_th, stride_bwd_x, stride_inside_y, stride_inside_th);
+        std::cerr << "[" << print_str << "]   stride_parameter = " << stride_fwd_x << "[m], " << stride_outside_y << "[m], " << stride_outside_th << "[deg], "
+                  << stride_bwd_x << "[m], " << stride_inside_y << "[m], " << stride_inside_th << "[deg]" << std::endl;
         std::cerr << "[" << print_str << "]   leg_default_translate_pos = ";
         for (size_t i = 0; i < footstep_param.leg_default_translate_pos.size(); i++) {
             std::cerr << footstep_param.leg_default_translate_pos[i].format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]"));

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -75,11 +75,11 @@ namespace rats
          */
         std::vector<hrp::Vector3> leg_default_translate_pos;
         /* stride params indicate max stride ( [mm], [mm], [deg] ) */
-        double stride_fwd_x, stride_y, stride_theta, stride_bwd_x;
+        double stride_fwd_x, stride_outside_y, stride_outside_theta, stride_bwd_x;
         footstep_parameter (const std::vector<hrp::Vector3>& _leg_pos,
-                            const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
+                            const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
             : leg_default_translate_pos(_leg_pos),
-              stride_fwd_x(_stride_fwd_x), stride_y(_stride_y), stride_theta(_stride_theta), stride_bwd_x(_stride_bwd_x)  {};
+              stride_fwd_x(_stride_fwd_x), stride_outside_y(_stride_outside_y), stride_outside_theta(_stride_outside_theta), stride_bwd_x(_stride_bwd_x) {};
     };
 
     /* velocity parameter for velocity mode */
@@ -1101,9 +1101,9 @@ namespace rats
     gait_generator (double _dt,
                     /* arguments for footstep_parameter */
                     const std::vector<hrp::Vector3>& _leg_pos, std::vector<std::string> _all_limbs,
-                    const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
+                    const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
         : footstep_nodes_list(), overwrite_footstep_nodes_list(), rg(_dt), lcg(_dt),
-        footstep_param(_leg_pos, _stride_fwd_x, _stride_y, _stride_theta, _stride_bwd_x),
+        footstep_param(_leg_pos, _stride_fwd_x, _stride_outside_y, _stride_outside_theta, _stride_bwd_x),
         vel_param(), offset_vel_param(), thtc(), cog(hrp::Vector3::Zero()), refzmp(hrp::Vector3::Zero()), prev_que_rzmp(hrp::Vector3::Zero()), diff_cp(hrp::Vector3::Zero()), modified_d_footstep(hrp::Vector3::Zero()),
         dt(_dt), all_limbs(_all_limbs), default_step_time(1.0), default_double_support_ratio_before(0.1), default_double_support_ratio_after(0.1), default_double_support_static_ratio_before(0.0), default_double_support_static_ratio_after(0.0), default_double_support_ratio_swing_before(0.1), default_double_support_ratio_swing_after(0.1), gravitational_acceleration(DEFAULT_GRAVITATIONAL_ACCELERATION),
         finalize_count(0), optional_go_pos_finalize_footstep_num(0), overwrite_footstep_index(0), overwritable_footstep_index_offset(1),
@@ -1224,11 +1224,11 @@ namespace rats
     {
       offset_vel_param.set(vel_x, vel_y, vel_theta);
     };
-    void set_stride_parameters (const double _stride_fwd_x, const double _stride_y, const double _stride_theta, const double _stride_bwd_x)
+    void set_stride_parameters (const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta, const double _stride_bwd_x)
     {
       footstep_param.stride_fwd_x = _stride_fwd_x;
-      footstep_param.stride_y = _stride_y;
-      footstep_param.stride_theta = _stride_theta;
+      footstep_param.stride_outside_y = _stride_outside_y;
+      footstep_param.stride_outside_theta = _stride_outside_theta;
       footstep_param.stride_bwd_x = _stride_bwd_x;
     };
     void set_use_inside_step_limitation(const bool uu) { use_inside_step_limitation = uu; };
@@ -1421,11 +1421,11 @@ namespace rats
       return tmp;
     };
     void get_swing_support_mid_coords(coordinates& ret) const { lcg.get_swing_support_mid_coords(ret); };
-    void get_stride_parameters (double& _stride_fwd_x, double& _stride_y, double& _stride_theta, double& _stride_bwd_x) const
+    void get_stride_parameters (double& _stride_fwd_x, double& _stride_outside_y, double& _stride_outside_theta, double& _stride_bwd_x) const
     {
       _stride_fwd_x = footstep_param.stride_fwd_x;
-      _stride_y = footstep_param.stride_y;
-      _stride_theta = footstep_param.stride_theta;
+      _stride_outside_y = footstep_param.stride_outside_y;
+      _stride_outside_theta = footstep_param.stride_outside_theta;
       _stride_bwd_x = footstep_param.stride_bwd_x;
     };
     size_t get_footstep_index() const { return lcg.get_footstep_index(); };

--- a/rtc/AutoBalancer/GaitGenerator.h
+++ b/rtc/AutoBalancer/GaitGenerator.h
@@ -71,11 +71,11 @@ namespace rats
     struct footstep_parameter
     {
         /* translate pos is translate position of a leg from default foot_midcoords
-         *   vector -> (list rleg-pos[mm] lleg-pos[mm] )
+         *   vector -> (list rleg-pos[m] lleg-pos[m] )
          */
         std::vector<hrp::Vector3> leg_default_translate_pos;
-        /* stride params indicate max stride ( [mm], [mm], [deg] ) */
-        double stride_fwd_x, stride_outside_y, stride_outside_theta, stride_bwd_x, stride_inside_y, stride_inside_theta;
+        /* stride params indicate max stride */
+        double stride_fwd_x/*[m]*/, stride_outside_y/*[m]*/, stride_outside_theta/*[deg]*/, stride_bwd_x/*[m]*/, stride_inside_y/*[m]*/, stride_inside_theta/*[deg]*/;
         footstep_parameter (const std::vector<hrp::Vector3>& _leg_pos,
                             const double _stride_fwd_x, const double _stride_outside_y, const double _stride_outside_theta,
                             const double _stride_bwd_x, const double _stride_inside_y, const double _stride_inside_theta)

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -944,7 +944,7 @@ public:
         gg->set_heel_zmp_offset_x(-105*1e-3);
         gg->set_toe_pos_offset_x(137*1e-3);
         gg->set_heel_pos_offset_x(-105*1e-3);
-        gg->set_stride_parameters(0.2,0.1,20,0.2);
+        gg->set_stride_parameters(0.2,0.1,20,0.2,0.1*0.5,20*0.5);
         gg->set_use_toe_heel_auto_set(true);
         gg->set_toe_angle(30);
         gg->set_heel_angle(10);
@@ -1334,7 +1334,7 @@ class testGaitGeneratorHRP2JSK : public testGaitGenerator
             leg_pos.push_back(hrp::Vector3(0,1e-3* 105,0)); /* lleg */
             all_limbs.push_back("rleg");
             all_limbs.push_back("lleg");
-            gg = new gait_generator(dt, leg_pos, all_limbs, 1e-3*150, 1e-3*50, 10, 1e-3*50);
+            gg = new gait_generator(dt, leg_pos, all_limbs, 1e-3*150, 1e-3*50, 10, 1e-3*50, 1e-3*50*0.5, 10*0.5);
         };
 };
 

--- a/rtc/AutoBalancer/testGaitGenerator.cpp
+++ b/rtc/AutoBalancer/testGaitGenerator.cpp
@@ -1230,6 +1230,40 @@ public:
         plot_and_print_errorcheck ();
     };
 
+    void test19 ()
+    {
+        test_doc_string = "test19 : Change stride parameter (translate)";
+        /* initialize sample footstep_list */
+        parse_params();
+        std::vector<hrp::Vector3> dzo;
+        dzo.push_back(hrp::Vector3(20*1e-3,-30*1e-3,0));
+        dzo.push_back(hrp::Vector3(20*1e-3,30*1e-3,0));
+        gg->set_default_zmp_offsets(dzo);
+        gg->set_stride_parameters(0.25,0.15,25,0.25,0.1,10);
+        gg->clear_footstep_nodes_list();
+        coordinates start_ref_coords;
+        mid_coords(start_ref_coords, 0.5, coordinates(leg_pos[1]), coordinates(leg_pos[0]));
+        gg->go_pos_param_2_footstep_nodes_list(600*1e-3, -300*1e-3, 0, boost::assign::list_of(coordinates(leg_pos[1])), start_ref_coords, boost::assign::list_of(LLEG));
+        gen_and_plot_walk_pattern();
+    };
+
+    void test20 ()
+    {
+        test_doc_string = "test20 : Change stride parameter (translate+rotate)";
+        /* initialize sample footstep_list */
+        parse_params();
+        std::vector<hrp::Vector3> dzo;
+        dzo.push_back(hrp::Vector3(20*1e-3,-30*1e-3,0));
+        dzo.push_back(hrp::Vector3(20*1e-3,30*1e-3,0));
+        gg->set_default_zmp_offsets(dzo);
+        gg->set_stride_parameters(0.25,0.15,25,0.25,0.1,10);
+        gg->clear_footstep_nodes_list();
+        coordinates start_ref_coords;
+        mid_coords(start_ref_coords, 0.5, coordinates(leg_pos[1]), coordinates(leg_pos[0]));
+        gg->go_pos_param_2_footstep_nodes_list(400*1e-3, -200*1e-3, -55, boost::assign::list_of(coordinates(leg_pos[1])), start_ref_coords, boost::assign::list_of(LLEG));
+        gen_and_plot_walk_pattern();
+    };
+
     void parse_params (bool is_print_doc_setring = true)
     {
       if (is_print_doc_setring) std::cerr << test_doc_string << std::endl;
@@ -1361,6 +1395,8 @@ void print_usage ()
     std::cerr << "  --test16 : Set foot steps with param (toe heel contact)" << std::endl;
     std::cerr << "  --test17 : Test goVelocity (dx = 0.1, dy = 0.05, dth = 10.0)" << std::endl;
     std::cerr << "  --test18 : Test goVelocity with changing velocity (translation and rotation)" << std::endl;
+    std::cerr << "  --test19 : Change stride parameter (translate)" << std::endl;
+    std::cerr << "  --test20 : Change stride parameter (translate+rotate)" << std::endl;
     std::cerr << " [option] should be:" << std::endl;
     std::cerr << "  --use-gnuplot : Use gnuplot and dump eps file to /tmp. (true/false, true by default)" << std::endl;
     std::cerr << "  --use-graph-append : Append generated graph to /tmp/testGaitGenerator.jpg. (true/false, false by default)" << std::endl;
@@ -1413,6 +1449,10 @@ int main(int argc, char* argv[])
           tgg.test17();
       } else if (std::string(argv[1]) == "--test18") {
           tgg.test18();
+      } else if (std::string(argv[1]) == "--test19") {
+          tgg.test19();
+      } else if (std::string(argv[1]) == "--test20") {
+          tgg.test20();
       } else {
           print_usage();
           ret = 1;


### PR DESCRIPTION
https://github.com/fkanehiro/hrpsys-base/issues/1166
の歩幅制限についてのPRです。

あらたにパラメタが４＝＞６に増えてますが、
4つのパラメタで指定しているデフォルトのものでも動作するようにしました。

１点、@YutaKojioと相談しつつ内側の歩幅制約で0.5倍かけてたところをかけなくしました。
挙動は若干かわりますが、最大値はかわらないので、各ロボットで干渉しないのをモデル上確認しました。
（最大値は同じで、最大値の範囲内なら若干あるくのが早くなる）

よろしくお願いします。