### PR TITLE
calculate convex hull from n-sided polygon's vertices

### DIFF
--- a/idl/StabilizerService.idl
+++ b/idl/StabilizerService.idl
@@ -171,7 +171,7 @@ module OpenHRP
       double eefm_ee_rot_error_p_gain;
       /// Pos rot error cutoff freq [Hz]
       double eefm_ee_error_cutoff_freq;
-      /// Sequence of vertices for all end effectors
+      /// Sequence of vertices for all end effectors assuming that the order is (rleg, lleg, rarm, larm)
       sequence< SupportPolygonVertices > eefm_support_polygon_vertices_sequence;
       /// Use force difference control or each limb force control. True by default.
       boolean eefm_use_force_difference_control;

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -2196,6 +2196,7 @@ void Stabilizer::setParameter(const OpenHRP::StabilizerService::stParam& i_stp)
   for (size_t i = 0; i < cp_check_margin.size(); i++) {
     cp_check_margin[i] = i_stp.cp_check_margin[i];
   }
+  szd->set_vertices_from_margin_params(cp_check_margin);
   for (size_t i = 0; i < tilt_margin.size(); i++) {
     tilt_margin[i] = i_stp.tilt_margin[i];
   }

--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -951,13 +951,9 @@ void Stabilizer::getActualParameters ()
       // truncate ZMP
       if (use_zmp_truncation) {
         Eigen::Vector2d tmp_new_refzmp(new_refzmp.head(2));
-        SimpleZMPDistributor::leg_type support_leg;
-        if (ref_contact_states[contact_states_index_map["rleg"]] && ref_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::BOTH;
-        else if (ref_contact_states[contact_states_index_map["rleg"]]) support_leg = SimpleZMPDistributor::RLEG;
-        else if (ref_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::LLEG;
-        if (!szd->is_inside_support_polygon(tmp_new_refzmp, ee_pos, ee_rot, ee_name, support_leg, std::vector<double>(), hrp::Vector3(0.0, 0.0, 0.0), true)){
-          new_refzmp.head(2) = tmp_new_refzmp;
-        }
+        szd->get_vertices(support_polygon_vetices);
+        szd->calc_convex_hull(support_polygon_vetices, ref_contact_states, ee_pos, ee_rot);
+        if (!szd->is_inside_support_polygon(tmp_new_refzmp, hrp::Vector3::Zero(), true, std::string(m_profile.instance_name))) new_refzmp.head(2) = tmp_new_refzmp;
       }
 
       // Distribute ZMP into each EE force/moment at each COP
@@ -1335,20 +1331,10 @@ void Stabilizer::calcStateForEmergencySignal()
   // CP Check
   bool is_cp_outside = false;
   if (on_ground && transition_count == 0 && control_mode == MODE_ST) {
-    SimpleZMPDistributor::leg_type support_leg;
-    size_t l_idx, r_idx;
-    Eigen::Vector2d tmp_cp;
-    for (size_t i = 0; i < rel_ee_name.size(); i++) {
-      if (rel_ee_name[i]=="rleg") r_idx = i;
-      else if (rel_ee_name[i]=="lleg") l_idx = i;
-    }
-    for (size_t i = 0; i < 2; i++) {
-      tmp_cp(i) = act_cp(i);
-    }
-    if (act_contact_states[contact_states_index_map["rleg"]] && act_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::BOTH;
-    else if (act_contact_states[contact_states_index_map["rleg"]]) support_leg = SimpleZMPDistributor::RLEG;
-    else if (act_contact_states[contact_states_index_map["lleg"]]) support_leg = SimpleZMPDistributor::LLEG;
-    if (!is_walking || is_estop_while_walking) is_cp_outside = !szd->is_inside_support_polygon(tmp_cp, rel_ee_pos, rel_ee_rot, rel_ee_name, support_leg, cp_check_margin, - sbp_cog_offset);
+    Eigen::Vector2d tmp_cp = act_cp.head(2);
+    szd->get_margined_vertices(margined_support_polygon_vetices);
+    szd->calc_convex_hull(margined_support_polygon_vetices, act_contact_states, rel_ee_pos, rel_ee_rot);
+    if (!is_walking || is_estop_while_walking) is_cp_outside = !szd->is_inside_support_polygon(tmp_cp, - sbp_cog_offset);
     if (DEBUGP) {
       std::cerr << "[" << m_profile.instance_name << "] CP value " << "[" << act_cp(0) << "," << act_cp(1) << "] [m], "
                 << "sbp cog offset [" << sbp_cog_offset(0) << " " << sbp_cog_offset(1) << "], outside ? "

--- a/rtc/Stabilizer/Stabilizer.h
+++ b/rtc/Stabilizer/Stabilizer.h
@@ -311,6 +311,7 @@ class Stabilizer
   boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_cogvel_filter;
   OpenHRP::StabilizerService::STAlgorithm st_algorithm;
   SimpleZMPDistributor* szd;
+  std::vector<std::vector<Eigen::Vector2d> > support_polygon_vetices, margined_support_polygon_vetices;
   // TPCC
   double k_tpcc_p[2], k_tpcc_x[2], d_rpy[2], k_brot_p[2], k_brot_tc[2];
   // RUN ST

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -55,7 +55,7 @@ public:
 
 class SimpleZMPDistributor
 {
-    FootSupportPolygon fs;
+    FootSupportPolygon fs, fs_mgn;
     double leg_inside_margin, leg_outside_margin, leg_front_margin, leg_rear_margin, wrench_alpha_blending;
     boost::shared_ptr<FirstOrderLowPassFilter<double> > alpha_filter;
 public:
@@ -239,6 +239,30 @@ public:
         // }
         set_vertices(vec);
     };
+    // Set vertices only for cp_check_margin for now
+    void set_vertices_from_margin_params (const std::vector<double>& margin)
+    {
+      std::vector<std::vector<Eigen::Vector2d> > vec;
+      // RLEG
+      {
+        std::vector<Eigen::Vector2d> tvec;
+        tvec.push_back(Eigen::Vector2d(leg_front_margin - margin[0], leg_inside_margin - margin[2]));
+        tvec.push_back(Eigen::Vector2d(leg_front_margin - margin[0], -1*(leg_outside_margin - margin[3])));
+        tvec.push_back(Eigen::Vector2d(-1*(leg_rear_margin - margin[1]), -1*(leg_outside_margin - margin[3])));
+        tvec.push_back(Eigen::Vector2d(-1*(leg_rear_margin - margin[1]), leg_inside_margin - margin[2]));
+        vec.push_back(tvec);
+      }
+      // LLEG
+      {
+        std::vector<Eigen::Vector2d> tvec;
+        tvec.push_back(Eigen::Vector2d(leg_front_margin - margin[0], leg_inside_margin - margin[3]));
+        tvec.push_back(Eigen::Vector2d(leg_front_margin - margin[0], -1*(leg_outside_margin - margin[2])));
+        tvec.push_back(Eigen::Vector2d(-1*(leg_rear_margin - margin[1]), -1*(leg_outside_margin - margin[2])));
+        tvec.push_back(Eigen::Vector2d(-1*(leg_rear_margin - margin[1]), leg_inside_margin - margin[3]));
+        vec.push_back(tvec);
+      }
+      fs_mgn.set_vertices(vec);
+    };
     // getter
     double get_wrench_alpha_blending () { return wrench_alpha_blending; };
     double get_leg_front_margin () { return leg_front_margin; };
@@ -247,6 +271,7 @@ public:
     double get_leg_outside_margin () { return leg_outside_margin; };
     double get_alpha_cutoff_freq () { return alpha_filter->getCutOffFreq(); };
     void get_vertices (std::vector<std::vector<Eigen::Vector2d> >& vs) { fs.get_vertices(vs); };
+    void get_margined_vertices (std::vector<std::vector<Eigen::Vector2d> >& vs) { fs_mgn.get_vertices(vs); };
     //
     double calcAlpha (const hrp::Vector3& tmprefzmp,
                       const std::vector<hrp::Vector3>& ee_pos,

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -78,13 +78,6 @@ public:
     {
         return leg_pos(0) <= (-1 * leg_rear_margin + margin);
     };
-    inline bool is_cp_inside_foot (const hrp::Vector3& cp, const leg_type support_leg, const double margin = 0.0, const double offset = 0.0)
-    {
-        if (support_leg == RLEG) return (cp(1) <= (leg_inside_margin - margin)) && (cp(1) >= (-1 * leg_outside_margin + margin)) && (cp(0) <= (leg_front_margin - margin)) && (cp(0) >= (-1 * leg_rear_margin + margin));
-        else if (support_leg == LLEG) return (cp(1) >= (-1 * leg_inside_margin + margin)) && (cp(1) <= (leg_outside_margin - margin)) && (cp(0) <= (leg_front_margin - margin)) && (cp(0) >= (-1 * leg_rear_margin + margin));
-        else if (support_leg == BOTH) return (cp(1) <= (leg_outside_margin + offset - margin)) && (cp(1) >= (-1 * (leg_outside_margin + offset) + margin)) && (cp(0) <= (leg_front_margin - margin)) && (cp(0) >= (-1 * leg_rear_margin + margin));
-        else return true;
-    };
     inline bool is_inside_support_polygon (Eigen::Vector2d& p, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot, const std::vector<std::string>& ee_name, const leg_type& support_leg, const std::vector<double>& tmp_margin = std::vector<double>(), const hrp::Vector3& offset = hrp::Vector3(0.0, 0.0, 0.0), bool calc_nearest_point = false)
     {
       // vector size zero check

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -58,6 +58,8 @@ class SimpleZMPDistributor
     FootSupportPolygon fs, fs_mgn;
     double leg_inside_margin, leg_outside_margin, leg_front_margin, leg_rear_margin, wrench_alpha_blending;
     boost::shared_ptr<FirstOrderLowPassFilter<double> > alpha_filter;
+    std::vector<Eigen::Vector2d> convex_hull;
+    enum projected_point_region {LEFT, MIDDLE, RIGHT};
 public:
     enum leg_type {RLEG, LLEG, RARM, LARM, BOTH, ALL};
     SimpleZMPDistributor (const double _dt) : wrench_alpha_blending (0.5)
@@ -78,96 +80,33 @@ public:
     {
         return leg_pos(0) <= (-1 * leg_rear_margin + margin);
     };
-    inline bool is_inside_support_polygon (Eigen::Vector2d& p, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot, const std::vector<std::string>& ee_name, const leg_type& support_leg, const std::vector<double>& tmp_margin = std::vector<double>(), const hrp::Vector3& offset = hrp::Vector3(0.0, 0.0, 0.0), bool calc_nearest_point = false)
+    inline bool is_inside_support_polygon (Eigen::Vector2d& p, const hrp::Vector3& offset = hrp::Vector3::Zero(), const bool& truncate_p = false, const std::string& str = "")
     {
-      // vector size zero check
-      if (ee_pos.size() == 0 || ee_rot.size() == 0 || ee_name.size() == 0 ) return true;
-      // vector size check
-      //   TODO : currently 2 feet is supported.
-      if ( !(ee_pos.size() == 2 && ee_rot.size() == 2 && ee_name.size() == 2) ) return true;
-      size_t l_idx, r_idx;
-      for (size_t i = 0; i < ee_name.size(); i++) {
-        if (ee_name[i]=="rleg") r_idx = i;
-        else if (ee_name[i]=="lleg") l_idx = i;
-      }
-      std::vector<Eigen::Vector2d> rleg_vertices;
-      std::vector<Eigen::Vector2d> lleg_vertices;
-      std::vector<Eigen::Vector2d> convex_vertices;
-
-      // assume that each foot vertices has four vertices
-      std::vector<double> margin(4, 0.0);
-      for (size_t i = 0; i < tmp_margin.size(); i++) {
-        margin[i] = tmp_margin[i];
-      }
-      // RLEG
-      rleg_vertices.push_back(Eigen::Vector2d(ee_pos[r_idx](0) + leg_front_margin - margin[0] + offset(0), ee_pos[r_idx](1) + leg_inside_margin - margin[2] + offset(1)));
-      rleg_vertices.push_back(Eigen::Vector2d(ee_pos[r_idx](0) + leg_front_margin - margin[0] + offset(0), ee_pos[r_idx](1) + -1*(leg_outside_margin - margin[3]) + offset(1)));
-      rleg_vertices.push_back(Eigen::Vector2d(ee_pos[r_idx](0) + -1*(leg_rear_margin - margin[1]) + offset(0), ee_pos[r_idx](1) + -1*(leg_outside_margin - margin[3]) + offset(1)));
-      rleg_vertices.push_back(Eigen::Vector2d(ee_pos[r_idx](0) + -1*(leg_rear_margin - margin[1]) + offset(0), ee_pos[r_idx](1) + leg_inside_margin - margin[2] + offset(1)));
-      // LLEG
-      lleg_vertices.push_back(Eigen::Vector2d(ee_pos[l_idx](0) + leg_front_margin - margin[0] + offset(0), ee_pos[l_idx](1) + leg_outside_margin - margin[3] + offset(1)));
-      lleg_vertices.push_back(Eigen::Vector2d(ee_pos[l_idx](0) + leg_front_margin - margin[0] + offset(0), ee_pos[l_idx](1) + -1*(leg_inside_margin - margin[2]) + offset(1)));
-      lleg_vertices.push_back(Eigen::Vector2d(ee_pos[l_idx](0) + -1*(leg_rear_margin - margin[1]) + offset(0), ee_pos[l_idx](1) + -1*(leg_inside_margin - margin[2]) + offset(1)));
-      lleg_vertices.push_back(Eigen::Vector2d(ee_pos[l_idx](0) + -1*(leg_rear_margin - margin[1]) + offset(0), ee_pos[l_idx](1) + leg_outside_margin - margin[3] + offset(1)));
-
-      if (support_leg == BOTH) {
-        // sort vertices in clockwise order
-        convex_vertices.push_back(lleg_vertices[0]);
-        convex_vertices.push_back(lleg_vertices[1]);
-        std::copy(rleg_vertices.begin(),rleg_vertices.end(),std::back_inserter(convex_vertices));
-        convex_vertices.push_back(lleg_vertices[2]);
-        convex_vertices.push_back(lleg_vertices[3]);
-        convex_vertices = calcConvexHull(convex_vertices);
-      } else if (support_leg == RLEG) {
-        convex_vertices = rleg_vertices;
-      } else if (support_leg == LLEG) {
-        convex_vertices = lleg_vertices;
-      }
-      // check whether p is inside support polygon
-      if (!calc_nearest_point) {
-        for (size_t i = 0; i < convex_vertices.size() - 1; i++) {
-          if (calcCrossProduct(p, convex_vertices[i + 1], convex_vertices[i]) < 0) return false;
-        }
-        if (calcCrossProduct(p, convex_vertices.front(), convex_vertices.back()) < 0) return false;
-        return true;
-      }
-      // calc nearest point
-      bool is_inside = true;
-      double cur_nearest_dist, nearest_dist;
-      Eigen::Vector2d cur_nearest_point, nearest_point;
-      if (calcCrossProduct(p, convex_vertices.front(), convex_vertices.back()) < 0) { // is outside
-        if (calcProjectedPoint(cur_nearest_point, p, convex_vertices.front(), convex_vertices.back())) { // projected point is on line
-          p = cur_nearest_point;
-          return false;
-        } else { // projected point is not on line
-          nearest_dist = (cur_nearest_point - p).norm();
-          nearest_point = cur_nearest_point;
-        }
-        is_inside = false;
-      }
-      for (size_t i = 0; i < convex_vertices.size() - 1; i++) {
-        if (calcCrossProduct(p, convex_vertices[i + 1], convex_vertices[i]) < 0) { // is outside
-          if (calcProjectedPoint(cur_nearest_point, p, convex_vertices[i + 1], convex_vertices[i])) { // projected point is on line
-            p = cur_nearest_point;
-            return false;
-          } else { // projected point is not on line
-            cur_nearest_dist = (cur_nearest_point - p).norm();
-            if (is_inside || i == 0) { // first set
-              nearest_dist = cur_nearest_dist;
-              nearest_point = cur_nearest_point;
-            } else if (cur_nearest_dist < nearest_dist) { // update nearest candidate
-              nearest_dist = cur_nearest_dist;
-              nearest_point = cur_nearest_point;
-            }
-          }
-          is_inside = false;
-        }
-      }
-      if (is_inside) {
-          return true;
+      // set any inner point(ip) and binary search two vertices(convex_hull[v_a], convex_hull[v_b]) between which p is.
+      p -= offset.head(2);
+      size_t n_ch = convex_hull.size();
+      Eigen::Vector2d ip = (convex_hull[0] + convex_hull[n_ch/3] + convex_hull[2*n_ch/3]) / 3.0;
+      size_t v_a = 0, v_b = n_ch;
+      while (v_a + 1 < v_b) {
+        size_t v_c = (v_a + v_b) / 2;
+        if (calcCrossProduct(convex_hull[v_a], convex_hull[v_c], ip) > 0) {
+          if (calcCrossProduct(convex_hull[v_a], p, ip) > 0 && calcCrossProduct(convex_hull[v_c], p, ip) < 0) v_b = v_c;
+          else v_a = v_c;
         } else {
-          p = nearest_point;
-          return false;
+          if (calcCrossProduct(convex_hull[v_a], p, ip) < 0 && calcCrossProduct(convex_hull[v_c], p, ip) > 0) v_a = v_c;
+          else v_b = v_c;
+        }
+      }
+      v_b %= n_ch;
+      if (calcCrossProduct(convex_hull[v_a], convex_hull[v_b], p) >= 0) {
+        p += offset.head(2);
+        return true;
+      } else {
+        if (truncate_p) {
+          if (!calc_closest_boundary_point(p, v_a, v_b)) std::cerr << "[" << str << "]   Cannot calculate closest boundary point on the convex hull" << std::endl;
+        }
+        p += offset.head(2);
+        return false;
       }
     };
     void print_params (const std::string& str)
@@ -179,6 +118,64 @@ public:
     {
         fs.print_vertices(str);
     };
+    // Compare Vector2d for sorting lexicographically
+    static bool compare_eigen2d(const Eigen::Vector2d& lv, const Eigen::Vector2d& rv)
+    {
+      return lv(0) < rv(0) || (lv(0) == rv(0) && lv(1) < rv(1));
+    };
+    // Calculate 2D convex hull based on Andrew's algorithm
+    // Assume that the order of vs, ee, and cs is the same
+    void calc_convex_hull (const std::vector<std::vector<Eigen::Vector2d> >& vs, const std::vector<bool>& cs, const std::vector<hrp::Vector3>& ee_pos, const std::vector <hrp::Matrix33>& ee_rot)
+    {
+      // transform coordinate
+      std::vector<Eigen::Vector2d>  tvs;
+      hrp::Vector3 tpos;
+      tvs.reserve(cs.size()*vs[0].size());
+      for (size_t i = 0; i < cs.size(); i++) {
+        if (cs[i]) {
+          for (size_t j = 0; j < vs[i].size(); j++) {
+            tpos = ee_pos[i] + ee_rot[i] * hrp::Vector3(vs[i][j](0), vs[i][j](1), 0.0);
+            tvs.push_back(tpos.head(2));
+          }
+        }
+      }
+      // calculate convex hull
+      int n_tvs = tvs.size(), n_ch = 0;
+      convex_hull.resize(2*n_tvs);
+      std::sort(tvs.begin(), tvs.end(), compare_eigen2d);
+      for (int i = 0; i < n_tvs; convex_hull[n_ch++] = tvs[i++])
+        while (n_ch >= 2 && calcCrossProduct(convex_hull[n_ch-1], tvs[i], convex_hull[n_ch-2]) <= 0) n_ch--;
+      for (int i = n_tvs-2, j = n_ch+1; i >= 0; convex_hull[n_ch++] = tvs[i--])
+        while (n_ch >= j && calcCrossProduct(convex_hull[n_ch-1], tvs[i], convex_hull[n_ch-2]) <= 0) n_ch--;
+      convex_hull.resize(n_ch-1);
+    };
+    // Calculate closest boundary point on the convex hull
+    bool calc_closest_boundary_point (Eigen::Vector2d& p, size_t& right_idx, size_t& left_idx) {
+      size_t n_ch = convex_hull.size();
+      Eigen::Vector2d cur_closest_point;
+      for (size_t i; i < n_ch; i++) {
+        switch(calcProjectedPoint(cur_closest_point, p, convex_hull[left_idx], convex_hull[right_idx])) {
+        case MIDDLE:
+          p = cur_closest_point;
+          return true;
+        case LEFT:
+          right_idx = left_idx;
+          left_idx = (left_idx + 1) % n_ch;
+          if ((p - convex_hull[right_idx]).dot(convex_hull[left_idx] - convex_hull[right_idx]) <= 0) {
+            p = cur_closest_point;
+            return true;
+          }
+        case RIGHT:
+          left_idx = right_idx;
+          right_idx = (right_idx - 1) % n_ch;
+          if ((p - convex_hull[left_idx]).dot(convex_hull[right_idx] - convex_hull[left_idx]) <= 0) {
+            p = cur_closest_point;
+            return true;
+          }
+        }
+      }
+      return false;
+    }
     // setter
     void set_wrench_alpha_blending (const double a) { wrench_alpha_blending = a; };
     void set_leg_front_margin (const double a) { leg_front_margin = a; };
@@ -1123,45 +1120,31 @@ public:
         }
     };
 
-  double calcCrossProduct(Eigen::Vector2d& a, Eigen::Vector2d& b, Eigen::Vector2d& o)
+  double calcCrossProduct(const Eigen::Vector2d& a, const Eigen::Vector2d& b, const Eigen::Vector2d& o)
   {
     return (a(0) - o(0)) * (b(1) - o(1)) - (a(1) - o(1)) * (b(0) - o(0));
   };
 
-  bool calcProjectedPoint(Eigen::Vector2d& ret, Eigen::Vector2d& target, Eigen::Vector2d& a, Eigen::Vector2d& b){
+  projected_point_region calcProjectedPoint(Eigen::Vector2d& ret, const Eigen::Vector2d& target, const Eigen::Vector2d& a, const Eigen::Vector2d& b){
     Eigen::Vector2d v1 = target - b;
     Eigen::Vector2d v2 = a - b;
     double v2_norm = v2.norm();
     if ( v2_norm = 0 ) {
         ret = a;
-        return false;
+        return LEFT;
     } else {
         double ratio = v1.dot(v2) / (v2_norm * v2_norm);
         if (ratio < 0){
             ret = b;
-            return false;
+            return RIGHT;
         } else if (ratio > 1){
             ret = a;
-            return false;
+            return LEFT;
         } else {
             ret = b + ratio * v2;
-            return true;
+            return MIDDLE;
         }
     }
-  };
-
-  // assume that vertices are listed in clockwise order
-  std::vector<Eigen::Vector2d> calcConvexHull(std::vector<Eigen::Vector2d> vertices)
-  {
-    std::vector<Eigen::Vector2d> convex_vertices;
-
-    convex_vertices.push_back(vertices.front());
-    for (size_t i = 1; i < vertices.size() - 1; i++) {
-      if (calcCrossProduct(vertices[i + 1], vertices[i - 1], vertices[i]) < 0) convex_vertices.push_back(vertices[i]);
-    }
-    convex_vertices.push_back(vertices.back());
-
-    return convex_vertices;
   };
 };
 

--- a/rtc/Stabilizer/ZMPDistributor.h
+++ b/rtc/Stabilizer/ZMPDistributor.h
@@ -1129,7 +1129,7 @@ public:
     Eigen::Vector2d v1 = target - b;
     Eigen::Vector2d v2 = a - b;
     double v2_norm = v2.norm();
-    if ( v2_norm = 0 ) {
+    if ( v2_norm == 0 ) {
         ret = a;
         return LEFT;
     } else {


### PR DESCRIPTION
今まで，支持多角形を求めるおよび支持多角形の内包判定で，各足の頂点を矩形かつ時計まわりでセットされいることを想定していたのを，任意の多角形でも使えるようにしました．
qhull, boost, opencv等のライブラリを使うことも考えましたが，バージョンの古いロボットで使えることやわかりやすさを考慮して，今回は関数を実装することにしました．

また，```eefm_support_polygon_vertices_sequence```が現状，rleg, lleg, rarm, larmの順で並んでいる前提になっていたので，その順であることをコメントに追加しました．
順不同にする変更は今後のTODOです．

@Tnoriaki 
new_refzmpの打ち切りの部分も変更したので大丈夫そうか確認お願いします．

よろしくお願いします．
