### PR TITLE
[rtc/CollisionDetector] Fix memory fault in collision detector

### DIFF
--- a/lib/util/BVutil.cpp
+++ b/lib/util/BVutil.cpp
@@ -93,7 +93,8 @@ void convertToConvexHull(hrp::Link *i_link)
     coldetModel->setPrimitiveType(ColdetModel::SP_MESH);
     // qhull
     int numVertices = i_link->coldetModel->getNumVertices();
-    double points[numVertices*3];
+    double* points;
+    points = new double[numVertices*3];
     float v[3];
     for (int i=0; i<numVertices; i++){
         i_link->coldetModel->getVertex(i, v[0],v[1],v[2]);
@@ -119,6 +120,7 @@ void convertToConvexHull(hrp::Link *i_link)
         index[p] = vertexIndex;
         coldetModel->setVertex(vertexIndex++, points[p*3+0], points[p*3+1], points[p*3+2]);
     }
+    delete[] points;
     facetT *facet;
     int num = qh num_facets;
     int triangleIndex = 0;


### PR DESCRIPTION
This PR changes `lib/util/BVutil.cpp` called from `rtc/CollisionDetector`.

### What I changed
Stop using simple initialization of the array `points` using non-const variable as number of elements.

### What is problem
Previous code violates the rule of C++ and causes undefined behavior. We can't expect the array is correctly allocated.
In QNX 6.5.0 x86-only inside HIRONX, accessing the array occurs memory fault in the middle of [for loop](https://github.com/fkanehiro/hrpsys-base/blob/master/lib/util/BVutil.cpp#L98-L103).
I assume the array is not correctly allocated in this case.