### PR TITLE
set ORBgiopMaxMsgSize from arguments

### DIFF
--- a/python/rtm.py
+++ b/python/rtm.py
@@ -334,6 +334,13 @@ def initCORBA():
     os.environ['ORBInitRef'] = 'NameService=corbaloc:iiop:%s:%s/NameService' % \
                                (nshost, nsport)
 
+    giopmaxmsgsize = '2147483648'
+    try:
+        n = sys.argv.index('-ORBgiopMaxMsgSize')
+        giopmaxmsgsize = sys.argv[n + 1]
+
+    os.environ['ORBgiopMaxMsgSize'] = giopmaxmsgsize
+
     try:
         orb = CORBA.ORB_init(sys.argv, CORBA.ORB_ID)
         nameserver = orb.resolve_initial_references("NameService")


### PR DESCRIPTION
see https://github.com/start-jsk/rtmros_hironx/issues/539, from omniorb4.2 we need to set ORBgiopMaxMsgSize environment from both server and client side?