### PR TITLE
fix bug of extended_preview_controller

### DIFF
--- a/rtc/AutoBalancer/PreviewController.cpp
+++ b/rtc/AutoBalancer/PreviewController.cpp
@@ -64,7 +64,7 @@ void extended_preview_control::calc_f()
   Eigen::Matrix<double, 4, 4> gsi(Eigen::Matrix<double, 4, 4>::Identity());
   Eigen::Matrix<double, 4, 1> qt(riccati.Q * riccati.c.transpose());
   for (size_t i = 0; i < delay; i++) {
-    if ( i == delay - 1 ) qt = riccati.P * qt;
+    if ( i == delay - 1 ) qt = riccati.P * riccati.c.transpose();
     fa = riccati.R_btPb_inv * riccati.b.transpose() * (gsi * qt);
     gsi = riccati.A_minus_bKt * gsi;
     f(i+1) = fa(0,0);


### PR DESCRIPTION
https://github.com/euslisp/jskeus/pull/551

extended-preview-cotrollerクラスの計算過程に誤りがあったため、修正しました。
Qの値が1.0で無いとき、正しい出力を返しません。
このPull Requestによる修正前後での```testPreviewController```の出力を添付いたします。
Q,Rの値を両方とも1e3倍したときに、理論上は出力は変わらないはずであるにも関わらず、修正前では出力が大きく変わっています。

**現状(修正前)**
Q=1, R=1e-6の場合。問題なし。
![hrpsys_q=1_r=1e-6](https://user-images.githubusercontent.com/32383525/61199072-804b0f80-a717-11e9-9bbe-96c76b14c954.png)

Q=1e3, R=1e-3の場合。正しく機能しない。
![hrpsys_q=1e3_r=1e-3](https://user-images.githubusercontent.com/32383525/61199082-89d47780-a717-11e9-9bae-47a14646aa3b.png)

**本PullRequest適用後**
Q=1, R=1e-6の場合。本Pull Request適用前と変化なし。
![hrpsys_PR_q=1_r=1e-6](https://user-images.githubusercontent.com/32383525/61199260-3dd60280-a718-11e9-81e3-7fa2b82e0e5e.png)

Q=1e3, R=1e-3の場合。正しく機能する。
![hrpsys_RP_q=1e3_r=1e-3](https://user-images.githubusercontent.com/32383525/61199266-4595a700-a718-11e9-9912-664a1afce78d.png)

