### PR TITLE
[SequencePlayer]fix_queue_increseing_in_setJointAnglesOfGroup

### DIFF
--- a/rtc/SequencePlayer/interpolator.cpp
+++ b/rtc/SequencePlayer/interpolator.cpp
@@ -170,7 +170,12 @@ void interpolator::setGoal(const double *newg, const double *newv, double time,
     if (online) remain_t = time; // interpolation will start
 }
 
-void interpolator::interpolate(double& remain_t_)
+void interpolator::interpolate_prev_value() {
+    remain_t += dt;
+    interpolate(remain_t, false);
+}
+
+void interpolator::interpolate(double& remain_t_, bool push_q)
 {
     if (remain_t_ <= 0) return;
 
@@ -192,7 +197,9 @@ void interpolator::interpolate(double& remain_t_)
             break;
         }
     }
-    push(x, v, a);
+    if (push_q){
+        push(x, v, a);
+    }
     remain_t_ = tm;
 }
 

--- a/rtc/SequencePlayer/interpolator.h
+++ b/rtc/SequencePlayer/interpolator.h
@@ -55,9 +55,11 @@ public:
   void setGoal(const double *gx, const double *gv, double time,
                bool online=true);
   void setGoal(const double *gx, double time, bool online=true);
-  // Interpolate value and push value to queue (q, dq, ddq).
+  // Interpolate value and push value to queue (q, dq, ddq) if push_q is true.
   //   If remain_t <= 0, do nothing.
-  void interpolate(double& remain_t_);
+  void interpolate(double& remain_t_, bool push_q=true);
+  // Interpolate previous value and without pushing to queue
+  void interpolate_prev_value();
   double deltaT() const { return dt; }
   double dimension() const { return dim; }
   void setName (const std::string& _name) { name = _name; };

--- a/rtc/SequencePlayer/seqplay.cpp
+++ b/rtc/SequencePlayer/seqplay.cpp
@@ -508,8 +508,7 @@ bool seqplay::setJointAnglesOfGroup(const char *gname, const double* i_qRef, con
 			i->extract(v, dq);
 			i->inter->go(x,v,interpolators[Q]->deltaT());
 		}
-		double x[i->indices.size()], v[i->indices.size()];
-		i->inter->get(x, v, false);
+		i->inter->interpolate_prev_value();
 		i->setGoal(i_qRef, i_tm);
 		return true;
 	}else{


### PR DESCRIPTION
This is a fix related to #1261 
## What i changed
I make a fix in seqplay::setJointAnglesOfGroup.
I changed it to interpolate the previous value(in order to set proper current positions, velocities, and accelerations before calling setGoal) and without pushing it to the queue.

## What is the problem
Originally, it interpolate next value and push it to queue, which increases the queue size.

I have tested with my own program, it generates a smooth trajectory when i call setJointAnglesOfGroup with 100Hz and the target time is 0.1[s]. The robot stops 0.1[s] later after the last setJointAnglesOfGroup is called. Before this change, the robot does not stop 0.1[s] later due to the increasing queue.

I don't know if it is a good way to solve this problem. 
Please let me know if you have any question. Thank you.