### PR TITLE
Extend joint control interface

### DIFF
--- a/idl/RobotHardwareService.idl
+++ b/idl/RobotHardwareService.idl
@@ -208,10 +208,27 @@ module OpenHRP
      */
     void getStatus2(out RobotState2 rs);
 
+    /**
+     * @brief RobotState2 with timestamp
+     */
     struct TimedRobotState2
     {
       RTC::Time tm;
       RobotState2 data;
     };
+
+    /**
+     * @brief set joint inertia
+     * @param name joint name
+     * @param mn joint inertia
+     * @return true if set successfully, false otherwise
+     */
+    boolean setJointInertia(in string name, in double mn);
+
+    /**
+     * @biref set joint inertias
+     * @param mns array of joint inertia
+     */
+    void setJointInertias(in DblSequence mns);
   };
 };

--- a/idl/RobotHardwareService.idl
+++ b/idl/RobotHardwareService.idl
@@ -243,6 +243,7 @@ module OpenHRP
 
     /**
      * @brief set disturbance observer gain
+     * @param gain disturbance observer gain
      */
     void setDisturbanceObserverGain(in double gain);
   };

--- a/idl/RobotHardwareService.idl
+++ b/idl/RobotHardwareService.idl
@@ -226,9 +226,24 @@ module OpenHRP
     boolean setJointInertia(in string name, in double mn);
 
     /**
-     * @biref set joint inertias
+     * @brief set joint inertias
      * @param mns array of joint inertia
      */
     void setJointInertias(in DblSequence mns);
+
+    /**
+     * @brief enable disturbance observer
+     */
+    void enableDisturbanceObserver();
+
+    /**
+     * @brief disable disturbance observer
+     */
+    void disableDisturbanceObserver();
+
+    /**
+     * @brief set disturbance observer gain
+     */
+    void setDisturbanceObserverGain(in double gain);
   };
 };

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -570,6 +570,16 @@ int read_power(double *voltage, double *current)
 }
 
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
+int write_command_acceleration(int id, double acc)
+{
+    return FALSE;
+}
+
+int write_command_accelerations(const double *accs)
+{
+    return FALSE;
+}
+
 int number_of_batteries()
 {
     return 1;

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -590,6 +590,11 @@ int write_joint_inertias(const double *mns)
     return FALSE;
 }
 
+int read_pd_controller_torques(double *torques)
+{
+    return FALSE;
+}
+
 int number_of_batteries()
 {
     return 1;

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -595,6 +595,16 @@ int read_pd_controller_torques(double *torques)
     return FALSE;
 }
 
+int write_disturbance_observer(int com)
+{
+    return FALSE;
+}
+
+int write_disturbance_observer_gain(double gain)
+{
+    return FALSE;
+}
+
 int number_of_batteries()
 {
     return 1;

--- a/lib/io/iob.cpp
+++ b/lib/io/iob.cpp
@@ -580,6 +580,16 @@ int write_command_accelerations(const double *accs)
     return FALSE;
 }
 
+int write_joint_inertia(int id, double mn)
+{
+    return FALSE;
+}
+
+int write_joint_inertias(const double *mns)
+{
+    return FALSE;
+}
+
 int number_of_batteries()
 {
     return 1;

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -612,6 +612,14 @@ extern "C"{
      int write_joint_inertias(const double *mns);
 
     /**
+     * @brief read pd controller torques [Nm]
+     * @param torques array of pd controller torque [Nm]
+     * @retval TRUE this function is supported
+     * @retval FALSE otherwise
+     */
+    int read_pd_controller_torques(double *torques);
+
+    /**
      * @brief get the number of batteries
      * @return the number of batteries
      */

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -620,6 +620,20 @@ extern "C"{
     int read_pd_controller_torques(double *torques);
 
     /**
+     * @brief turn on/off disturbance observer
+     * @param com 	ON/OFF
+     * @return		TRUE if this function is supported, FALSE otherwise
+     */
+    int write_disturbance_observer(int com);
+
+    /**
+     * @brief write disturbance observer gain
+     * @param gain	disturbance observer gain
+     * @return		TRUE if this function is supported, FALSE otherwise
+     */
+    int write_disturbance_observer_gain(double gain);
+
+    /**
      * @brief get the number of batteries
      * @return the number of batteries
      */

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -580,6 +580,22 @@ extern "C"{
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     //@{
     /**
+     * @brief write command angular acceleration[rad/s^2]
+     * @param id	joint id
+     * @param vel	angular acceleration [rad/s^2]
+     * @return		TRUE or E_ID
+     */
+    int write_command_acceleration(int id, double vel);
+
+    /**
+     * @brief write command angular accelerations[rad/s^2]
+     * @param vels	array of angular acceleration [rad/s^2]
+     * @retval TRUE this function is supported
+     * @retval FALSE otherwise
+     */
+     int write_command_accelerations(const double *vels);
+
+    /**
      * @brief get the number of batteries
      * @return the number of batteries
      */

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -596,6 +596,22 @@ extern "C"{
      int write_command_accelerations(const double *vels);
 
     /**
+     * @brief write joint inertia
+     * @param id	joint id
+     * @param mn	joint inertia
+     * @return		TRUE or E_ID
+     */
+    int write_joint_inertia(int id, double mn);
+
+    /**
+     * @brief write joint inertias
+     * @param mns	array of joint inertia
+     * @retval TRUE this function is supported
+     * @retval FALSE otherwise
+     */
+     int write_joint_inertias(const double *mns);
+
+    /**
      * @brief get the number of batteries
      * @return the number of batteries
      */

--- a/lib/io/iob.h
+++ b/lib/io/iob.h
@@ -582,18 +582,18 @@ extern "C"{
     /**
      * @brief write command angular acceleration[rad/s^2]
      * @param id	joint id
-     * @param vel	angular acceleration [rad/s^2]
+     * @param acc	angular acceleration [rad/s^2]
      * @return		TRUE or E_ID
      */
-    int write_command_acceleration(int id, double vel);
+    int write_command_acceleration(int id, double acc);
 
     /**
      * @brief write command angular accelerations[rad/s^2]
-     * @param vels	array of angular acceleration [rad/s^2]
+     * @param accs	array of angular acceleration [rad/s^2]
      * @retval TRUE this function is supported
      * @retval FALSE otherwise
      */
-     int write_command_accelerations(const double *vels);
+     int write_command_accelerations(const double *accs);
 
     /**
      * @brief write joint inertia

--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -711,6 +711,9 @@ CORBA::Boolean RobotHardwareServicePort::setJointInertia(const char* name, ::COR
 void RobotHardwareServicePort::setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns)
 {
 }
+void RobotHardwareServicePort::enableDisturbanceObserver(){}
+void RobotHardwareServicePort::disableDisturbanceObserver(){}
+void RobotHardwareServicePort::setDisturbanceObserverGain(::CORBA::Double gain){}
 //
 void RobotHardwareServicePort::setRobot(BodyRTC *i_robot) { m_robot = i_robot; }
 

--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -702,6 +702,15 @@ CORBA::Long RobotHardwareServicePort::lengthDigitalOutput() {
 CORBA::Boolean RobotHardwareServicePort::readDigitalOutput(::OpenHRP::RobotHardwareService::OctSequence_out dout) {
     return false;
 }
+
+CORBA::Boolean RobotHardwareServicePort::setJointInertia(const char* name, ::CORBA::Double mn)
+{
+    return true;
+}
+
+void RobotHardwareServicePort::setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns)
+{
+}
 //
 void RobotHardwareServicePort::setRobot(BodyRTC *i_robot) { m_robot = i_robot; }
 

--- a/lib/util/BodyRTC.h
+++ b/lib/util/BodyRTC.h
@@ -45,6 +45,9 @@ public:
     CORBA::Boolean readDigitalOutput(::OpenHRP::RobotHardwareService::OctSequence_out dout);
     CORBA::Boolean setJointInertia(const char* name, ::CORBA::Double mn);
     void setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns);
+    void enableDisturbanceObserver();
+    void disableDisturbanceObserver();
+    void setDisturbanceObserverGain(::CORBA::Double gain);
     void setRobot(BodyRTC *i_robot);
 private:
     BodyRTC *m_robot;

--- a/lib/util/BodyRTC.h
+++ b/lib/util/BodyRTC.h
@@ -43,6 +43,8 @@ public:
     CORBA::Boolean writeDigitalOutputWithMask(const ::OpenHRP::RobotHardwareService::OctSequence& dout, const ::OpenHRP::RobotHardwareService::OctSequence& mask);
     CORBA::Long lengthDigitalOutput();
     CORBA::Boolean readDigitalOutput(::OpenHRP::RobotHardwareService::OctSequence_out dout);
+    CORBA::Boolean setJointInertia(const char* name, ::CORBA::Double mn);
+    void setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns);
     void setRobot(BodyRTC *i_robot);
 private:
     BodyRTC *m_robot;

--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -49,6 +49,7 @@ RobotHardware::RobotHardware(RTC::Manager* manager)
     m_isDemoMode(0),
     m_qRefIn("qRef", m_qRef),
     m_dqRefIn("dqRef", m_dqRef),
+    m_ddqRefIn("ddqRef", m_ddqRef),
     m_tauRefIn("tauRef", m_tauRef),
     m_qOut("q", m_q),
     m_dqOut("dq", m_dq),
@@ -75,6 +76,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   
   addInPort("qRef", m_qRefIn);
   addInPort("dqRef", m_dqRefIn);
+  addInPort("ddqRef", m_ddqRefIn);
   addInPort("tauRef", m_tauRefIn);
 
   addOutPort("q", m_qOut);
@@ -138,6 +140,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   m_servoState.data.length(m_robot->numJoints());
   m_qRef.data.length(m_robot->numJoints());
   m_dqRef.data.length(m_robot->numJoints());
+  m_ddqRef.data.length(m_robot->numJoints());
   m_tauRef.data.length(m_robot->numJoints());
 
   int ngyro = m_robot->numSensors(Sensor::RATE_GYRO);
@@ -262,6 +265,12 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
       //std::cout << "RobotHardware: dqRef[21] = " << m_dqRef.data[21] << std::endl;
       // output to iob
       m_robot->writeVelocityCommands(m_dqRef.data.get_buffer());
+  }
+  if (m_ddqRefIn.isNew()){
+      m_ddqRefIn.read();
+      //std::cout << "RobotHardware: dqRef[21] = " << m_dqRef.data[21] << std::endl;
+      // output to iob
+      m_robot->writeAccelerationCommands(m_ddqRef.data.get_buffer());
   }
   if (m_tauRefIn.isNew()){
       m_tauRefIn.read();

--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -55,6 +55,7 @@ RobotHardware::RobotHardware(RTC::Manager* manager)
     m_dqOut("dq", m_dq),
     m_tauOut("tau", m_tau),
     m_ctauOut("ctau", m_ctau),
+    m_pdtauOut("pdtau", m_pdtau),
     m_servoStateOut("servoState", m_servoState),
     m_emergencySignalOut("emergencySignal", m_emergencySignal),
     m_rstate2Out("rstate2", m_rstate2),
@@ -83,6 +84,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   addOutPort("dq", m_dqOut);
   addOutPort("tau", m_tauOut);
   addOutPort("ctau", m_ctauOut);
+  addOutPort("pdtau", m_pdtauOut);
   addOutPort("servoState", m_servoStateOut);
   addOutPort("emergencySignal", m_emergencySignalOut);
   addOutPort("rstate2", m_rstate2Out);
@@ -137,6 +139,7 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
   m_dq.data.length(m_robot->numJoints());
   m_tau.data.length(m_robot->numJoints());
   m_ctau.data.length(m_robot->numJoints());
+  m_pdtau.data.length(m_robot->numJoints());
   m_servoState.data.length(m_robot->numJoints());
   m_qRef.data.length(m_robot->numJoints());
   m_dqRef.data.length(m_robot->numJoints());
@@ -288,6 +291,8 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
   m_tau.tm = tm;
   m_robot->readJointCommandTorques(m_ctau.data.get_buffer());
   m_ctau.tm = tm;
+  m_robot->readPDControllerTorques(m_pdtau.data.get_buffer());
+  m_pdtau.tm = tm;
   for (unsigned int i=0; i<m_rate.size(); i++){
       double rate[3];
       m_robot->readGyroSensor(i, rate);
@@ -339,6 +344,7 @@ RTC::ReturnCode_t RobotHardware::onExecute(RTC::UniqueId ec_id)
   m_dqOut.write();
   m_tauOut.write();
   m_ctauOut.write();
+  m_pdtauOut.write();
   m_servoStateOut.write();
   for (unsigned int i=0; i<m_rateOut.size(); i++){
       m_rateOut[i]->write();

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -130,6 +130,11 @@ class RobotHardware
   TimedDoubleSeq m_dqRef;
   InPort<TimedDoubleSeq> m_dqRefIn;
   /**
+     \brief array of reference accelerations of joint with jointId
+  */
+  TimedDoubleSeq m_ddqRef;
+  InPort<TimedDoubleSeq> m_ddqRefIn;
+  /**
      \brief array of reference torques of joint with jointId
   */
   TimedDoubleSeq m_tauRef;

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -159,6 +159,10 @@ class RobotHardware
   */
   TimedDoubleSeq m_ctau;
   /**
+     \brief array of PD controller torques of joint with jointId
+  */
+  TimedDoubleSeq m_pdtau;
+  /**
      \brief vector of actual acceleration (vector length = number of acceleration sensors)
   */
   std::vector<TimedAcceleration3D> m_acc;
@@ -181,6 +185,7 @@ class RobotHardware
   OutPort<TimedDoubleSeq> m_dqOut;
   OutPort<TimedDoubleSeq> m_tauOut;
   OutPort<TimedDoubleSeq> m_ctauOut;
+  OutPort<TimedDoubleSeq> m_pdtauOut;
   std::vector<OutPort<TimedAcceleration3D> *> m_accOut;
   std::vector<OutPort<TimedAngularVelocity3D> *> m_rateOut;
   std::vector<OutPort<TimedDoubleSeq> *> m_forceOut;

--- a/rtc/RobotHardware/RobotHardwareService_impl.cpp
+++ b/rtc/RobotHardware/RobotHardwareService_impl.cpp
@@ -174,3 +174,13 @@ CORBA::Boolean RobotHardwareService_impl::readDigitalOutput(::OpenHRP::RobotHard
     dout->length(lengthDigitalOutput());
     return m_robot->readDigitalOutput((char *)(dout->get_buffer()));
 }
+
+CORBA::Boolean RobotHardwareService_impl::setJointInertia(const char* name, ::CORBA::Double mn)
+{
+    m_robot->setJointInertia(name, mn);
+}
+
+void RobotHardwareService_impl::setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns)
+{
+    m_robot->setJointInertias(mns.get_buffer());
+}

--- a/rtc/RobotHardware/RobotHardwareService_impl.cpp
+++ b/rtc/RobotHardware/RobotHardwareService_impl.cpp
@@ -184,3 +184,19 @@ void RobotHardwareService_impl::setJointInertias(const ::OpenHRP::RobotHardwareS
 {
     m_robot->setJointInertias(mns.get_buffer());
 }
+
+
+void RobotHardwareService_impl::enableDisturbanceObserver()
+{
+    m_robot->enableDisturbanceObserver();
+}
+
+void RobotHardwareService_impl::disableDisturbanceObserver()
+{
+    m_robot->disableDisturbanceObserver();
+}
+
+void RobotHardwareService_impl::setDisturbanceObserverGain(::CORBA::Double gain)
+{
+    m_robot->setDisturbanceObserverGain(gain);
+}

--- a/rtc/RobotHardware/RobotHardwareService_impl.h
+++ b/rtc/RobotHardware/RobotHardwareService_impl.h
@@ -35,6 +35,9 @@ public:
     CORBA::Boolean readDigitalOutput(::OpenHRP::RobotHardwareService::OctSequence_out dout);
     CORBA::Boolean setJointInertia(const char* name, ::CORBA::Double mn);
     void setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns);
+    void enableDisturbanceObserver();
+    void disableDisturbanceObserver();
+    void setDisturbanceObserverGain(::CORBA::Double gain);
     //
     void setRobot(boost::shared_ptr<robot>& i_robot) { m_robot = i_robot; }
 private:

--- a/rtc/RobotHardware/RobotHardwareService_impl.h
+++ b/rtc/RobotHardware/RobotHardwareService_impl.h
@@ -33,6 +33,8 @@ public:
     CORBA::Boolean writeDigitalOutputWithMask(const ::OpenHRP::RobotHardwareService::OctSequence& dout, const ::OpenHRP::RobotHardwareService::OctSequence& mask);
     CORBA::Long lengthDigitalOutput();
     CORBA::Boolean readDigitalOutput(::OpenHRP::RobotHardwareService::OctSequence_out dout);
+    CORBA::Boolean setJointInertia(const char* name, ::CORBA::Double mn);
+    void setJointInertias(const ::OpenHRP::RobotHardwareService::DblSequence& mns);
     //
     void setRobot(boost::shared_ptr<robot>& i_robot) { m_robot = i_robot; }
 private:

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -841,3 +841,16 @@ int robot::numThermometers()
     return 0;
 #endif
 }
+
+bool robot::setJointInertia(const char *jname, double mn)
+{
+    Link *l = link(jname);
+    if (!l) return false;
+    int jid = l->jointId;
+    return write_joint_inertia(jid, mn);
+}
+
+void robot::setJointInertias(const double *mns)
+{
+    write_joint_inertias(mns);
+}

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -866,15 +866,21 @@ int robot::readPDControllerTorques(double *o_torques)
 
 void robot::enableDisturbanceObserver()
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     write_disturbance_observer(ON);
+#endif
 }
 
 void robot::disableDisturbanceObserver()
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     write_disturbance_observer(OFF);
+#endif
 }
 
 void robot::setDisturbanceObserverGain(double gain)
 {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
     write_disturbance_observer_gain(gain);
+#endif
 }

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -854,3 +854,12 @@ void robot::setJointInertias(const double *mns)
 {
     write_joint_inertias(mns);
 }
+
+int robot::readPDControllerTorques(double *o_torques)
+{
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
+    return read_pd_controller_torques(o_torques);
+#else
+    return 0;
+#endif
+}

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -863,3 +863,18 @@ int robot::readPDControllerTorques(double *o_torques)
     return 0;
 #endif
 }
+
+void robot::enableDisturbanceObserver()
+{
+    write_disturbance_observer(ON);
+}
+
+void robot::disableDisturbanceObserver()
+{
+    write_disturbance_observer(OFF);
+}
+
+void robot::setDisturbanceObserverGain(double gain)
+{
+    write_disturbance_observer_gain(gain);
+}

--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -484,6 +484,13 @@ void robot::writeVelocityCommands(const double *i_commands)
     write_command_velocities(i_commands);
 }
 
+void robot::writeAccelerationCommands(const double *i_commands)
+{
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 2
+    write_command_accelerations(i_commands);
+#endif
+}
+
 void robot::readPowerStatus(double &o_voltage, double &o_current)
 {
     read_power(&o_voltage, &o_current);

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -276,6 +276,20 @@ public:
      */
     bool setServoErrorLimit(const char *i_jname, double i_limit);
 
+    /**
+       \brief set joint inertia
+       \param i_jname joint name
+       \param i_mn joint inertia
+       \return true if set successfully, false otherwise
+     */
+    bool setJointInertia(const char *i_jname, double i_mn);
+
+    /**
+       \brief set joint inertias
+       \param i_mns array of joint inertia
+     */
+    void setJointInertias(const double *i_mn);
+
     void setProperty(const char *key, const char *value);
     bool addJointGroup(const char *gname, const std::vector<std::string>& jnames);
     std::vector<double> m_servoErrorLimit;  

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -221,6 +221,12 @@ public:
     void writeVelocityCommands(const double *i_commands);
 
     /**
+       \brief write array of reference accelerations of joint servo
+       \param i_commands array of reference accelerations of joint servo[rad/s]
+     */
+    void writeAccelerationCommands(const double *i_commands);
+
+    /**
        \brief get length of extra servo states
        \param id joint id
        \return length of extra servo states

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -227,6 +227,13 @@ public:
     void writeAccelerationCommands(const double *i_commands);
 
     /**
+       \brief read array of all pd controller torques[Nm]
+       \param o_torques array of all pd controller torques
+       \param TRUE if read successfully, FALSE otherwise
+     */
+    int readPDControllerTorques(double *o_torques);
+
+    /**
        \brief get length of extra servo states
        \param id joint id
        \return length of extra servo states

--- a/rtc/RobotHardware/robot.h
+++ b/rtc/RobotHardware/robot.h
@@ -297,6 +297,22 @@ public:
      */
     void setJointInertias(const double *i_mn);
 
+    /**
+       \brief enable disturbance observer
+    */
+    void enableDisturbanceObserver();
+
+    /**
+       \brief disable disturbance observer
+    */
+    void disableDisturbanceObserver();
+
+    /**
+       \brief set disturbance observer gain
+       \param gain disturbance observer gain
+    */
+    void setDisturbanceObserverGain(double gain);
+
     void setProperty(const char *key, const char *value);
     bool addJointGroup(const char *gname, const std::vector<std::string>& jnames);
     std::vector<double> m_servoErrorLimit;  


### PR DESCRIPTION
This PR add the following interfaces (available only in v2)
- set reference joint accelerations
- set joint inertias
- get PD controller torques
- control disturbance observer