### PR TITLE
Detect use-after-free of hrpExecutionContext

### DIFF
--- a/ec/hrpEC/hrpEC-common.cpp
+++ b/ec/hrpEC/hrpEC-common.cpp
@@ -11,8 +11,16 @@ namespace RTC
 {
     hrpExecutionContext::~hrpExecutionContext()
     {
+        if (m_thread_pending)
+            abort ();
     }
     int hrpExecutionContext::svc(void)
+    {
+        int ret = svc_wrapped ();
+        m_thread_pending = false;
+        return ret;
+    }
+    int hrpExecutionContext::svc_wrapped(void)
     {
         if (open_iob() == FALSE){
             std::cerr << "open_iob: failed to open" << std::endl;
@@ -189,6 +197,12 @@ namespace RTC
             }
         }
         throw OpenHRP::ExecutionProfileService::ExecutionProfileServiceException("no such component");
+    }
+
+    void hrpExecutionContext::activate ()
+    {
+        m_thread_pending = true;
+        PeriodicExecutionContext::activate ();
     }
 
     void hrpExecutionContext::resetProfile()

--- a/ec/hrpEC/hrpEC.cpp
+++ b/ec/hrpEC/hrpEC.cpp
@@ -33,7 +33,8 @@ namespace RTC
 #else
         : RTC_exp::PeriodicExecutionContext(),
 #endif 
-          m_priority(49)
+          m_priority(49),
+          m_thread_pending (false)
     {
         resetProfile();
         rtclog.setName("hrpEC");

--- a/ec/hrpEC/hrpEC.h
+++ b/ec/hrpEC/hrpEC.h
@@ -35,7 +35,7 @@ namespace RTC
 #ifdef OPENRTM_VERSION_TRUNK
     virtual void tick(){}
 #endif
-    void activate () override;
+    void activate ();
 
     OpenHRP::ExecutionProfileService::Profile *getProfile();
     OpenHRP::ExecutionProfileService::ComponentProfile getComponentProfile(RTC::LightweightRTObject_ptr obj);

--- a/ec/hrpEC/hrpEC.h
+++ b/ec/hrpEC/hrpEC.h
@@ -35,6 +35,7 @@ namespace RTC
 #ifdef OPENRTM_VERSION_TRUNK
     virtual void tick(){}
 #endif
+    void activate () override;
 
     OpenHRP::ExecutionProfileService::Profile *getProfile();
     OpenHRP::ExecutionProfileService::ComponentProfile getComponentProfile(RTC::LightweightRTObject_ptr obj);
@@ -64,10 +65,13 @@ namespace RTC
       }
       fprintf(stderr, "[ms]\n");
     };
+    int svc_wrapped (void);
+
     OpenHRP::ExecutionProfileService::Profile m_profile;
     struct timeval m_tv;
     int m_priority;
     std::vector<std::string> rtc_names;
+    volatile bool m_thread_pending;
   };
 };
 


### PR DESCRIPTION
These changes will hopefully track down why hrpExecutionContext is being freed prematurely.