### PR TITLE
Change ROBOT_IOB_VERSION variable from bool to cached string value

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -191,10 +191,7 @@ if(NO_DIGITAL_INPUT)
   message(STATUS "Disablng readDigitalInput and lengthDigitalInput")
 endif()
 
-option(ROBOT_IOB_VERSION "Supported robot IOB version (lib/io/iob.h)")
-if("${ROBOT_IOB_VERSION}" STREQUAL "OFF")
-  set(ROBOT_IOB_VERSION 4)
-endif()
+set(ROBOT_IOB_VERSION 4 CACHE STRING "Supported robot IOB version (lib/io/iob.h)") # can be overwritten by extra compile options or ccmake
 add_definitions(-DROBOT_IOB_VERSION=${ROBOT_IOB_VERSION})
 message(STATUS "compile iob with -DROBOT_IOB_VERSION=${ROBOT_IOB_VERSION}")
 


### PR DESCRIPTION
問題点:
CMakeLists.txtではROBOT_IOB_VERSIONは現在boolのoptionとして定義されており, ユーザがデフォルトのversion以外を利用したい場合`-DROBOT_IOB_VERSION=0`などをコンパイルオプションとして渡す実装になっています.
しかし与えたROBOT_IOB_VERSIONはキャッシュされないため, コンパイルのたびに上記のオプションを指定しないと, デフォルトのversion(ここでは4)が使用されることになります.

解決案:
ROBOT_IOB_VERSIONをoption(boolの値)ではなくCACHEされるSTRINGの値として定義します.
これにより最後に利用した-DROBOT_IOB_VERSIONの値がキャッシュされます (ccmakeなどからもON/OFFではなく数値を変更可能になります).
コンパイルオプションを明示的に使用した場合はその値が利用されます.
また, キャッシュがない状態でROBOT_IOB_VERSIONが指定されない場合は以前と同じくデフォルトの値が設定されます.
