### PR TITLE
[SequencePlayer] fix bug in removeJointGroup

### DIFF
--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -849,6 +849,7 @@ bool SequencePlayer::removeJointGroup(const char *gname)
     bool ret;
     {
         Guard guard(m_mutex);
+        if (!setInitialState()) return false;
         ret = m_seq->removeJointGroup(gname);
     }
     return ret;


### PR DESCRIPTION
SequencePlayerの`removeJointGroup`関数のバグを直しました。

通常SequencePlayerは、現在のStateHolderの値を始点として、目標の状態へと補間する軌道を生成します。
ところが、`removeJointGroup`を呼ぶと、現在のStateHolderの値を始点としない値が出力されていました。

HRP2とJAXONはともにStateHolderのBasePosの初期値はモデルファイルの腰の高さになっているにもかかわらず、`removeJointGroup`を使うHRP2はSequencePlayerがBasePosとしてStateHolderの値と関係ないゼロを出力してしまうため、
https://github.com/jsk-ros-pkg/jsk_control/tree/master/jsk_footstep_controller
のREADMEの写真のように、HRP2とJAXONでodomの高さが異なるという現象が生じていました。