### PR TITLE
Update for force balancing and filter of reference force updater

### DIFF
--- a/idl/ReferenceForceUpdaterService.idl
+++ b/idl/ReferenceForceUpdaterService.idl
@@ -7,6 +7,7 @@ module OpenHRP
   interface ReferenceForceUpdaterService
   {
       typedef sequence<double, 3> DblSequence3;
+      typedef sequence<string> StrSequence;
 
       /**
        * @struct ReferenceForceUpdaterParam
@@ -79,5 +80,12 @@ module OpenHRP
        * @brief Wait for ReferenceForceUpdater mode transition.
        */
       void waitReferenceForceUpdaterTransition(in string name);
+
+      /**
+       * @brief Get supported name sequence of ReferenceForceUpdater
+       * @param o_param is supported name sequence
+       * @return true if set successfully, false otherwise
+       */
+      boolean getSupportedReferenceForceUpdaterNameSequence(out StrSequence o_names);
   };
 };

--- a/idl/ReferenceForceUpdaterService.idl
+++ b/idl/ReferenceForceUpdaterService.idl
@@ -33,6 +33,8 @@ module OpenHRP
           boolean is_hold_value;
           /// Transition time[s]
           double transition_time;
+          /// Cutoff frequency for actual force value [Hz]
+          double cutoff_freq;
       };
 
       /**

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -333,6 +333,7 @@ RTC::ReturnCode_t AutoBalancer::onInitialize()
         registerInPort(std::string("ref_"+sensor_names[i]).c_str(), *m_ref_forceIn[i]);
         std::cerr << "[" << m_profile.instance_name << "]   name = " << std::string("ref_"+sensor_names[i]) << std::endl;
         ref_forces.push_back(hrp::Vector3(0,0,0));
+        ref_moments.push_back(hrp::Vector3(0,0,0));
     }
     // set force port
     for (unsigned int i=0; i<nforce; i++){
@@ -913,6 +914,7 @@ void AutoBalancer::rotateRefForcesForFixCoords (coordinates& tmp_fix_coords)
       //ref_forces[i] = eeR * hrp::Vector3(m_ref_force[i].data[0], m_ref_force[i].data[1], m_ref_force[i].data[2]);
       // world frame
       ref_forces[i] = tmp_fix_coords.rot * hrp::Vector3(m_ref_force[i].data[0], m_ref_force[i].data[1], m_ref_force[i].data[2]);
+      ref_moments[i] = tmp_fix_coords.rot * hrp::Vector3(m_ref_force[i].data[3], m_ref_force[i].data[4], m_ref_force[i].data[5]);
     }
     sbp_offset = tmp_fix_coords.rot * hrp::Vector3(sbp_offset);
 };
@@ -2066,6 +2068,7 @@ void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point,
                 // Force applied point is assumed as end effector
                 hrp::Vector3 fpos = it->second.target_link->p + it->second.target_link->R * it->second.localPos;
                 nume(j) += ( (fpos(2) - ref_com_height) * ref_forces[idx](j) - fpos(j) * ref_forces[idx](2) );
+                nume(j) += (j==0 ? ref_moments[idx](1):-ref_moments[idx](0));
                 denom(j) -= ref_forces[idx](2);
             }
         }

--- a/rtc/AutoBalancer/AutoBalancer.cpp
+++ b/rtc/AutoBalancer/AutoBalancer.cpp
@@ -2024,21 +2024,21 @@ void AutoBalancer::static_balance_point_proc_one(hrp::Vector3& tmp_input_sbp, co
   if ( use_force == MODE_NO_FORCE ) {
     tmp_input_sbp = tmpcog + sbp_cog_offset;
   } else {
-    calc_static_balance_point_from_forces(target_sbp, tmpcog, ref_com_height, ref_forces);
+    calc_static_balance_point_from_forces(target_sbp, tmpcog, ref_com_height);
     tmp_input_sbp = target_sbp - sbp_offset;
     sbp_cog_offset = tmp_input_sbp - tmpcog;
   }
 };
 
-void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point, const hrp::Vector3& tmpcog, const double ref_com_height, std::vector<hrp::Vector3>& tmp_forces)
+void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point, const hrp::Vector3& tmpcog, const double ref_com_height)
 {
   hrp::Vector3 denom, nume;
   /* sb_point[m] = nume[kg * m/s^2 * m] / denom[kg * m/s^2] */
   double mass = m_robot->totalMass();
   double mg = mass * gg->get_gravitational_acceleration();
   hrp::Vector3 total_sensor_ref_force = hrp::Vector3::Zero();
-  for (size_t i = 0; i < tmp_forces.size(); i++) {
-      total_sensor_ref_force += tmp_forces[i];
+  for (size_t i = 0; i < ref_forces.size(); i++) {
+      total_sensor_ref_force += ref_forces[i];
   }
   hrp::Vector3 total_nosensor_ref_force = mg * hrp::Vector3::UnitZ() - total_sensor_ref_force; // total ref force at the point without sensors, such as torso
   hrp::Vector3 tmp_ext_moment = fix_leg_coords2.pos.cross(total_nosensor_ref_force) + fix_leg_coords2.rot * hrp::Vector3(m_refFootOriginExtMoment.data.x, m_refFootOriginExtMoment.data.y, m_refFootOriginExtMoment.data.z);
@@ -2065,8 +2065,8 @@ void AutoBalancer::calc_static_balance_point_from_forces(hrp::Vector3& sb_point,
                 size_t idx = contact_states_index_map[it->first];
                 // Force applied point is assumed as end effector
                 hrp::Vector3 fpos = it->second.target_link->p + it->second.target_link->R * it->second.localPos;
-                nume(j) += ( (fpos(2) - ref_com_height) * tmp_forces[idx](j) - fpos(j) * tmp_forces[idx](2) );
-                denom(j) -= tmp_forces[idx](2);
+                nume(j) += ( (fpos(2) - ref_com_height) * ref_forces[idx](j) - fpos(j) * ref_forces[idx](2) );
+                denom(j) -= ref_forces[idx](2);
             }
         }
         if ( use_force == MODE_REF_FORCE_WITH_FOOT ) {

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -232,7 +232,7 @@ class AutoBalancer
   void copyRatscoords2Footstep(OpenHRP::AutoBalancerService::Footstep& out_fs, const rats::coordinates& in_fs);
   // static balance point offsetting
   void static_balance_point_proc_one(hrp::Vector3& tmp_input_sbp, const double ref_com_height);
-  void calc_static_balance_point_from_forces(hrp::Vector3& sb_point, const hrp::Vector3& tmpcog, const double ref_com_height, std::vector<hrp::Vector3>& tmp_forces);
+  void calc_static_balance_point_from_forces(hrp::Vector3& sb_point, const hrp::Vector3& tmpcog, const double ref_com_height);
   hrp::Vector3 calc_vel_from_hand_error (const rats::coordinates& tmp_fix_coords);
   bool isOptionalDataContact (const std::string& ee_name)
   {

--- a/rtc/AutoBalancer/AutoBalancer.h
+++ b/rtc/AutoBalancer/AutoBalancer.h
@@ -276,7 +276,7 @@ class AutoBalancer
   // static balance point offsetting
   hrp::Vector3 sbp_offset, sbp_cog_offset;
   enum {MODE_NO_FORCE, MODE_REF_FORCE, MODE_REF_FORCE_WITH_FOOT, MODE_REF_FORCE_RFU_EXT_MOMENT} use_force;
-  std::vector<hrp::Vector3> ref_forces;
+  std::vector<hrp::Vector3> ref_forces, ref_moments;
 
   unsigned int m_debugLevel;
   bool is_legged_robot, is_stop_mode, is_hand_fix_mode, is_hand_fix_initial;

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
@@ -763,6 +763,19 @@ void ReferenceForceUpdater::waitReferenceForceUpdaterTransition(const std::strin
     usleep(1000);
 };
 
+bool ReferenceForceUpdater::getSupportedReferenceForceUpdaterNameSequence(OpenHRP::ReferenceForceUpdaterService::StrSequence_out o_names)
+{
+  std::cerr << "[" << m_profile.instance_name << "] getSupportedReferenceForceUpdaterNameSequence" << std::endl;
+  Guard guard(m_mutex);
+  o_names->length(m_RFUParam.size());
+  size_t i = 0;
+  for (std::map<std::string, ReferenceForceUpdaterParam>::iterator itr = m_RFUParam.begin(); itr != m_RFUParam.end(); itr++ ) {
+      o_names[i] = itr->first.c_str();
+      i++;
+  }
+  return true;
+};
+
 extern "C"
 {
 

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -113,6 +113,7 @@ class ReferenceForceUpdater
   bool startReferenceForceUpdaterNoWait(const std::string& i_name_);
   bool stopReferenceForceUpdaterNoWait(const std::string& i_name_);
   void waitReferenceForceUpdaterTransition(const std::string& i_name_);
+  bool getSupportedReferenceForceUpdaterNameSequence(OpenHRP::ReferenceForceUpdaterService::StrSequence_out o_names);
   void getTargetParameters ();
   void calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matrix33& foot_origin_rot);
   void updateRefFootOriginExtMoment (const std::string& arm);

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -110,6 +110,7 @@ class ReferenceForceUpdater
   bool startReferenceForceUpdaterNoWait(const std::string& i_name_);
   bool stopReferenceForceUpdaterNoWait(const std::string& i_name_);
   void waitReferenceForceUpdaterTransition(const std::string& i_name_);
+  void getTargetParameters ();
   void calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matrix33& foot_origin_rot);
   void updateRefFootOriginExtMoment (const std::string& arm);
   void updateRefForces (const std::string& arm);

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -198,7 +198,14 @@ class ReferenceForceUpdater
     int update_count;
     bool is_active, is_stopping, is_hold_value;
     boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_force_filter;
-    ReferenceForceUpdaterParam () {
+    void printParam (const std::string print_str)
+    {
+        std::cerr << "[" << print_str << "]   p_gain = " << p_gain << ", d_gain = " << d_gain << ", i_gain = " << i_gain << std::endl;
+        std::cerr << "[" << print_str << "]   update_freq = " << update_freq << "[Hz], update_time_ratio = " << update_time_ratio << ", transition_time = " << transition_time << "[s], cutoff_freq = " << act_force_filter->getCutOffFreq() << "[Hz]" << std::endl;
+        std::cerr << "[" << print_str << "]   motion_dir = " << motion_dir.format(Eigen::IOFormat(Eigen::StreamPrecision, 0, ", ", ", ", "", "", "    [", "]")) << std::endl;
+        std::cerr << "[" << print_str << "]   frame = " << frame << ", is_hold_value = " << (is_hold_value?"true":"false") << std::endl;
+    }
+    void initializeParam () {
       //params defined in idl
       motion_dir = hrp::Vector3::UnitZ();
       frame="local";
@@ -212,6 +219,15 @@ class ReferenceForceUpdater
       is_active = false;
       is_stopping = false;
       is_hold_value = false;
+    };
+    ReferenceForceUpdaterParam () {
+      initializeParam();
+    };
+    ReferenceForceUpdaterParam (const double _dt) {
+      initializeParam();
+      update_count = round((1/update_freq)/_dt);
+      double default_cutoff_freq = 1e8;
+      act_force_filter = boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> >(new FirstOrderLowPassFilter<hrp::Vector3>(default_cutoff_freq, _dt, hrp::Vector3::Zero()));
     };
   };
   std::map<std::string, hrp::VirtualForceSensorParam> m_vfs;

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -218,7 +218,7 @@ class ReferenceForceUpdater
   std::map<std::string, ee_trans> ee_map;
   std::map<std::string, size_t> ee_index_map;
   std::map<std::string, ReferenceForceUpdaterParam> m_RFUParam;
-  std::vector<hrp::Vector3> ref_force;
+  std::vector<hrp::Vector3> ref_force, act_force;
   std::map<std::string, interpolator*> ref_force_interpolator;
   std::map<std::string, interpolator*> transition_interpolator;
   std::vector<double> transition_interpolator_ratio;

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.h
@@ -23,6 +23,9 @@
 #include "../ImpedanceController/JointPathEx.h"
 #include "../ImpedanceController/RatsMatrix.h"
 #include "../SequencePlayer/interpolator.h"
+#include "../TorqueFilter/IIRFilter.h"
+#include <boost/shared_ptr.hpp>
+
 // #include "ImpedanceOutputGenerator.h"
 // #include "ObjectTurnaroundDetector.h"
 // Service implementation headers
@@ -194,6 +197,7 @@ class ReferenceForceUpdater
     std::string frame;
     int update_count;
     bool is_active, is_stopping, is_hold_value;
+    boost::shared_ptr<FirstOrderLowPassFilter<hrp::Vector3> > act_force_filter;
     ReferenceForceUpdaterParam () {
       //params defined in idl
       motion_dir = hrp::Vector3::UnitZ();

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdaterService_impl.cpp
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdaterService_impl.cpp
@@ -49,6 +49,13 @@ void ReferenceForceUpdaterService_impl::waitReferenceForceUpdaterTransition(cons
 };
 
 
+CORBA::Boolean ReferenceForceUpdaterService_impl::getSupportedReferenceForceUpdaterNameSequence(OpenHRP::ReferenceForceUpdaterService::StrSequence_out o_names)
+{
+    o_names = new OpenHRP::ReferenceForceUpdaterService::StrSequence();
+    return m_rfu->getSupportedReferenceForceUpdaterNameSequence(o_names);
+};
+
+
 void ReferenceForceUpdaterService_impl::rfu(ReferenceForceUpdater *i_rfu)
 {
     m_rfu = i_rfu;

--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdaterService_impl.h
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdaterService_impl.h
@@ -30,6 +30,7 @@ public:
     CORBA::Boolean startReferenceForceUpdaterNoWait(const char *i_name_);
     CORBA::Boolean stopReferenceForceUpdaterNoWait(const char *i_name_);
     void waitReferenceForceUpdaterTransition(const char* i_name_);
+    CORBA::Boolean getSupportedReferenceForceUpdaterNameSequence(OpenHRP::ReferenceForceUpdaterService::StrSequence_out o_names);
 
     void rfu(ReferenceForceUpdater *i_rfu);
 private:

--- a/rtc/TorqueFilter/IIRFilter.h
+++ b/rtc/TorqueFilter/IIRFilter.h
@@ -107,12 +107,12 @@ public:
     ~FirstOrderLowPassFilter()
     {
     };
-    T passFilter (T value)
+    T passFilter (const T& value)
     {
         prev_value = 1.0/(1+const_param) * prev_value + const_param/(1+const_param) * value;
         return prev_value;
     };
-    void reset (T value) { prev_value = value; };
+    void reset (const T& value) { prev_value = value; };
     void setCutOffFreq (const double f)
     {
         cutoff_freq = f;


### PR DESCRIPTION
ReferenceForceUpdaterでローパスフィルタを使えるようにしました。
デフォルトでは大きい値なので、ローパスなしになり、今までと挙動がほぼかわらないと思います。
@YutaKojio, @shintarokkk

AutoBalancerで手先の力に応じてバランスとる部分(static balance point計算部分）で
手先のモーメントがはいってなかったのでいれるようにしました。
`:set-ref-moment`をいれてないかぎりは副作用はないと思います。
@mmurooka 

よろしくお願いします。