### PR TITLE
[SoftErrorLimiter] add :mask_joint_limit for disabling to check designated joint

### DIFF
--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.cpp
@@ -153,6 +153,19 @@ RTC::ReturnCode_t SoftErrorLimiter::onInitialize()
   // load joint limit table
   hrp::readJointLimitTableFromProperties (joint_limit_tables, m_robot, prop["joint_limit_table"], std::string(m_profile.instance_name));
 
+  // read ignored joint
+  m_joint_mask.resize(m_robot->numJoints(), false);
+  coil::vstring ijoints = coil::split(prop["mask_joint_limit"], ",");
+  for(int i = 0; i < ijoints.size(); i++) {
+      hrp::Link *lk = m_robot->link(std::string(ijoints[i]));
+      if((!!lk) && (lk->jointId >= 0)) {
+          std::cout << "[" << m_profile.instance_name << "] "
+                    << "disable ErrorLimit, joint : " << ijoints[i]
+                    << " (id = " << lk->jointId << ")" << std::endl;
+          m_joint_mask[lk->jointId] = true;
+      }
+  }
+
   return RTC::RTC_OK;
 }
 
@@ -270,6 +283,7 @@ RTC::ReturnCode_t SoftErrorLimiter::onExecute(RTC::UniqueId ec_id)
 
     // Velocity limitation for reference joint angles
     for ( unsigned int i = 0; i < m_qRef.data.length(); i++ ){
+      if(m_joint_mask[i]) continue;
       // Determin total upper-lower limit considering velocity, position, and error limits.
       // e.g.,
       //  total lower limit = max (vel, pos, err) <= severest lower limit

--- a/rtc/SoftErrorLimiter/SoftErrorLimiter.h
+++ b/rtc/SoftErrorLimiter/SoftErrorLimiter.h
@@ -147,6 +147,7 @@ class SoftErrorLimiter
  private:
   boost::shared_ptr<robot> m_robot;
   std::map<std::string, hrp::JointLimitTable> joint_limit_tables;
+  std::vector<bool> m_joint_mask;
   unsigned int m_debugLevel;
   int dummy, position_limit_error_beep_freq, soft_limit_error_beep_freq, debug_print_freq;
   double dt;


### PR DESCRIPTION
SoftErrorLimiterでconfで指定した関節について無視（limitにかかっているか確認せずに通過させる）するようにしました。