### PR TITLE
fix bug on too large change in COG

### DIFF
--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -1140,8 +1140,17 @@ namespace rats
       rg.update_refzmp();
       sfzos.clear();
     }
+    finalize_count = 0;
     refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
-    solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, refzmp_exist_p);
+    if (!refzmp_exist_p) {
+      finalize_count++;
+      rzmp = prev_que_rzmp;
+      sfzos = prev_que_sfzos;
+    } else {
+      prev_que_rzmp = rzmp;
+      prev_que_sfzos = sfzos;
+    }
+    solved = preview_controller_ptr->update(refzmp, cog, swing_foot_zmp_offsets, rzmp, sfzos, (refzmp_exist_p || finalize_count < preview_controller_ptr->get_delay()-default_step_time/dt));
     rg.update_refzmp();
   };
 

--- a/rtc/AutoBalancer/GaitGenerator.cpp
+++ b/rtc/AutoBalancer/GaitGenerator.cpp
@@ -1137,6 +1137,10 @@ namespace rats
     for (size_t i = overwrite_idx; i < queue_size - 1; i++) {
       refzmp_exist_p = rg.get_current_refzmp(rzmp, sfzos, default_double_support_ratio_before, default_double_support_ratio_after, default_double_support_static_ratio_before, default_double_support_static_ratio_after);
       preview_controller_ptr->set_preview_queue(rzmp, sfzos, i+1);
+      if (refzmp_exist_p) {
+        prev_que_rzmp = rzmp;
+        prev_que_sfzos = sfzos;
+      }
       rg.update_refzmp();
       sfzos.clear();
     }


### PR DESCRIPTION
歩行時に重心が飛ぶバグを３つ修正しました．

- step time が0.8秒以下でgoVelocity すると途中で急停止する
1fd197e
- 歩行終了直前（finalize_count>0）の時に着地位置を変更するとrzmpが新しい着地位置に更新されない
71efaf7
- 歩行終了時に重心が収束しきっていないため，歩行終了直後にcogが飛ぶ（速度にして0.1[m/s]強）
afc60e2

３つ目に関しては他の解決策もあるかもしれないです．

よろしくお願い致します．
