### PR TITLE
[Stabilizer.cpp] fix segmentation fault in calcFootOriginCoords

### DIFF
--- a/rtc/Stabilizer/Stabilizer.cpp
+++ b/rtc/Stabilizer/Stabilizer.cpp
@@ -767,7 +767,8 @@ void Stabilizer::getCurrentParameters ()
 
 void Stabilizer::calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matrix33& foot_origin_rot)
 {
-  rats::coordinates leg_c[2], tmpc;
+  rats::coordinates tmpc;
+  std::vector<rats::coordinates> leg_c(stikp.size());
   hrp::Vector3 ez = hrp::Vector3::UnitZ();
   hrp::Vector3 ex = hrp::Vector3::UnitX();
   for (size_t i = 0; i < stikp.size(); i++) {
@@ -784,7 +785,7 @@ void Stabilizer::calcFootOriginCoords (hrp::Vector3& foot_origin_pos, hrp::Matri
   }
   if (ref_contact_states[contact_states_index_map["rleg"]] &&
       ref_contact_states[contact_states_index_map["lleg"]]) {
-    rats::mid_coords(tmpc, 0.5, leg_c[0], leg_c[1]);
+    rats::mid_coords(tmpc, 0.5, leg_c[contact_states_index_map["rleg"]], leg_c[contact_states_index_map["lleg"]]);
     foot_origin_pos = tmpc.pos;
     foot_origin_rot = tmpc.rot;
   } else if (ref_contact_states[contact_states_index_map["rleg"]]) {


### PR DESCRIPTION
`Stabilizer.cpp` gets segmentation fault if endeffectors other than 1st or 2nd endeffector are assigned as legs.

example of such a case:
https://github.com/start-jsk/rtmros_gazebo/blob/26a9dd2d4ba8ee74dcf53d8fa8a6ce1caf7a6923/hrpsys_gazebo_general/config/SampleRobot.conf#L6

This PR fixed this problem.