### PR TITLE
allow multi CORBA nameserver and RTCManager

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -421,7 +421,9 @@ def findRTCmanager(hostname=None, rnc=None):
 
     def getManagerDirectly(hostname, mgr=None):
         global orb
-        corbaloc = "corbaloc:iiop:" + hostname + ":2810/manager"
+        mgrport = int(nsport) + 1 # RTC manager port is set as name server port + 1 traditionally
+        corbaloc = "corbaloc:iiop:" + hostname + ":" + str(mgrport) + "/manager"
+        print("\033[34m[rtm.py] tring to findRTCManager on port" + str(mgrport) + "\033[0m")
         try:
             obj = orb.string_to_object(corbaloc)
             mgr = RTCmanager(obj._narrow(RTM.Manager))


### PR DESCRIPTION
複数のnameserverとRTCManagerを干渉なく起動できるよう，
managerのポート番号を2810固定ではなくnameserverの+1になるようにしました．
nameserverのポートに関して何も変更をしていないユーザーには影響ないと思います．