### PR TITLE
[CameraImageViewer] support RTC::CameraImage

### DIFF
--- a/rtc/CameraImageViewer/CameraImageViewer.cpp
+++ b/rtc/CameraImageViewer/CameraImageViewer.cpp
@@ -34,6 +34,7 @@ CameraImageViewer::CameraImageViewer(RTC::Manager* manager)
     : RTC::DataFlowComponentBase(manager),
       // <rtc-template block="initializer">
       m_imageIn("imageIn", m_image),
+      m_imageOldIn("imageOldIn", m_imageOld),
       // </rtc-template>
       m_cvImage(NULL),
       dummy(0)
@@ -59,6 +60,7 @@ RTC::ReturnCode_t CameraImageViewer::onInitialize()
     // <rtc-template block="registration">
     // Set InPort buffers
     addInPort("imageIn", m_imageIn);
+    addInPort("imageOldIn", m_imageOldIn);
 
     // Set OutPort buffer
   
@@ -180,6 +182,44 @@ RTC::ReturnCode_t CameraImageViewer::onExecute(RTC::UniqueId ec_id)
         default:
             break;
         }
+    }
+
+    if (m_imageOldIn.isNew()){
+        do {
+            m_imageOldIn.read();
+        }while(m_imageOldIn.isNew());
+        if (m_cvImage && (m_imageOld.width != m_cvImage->width 
+                          || m_imageOld.height != m_cvImage->height)){
+            cvReleaseImage(&m_cvImage);
+            m_cvImage = NULL;
+        }
+        int bytes = m_imageOld.bpp/8;
+        if (!bytes){
+            bytes = m_imageOld.pixels.length()/(m_imageOld.width*m_imageOld.height);
+        }
+        if (!m_cvImage){
+            m_cvImage = cvCreateImage(cvSize(m_imageOld.width,
+                                             m_imageOld.height),
+                                      IPL_DEPTH_8U, bytes);
+        }
+        switch(bytes){
+        case 1:
+            memcpy(m_cvImage->imageData, 
+                   m_imageOld.pixels.get_buffer(),
+                   m_imageOld.pixels.length());
+            break;
+        case 3:
+            // RGB -> BGR
+            char *dst = m_cvImage->imageData;
+            for (unsigned int i=0; i<m_imageOld.pixels.length(); i+=3){
+                dst[i  ] = m_imageOld.pixels[i+2]; 
+                dst[i+1] = m_imageOld.pixels[i+1]; 
+                dst[i+2] = m_imageOld.pixels[i  ]; 
+            }
+            break;
+        }
+    }
+    if (m_cvImage){
         cvShowImage("Image",m_cvImage);
         cvWaitKey(10);
     }

--- a/rtc/CameraImageViewer/CameraImageViewer.h
+++ b/rtc/CameraImageViewer/CameraImageViewer.h
@@ -18,6 +18,7 @@
 #include <rtm/DataInPort.h>
 #include <rtm/DataOutPort.h>
 #include <rtm/idl/BasicDataTypeSkel.h>
+#include <rtm/idl/InterfaceDataTypesSkel.h>
 #include <cv.h>
 #include <highgui.h>
 
@@ -106,10 +107,12 @@ class CameraImageViewer
   // </rtc-template>
 
   Img::TimedCameraImage m_image;
+  CameraImage m_imageOld;
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
   InPort<Img::TimedCameraImage> m_imageIn;
+  InPort<CameraImage> m_imageOldIn;
   
   // </rtc-template>
 


### PR DESCRIPTION
This PR add an input data port named "imageOldIn" to support RTC::CameraImage to CameraImageViewer.
