### PR TITLE
[ .travis.sh ] fix apt-key

### DIFF
--- a/.travis.sh
+++ b/.travis.sh
@@ -77,9 +77,9 @@ case $TEST_PACKAGE in
                 travis_time_start  install_python
 
                 #http://askubuntu.com/questions/204510/how-to-install-python-2-5-4
-                sudo apt-add-repository -y ppa:fkrull/deadsnakes
+                sudo apt-add-repository -y ppa:deadsnakes
                 sudo apt-get update -qq
-                sudo apt-get install -qq -y python2.5 python2.7 python3.4
+                sudo apt-get install -qq -y --force-yes python2.5 python2.7 python3.4
 
                 travis_time_end
                 travis_time_start  check_python


### PR DESCRIPTION
11番目のテスト(ROS_DISTRO=indigo TEST_TYPE=python TEST_PACKAGE=hrpsys)が以下のエラーで通らなかったので、キーを追加しました。
~~~
+++ sudo apt-add-repository -y ppa:fkrull/deadsnakes
gpg: keyring `/tmp/tmpdr3jbcvs/secring.gpg' created
gpg: keyring `/tmp/tmpdr3jbcvs/pubring.gpg' created
gpg: "tag:launchpad.net:2008:redacted" not a key ID: skipping
+++ sudo apt-get update -qq
W: GPG error: http://ppa.launchpad.net trusty InRelease: The following signatures couldn't be verified because the public key is not available: NO_PUBKEY 5BB92C09DB82666C
++ sudo apt-get install -qq -y python2.5 python2.7 python3.4
WARNING: The following packages cannot be authenticated!
  python2.5-minimal python2.5
E: There are problems and -y was used without --force-yes
+++ error
+++ travis_time_end 31
+++ set +x
~~~