### PR TITLE
support any RTCmanager port num

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -18,6 +18,7 @@ import re
 rootnc = None
 nshost = None
 nsport = None
+mgrport = None
 
 ##
 # \brief wrapper class of RT component
@@ -311,7 +312,7 @@ def unbindObject(name, kind):
 # \brief initialize ORB 
 #
 def initCORBA():
-    global rootnc, orb, nshost, nsport
+    global rootnc, orb, nshost, nsport, mgrport
 
     # from omniorb's document
     # When CORBA::ORB_init() is called, the value for each configuration
@@ -329,6 +330,15 @@ def initCORBA():
             nshost = socket.gethostname()
         if not nsport:
             nsport = 15005
+
+    try:
+        n = sys.argv.index('-RTCManagerPort')
+        mgrport = int(sys.argv[n + 1])
+        print("\033[34m[rtm.py]-RTCManagerPort set as " + str(mgrport) + "\033[0m")
+    except:
+        if not mgrport:
+            mgrport = 2810 # default
+            print("\033[34m[rtm.py] No RTCManagerPort option set, use " + str(mgrport) + "\033[0m")
 
     print("configuration ORB with %s:%s"%(nshost, nsport))
     os.environ['ORBInitRef'] = 'NameService=corbaloc:iiop:%s:%s/NameService' % \
@@ -420,10 +430,9 @@ def findRTCmanager(hostname=None, rnc=None):
         return mgr
 
     def getManagerDirectly(hostname, mgr=None):
-        global orb
-        mgrport = int(nsport) + 1 # RTC manager port is set as name server port + 1 traditionally
+        global orb, mgrport
         corbaloc = "corbaloc:iiop:" + hostname + ":" + str(mgrport) + "/manager"
-        print("\033[34m[rtm.py] tring to findRTCManager on port" + str(mgrport) + "\033[0m")
+        print("\033[34m[rtm.py] trying to findRTCManager on port" + str(mgrport) + "\033[0m")
         try:
             obj = orb.string_to_object(corbaloc)
             mgr = RTCmanager(obj._narrow(RTM.Manager))

--- a/python/rtm.py
+++ b/python/rtm.py
@@ -313,7 +313,7 @@ def unbindObject(name, kind):
 #
 def initCORBA():
     global rootnc, orb, nshost, nsport, mgrport
-    mgrhost = "" # will be unused
+    mgrhost = None # will be unused
 
     # from omniorb's document
     # When CORBA::ORB_init() is called, the value for each configuration
@@ -331,21 +331,28 @@ def initCORBA():
     mc = OpenRTM_aist.ManagerConfig();
     mc.parseArgs(rtm_argv)
 
-    try:
-        nshost, nsport = mc._argprop.getProperty("corba.nameservers").split(":")
-    except:  # default
-        nshost = socket.gethostname()
-        nsport = 15005
-        print("\033[34m[rtm.py] No corba.nameservers set, use " + nshost + ":" + str(nsport) + "\033[0m")
+    if nshost != None or nsport != None: # nshost and nsport can be set via other script like "import rtm; rtm.nshost=XXX"
+        print("\033[34m[rtm.py] nshost or nsport already set as " + str(nshost) + ":" + str(nsport) + "\033[0m")
+    else:
+        try:
+            nshost, nsport = mc._argprop.getProperty("corba.nameservers").split(":")
+        except:
+            nshost = socket.gethostname()
+            nsport = 15005  # default
+            print("\033[34m[rtm.py] No corba.nameservers set, use " + nshost + ":" + str(nsport) + "\033[0m")
 
-    try:
-        mgrhost, mgrport = mc._argprop.getProperty("corba.master_manager").split(":")
-    except:  # default
-        mgrport = 2810
-        print("\033[34m[rtm.py] No corba.master_manager set, use " + nshost + ":" + str(mgrport) + "\033[0m")
+    if mgrhost != None or mgrport != None: # 
+        print("\033[34m[rtm.py] mgrhost or mgrport already set as " + str(mgrhost) + ":" + str(mgrport) + "\033[0m")
+    else:
+        try:
+            mgrhost, mgrport = mc._argprop.getProperty("corba.master_manager").split(":")
+        except:
+            mgrhost = socket.gethostname()
+            mgrport = 2810  # default
+            print("\033[34m[rtm.py] No corba.master_manager set, use " + mgrhost + ":" + str(mgrport) + "\033[0m")
 
     print("\033[34m[rtm.py] configuration ORB with %s:%s\033[0m"%(nshost, nsport))
-    print("\033[34m[rtm.py] configuration RTCManager with %s:%s\033[0m"%(nshost, mgrport))
+    print("\033[34m[rtm.py] configuration RTCManager with %s:%s\033[0m"%(mgrhost, mgrport))
     os.environ['ORBInitRef'] = 'NameService=corbaloc:iiop:%s:%s/NameService' % \
                                (nshost, nsport)
 


### PR DESCRIPTION
後方互換性も考えて，RTCmanagerのポートは基本2810のままで，
変更したい人だけ任意の値に変えられるよう，オプション引数から設定できるようにしました．
「-ORBInitRef」を見習って「-RTCManagerPort」というオプションを勝手に追加してrtm.pyに外からmgrportを変更できるようにしました．
何もしなければデフォルト2810になるのでこれまでと挙動が変わらないはずです．