### PR TITLE
enable to compile with OpenRTM-1.2.2

### DIFF
--- a/idl/HRPDataTypes.idl
+++ b/idl/HRPDataTypes.idl
@@ -13,6 +13,7 @@ module OpenHRP
   struct SceneState
   {
     double time;
+    RTC::Time tm;
     RobotStateSeq states;
   };
 

--- a/idl/Img.idl
+++ b/idl/Img.idl
@@ -27,6 +27,12 @@ struct ImageData
   sequence<octet> raw_data;
 };
 
+struct TimedImageData
+{
+  RTC::Time tm;
+  ImageData data;
+};
+
 
 /* camera image */
 struct CameraIntrinsicParameter

--- a/idl/PCDLoaderService.idl
+++ b/idl/PCDLoaderService.idl
@@ -14,6 +14,12 @@ module OpenHRP
     };
     
     typedef sequence<PCDOffset> PCDOffsetSeq;
+
+    struct TimedPCDOffsetSeq
+    {
+        RTC::Time tm;
+        PCDOffsetSeq data;
+    };
     
     interface PCDLoaderService
     {

--- a/rtc/ImageData2CameraImage/ImageData2CameraImage.cpp
+++ b/rtc/ImageData2CameraImage/ImageData2CameraImage.cpp
@@ -32,8 +32,8 @@ static const char* imagedata2cameraimage_spec[] =
 ImageData2CameraImage::ImageData2CameraImage(RTC::Manager* manager)
   : RTC::DataFlowComponentBase(manager),
     // <rtc-template block="initializer">
-    m_dataIn("imageIn", m_data.data.image),
-    m_dataOut("imageOut", m_data),
+    m_dataIn("imageIn", m_tid),
+    m_dataOut("imageOut", m_tci),
     // </rtc-template>
     dummy(0)
 {
@@ -68,7 +68,7 @@ RTC::ReturnCode_t ImageData2CameraImage::onInitialize()
   // Set CORBA Service Ports
   
   // </rtc-template>
-  m_data.error_code = 0;
+  m_tci.error_code = 0;
 
   return RTC::RTC_OK;
 }
@@ -112,6 +112,8 @@ RTC::ReturnCode_t ImageData2CameraImage::onExecute(RTC::UniqueId ec_id)
 {
   if (m_dataIn.isNew()){
     m_dataIn.read();
+    m_tci.tm = m_tid.tm;
+    m_tci.data.image = m_tid.data;
     m_dataOut.write();
   }
   return RTC::RTC_OK;

--- a/rtc/ImageData2CameraImage/ImageData2CameraImage.h
+++ b/rtc/ImageData2CameraImage/ImageData2CameraImage.h
@@ -103,11 +103,12 @@ class ImageData2CameraImage
   
   // </rtc-template>
 
-  Img::TimedCameraImage m_data;
+  Img::TimedImageData m_tid;
+  Img::TimedCameraImage m_tci;
 
   // DataInPort declaration
   // <rtc-template block="inport_declare">
-  InPort<Img::ImageData> m_dataIn;
+  InPort<Img::TimedImageData> m_dataIn;
   
   // </rtc-template>
 

--- a/rtc/PCDLoader/PCDLoader.cpp
+++ b/rtc/PCDLoader/PCDLoader.cpp
@@ -177,8 +177,8 @@ void PCDLoader::setCloudXYZRGB(PointCloudTypes::PointCloud& cloud, const pcl::Po
 void PCDLoader::updateOffsetToCloudXYZ(void)
 {
     pcl::PointCloud<pcl::PointXYZ>::Ptr clouds(new pcl::PointCloud<pcl::PointXYZ>);
-    for (unsigned int i=0; i<m_offset.length(); i++){
-        const OpenHRP::PCDOffset& offset = m_offset[i];
+    for (unsigned int i=0; i<m_offset.data.length(); i++){
+        const OpenHRP::PCDOffset& offset = m_offset.data[i];
         const std::string label(offset.label);
         if( m_clouds_xyz.find(label) != m_clouds_xyz.end() ){
             const hrp::Vector3 center(offset.center.x, offset.center.y, offset.center.z);
@@ -211,8 +211,8 @@ void PCDLoader::updateOffsetToCloudXYZ(void)
 void PCDLoader::updateOffsetToCloudXYZRGB(void)
 {
     pcl::PointCloud<pcl::PointXYZRGB>::Ptr clouds(new pcl::PointCloud<pcl::PointXYZRGB>);
-    for (unsigned int i=0; i<m_offset.length(); i++){
-        const OpenHRP::PCDOffset& offset = m_offset[i];
+    for (unsigned int i=0; i<m_offset.data.length(); i++){
+        const OpenHRP::PCDOffset& offset = m_offset.data[i];
         const std::string label(offset.label);
         if( m_clouds_xyzrgb.find(label) != m_clouds_xyzrgb.end() ){
             const hrp::Vector3 center(offset.center.x, offset.center.y, offset.center.z);

--- a/rtc/PCDLoader/PCDLoader.h
+++ b/rtc/PCDLoader/PCDLoader.h
@@ -110,13 +110,13 @@ protected:
   // </rtc-template>
     
   PointCloudTypes::PointCloud m_cloud;
-  OpenHRP::PCDOffsetSeq m_offset;
+  OpenHRP::TimedPCDOffsetSeq m_offset;
   RTC::TimedBoolean m_isOutput;
   
   // DataInPort declaration
   // <rtc-template block="inport_declare">
   
-  InPort<OpenHRP::PCDOffsetSeq> m_offsetIn;
+  InPort<OpenHRP::TimedPCDOffsetSeq> m_offsetIn;
   
   // </rtc-template>
   


### PR DESCRIPTION
This PR enables to compile with OpenRTM-1.2.2.
This PR makes incompatible changes to ImageData2CameraImage and PCDLoader.
Because OpenRTM-1.2.2 assumes that every data type used for data ports has 'tm' field for timestamp.
