### PR TITLE
fix calcInverseKinematics2Loop with localPos and localR

### DIFF
--- a/rtc/ImpedanceController/JointPathEx.cpp
+++ b/rtc/ImpedanceController/JointPathEx.cpp
@@ -235,7 +235,8 @@ bool JointPathEx::calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatri
 }
 
 bool JointPathEx::calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega,
-                                             const double LAMBDA, const double avoid_gain, const double reference_gain, const hrp::dvector* reference_q) {
+                                             const double LAMBDA, const double avoid_gain, const double reference_gain, const hrp::dvector* reference_q,
+                                             const Vector3& localPos) {
     const int n = numJoints();
 
     if ( DEBUG ) {
@@ -260,7 +261,7 @@ bool JointPathEx::calcInverseKinematics2Loop(const Vector3& dp, const Vector3& o
     if (ij_workspace_dim > 0) {
         v << dp, omega, dvector::Zero(ij_workspace_dim);
         hrp::dmatrix ee_J = dmatrix::Zero(ee_workspace_dim, n);
-        calcJacobian(ee_J);
+        calcJacobian(ee_J, localPos);
         hrp::dmatrix ij_J = dmatrix::Zero(ij_workspace_dim, n);
         for (size_t i = 0; i < ij_workspace_dim; i++) {
             std::pair<size_t, size_t>& pair = interlocking_joint_pair_indices[i];
@@ -270,7 +271,7 @@ bool JointPathEx::calcInverseKinematics2Loop(const Vector3& dp, const Vector3& o
         J << ee_J, ij_J;
     } else {
         v << dp, omega;
-        calcJacobian(J);
+        calcJacobian(J, localPos);
     }
     calcJacobianInverseNullspace(J, Jinv, Jnull);
     dq = Jinv * v; // dq = pseudoInverse(J) * v
@@ -467,7 +468,7 @@ bool JointPathEx::calcInverseKinematics2Loop(const Vector3& end_effector_p, cons
     hrp::Vector3 vel_r(endLink()->R * matrix_logEx(endLink()->R.transpose() * target_link_R));
     vel_p *= vel_gain;
     vel_r *= vel_gain;
-    return calcInverseKinematics2Loop(vel_p, vel_r, LAMBDA, avoid_gain, reference_gain, reference_q);
+    return calcInverseKinematics2Loop(vel_p, vel_r, LAMBDA, avoid_gain, reference_gain, reference_q, localPos);
 }
 
 bool JointPathEx::calcInverseKinematics2(const Vector3& end_p, const Matrix33& end_R,

--- a/rtc/ImpedanceController/JointPathEx.h
+++ b/rtc/ImpedanceController/JointPathEx.h
@@ -17,7 +17,8 @@ namespace hrp {
   public:
     JointPathEx(BodyPtr& robot, Link* base, Link* end, double control_cycle, bool _use_inside_joint_weight_retrieval = true, const std::string& _debug_print_prefix = "");
     bool calcJacobianInverseNullspace(dmatrix &J, dmatrix &Jinv, dmatrix &Jnull);
-    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL);
+    bool calcInverseKinematics2Loop(const Vector3& dp, const Vector3& omega, const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const dvector* reference_q = NULL,
+                                    const hrp::Vector3& localPos = hrp::Vector3::Zero());
     bool calcInverseKinematics2Loop(const Vector3& end_effector_p, const Matrix33& end_effector_R,
                                     const double LAMBDA, const double avoid_gain = 0.0, const double reference_gain = 0.0, const hrp::dvector* reference_q = NULL,
                                     const double vel_gain = 1.0,


### PR DESCRIPTION
calcInverseKinematics2Loop関数のうち，endLink()からend effectorに対するlocal座標を受け取れるものについて正しく設定されていなさそうだったので変更しました．

具体的には関数内部でcalcJacobianの第二引数にlocalPosを渡しました