### PR TITLE
Fix startReferenceForceUpdater and stopReferenceForceUpdater for legged robot

### DIFF
--- a/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
+++ b/rtc/ReferenceForceUpdater/ReferenceForceUpdater.cpp
@@ -838,14 +838,14 @@ bool ReferenceForceUpdater::stopReferenceForceUpdaterNoWait(const std::string& i
 bool ReferenceForceUpdater::startReferenceForceUpdater(const std::string& i_name_)
 {
     bool ret = startReferenceForceUpdaterNoWait(i_name_);
-    waitReferenceForceUpdaterTransition(i_name_);
+    if (ret) waitReferenceForceUpdaterTransition(i_name_);
     return ret;
 };
 
 bool ReferenceForceUpdater::stopReferenceForceUpdater(const std::string& i_name_)
 {
     bool ret = stopReferenceForceUpdaterNoWait(i_name_);
-    waitReferenceForceUpdaterTransition(i_name_);
+    if (ret) waitReferenceForceUpdaterTransition(i_name_);
     return ret;
 };
 
@@ -880,5 +880,3 @@ extern "C"
   }
 
 };
-
-


### PR DESCRIPTION
253c017185840afc03c71382f7150dcdd21be658 のcommitからstopReferenceForceUpdaterに間違った名前のlimbに与える（アームがない脚型ロボットでlarmを送るなど）と，以下のエラーで止まってしまうので，修正しました．
```
home/kangaroo/ros/indigo/devel/lib/python2.7/dist-packages/hrpsys/ReferenceForceUpdaterService_idl.pyc in stopReferenceForceUpdater(self, *args)
     92 
     93     def stopReferenceForceUpdater(self, *args):
---> 94         return _omnipy.invoke(self, "stopReferenceForceUpdater", _0_OpenHRP.ReferenceForceUpdaterService._d_stopReferenceForceUpdater, args)
     95 
     96     def startReferenceForceUpdaterNoWait(self, *args):

COMM_FAILURE: CORBA.COMM_FAILURE(omniORB.COMM_FAILURE_WaitingForReply, CORBA.COMPLETED_MAYBE)
```

