### PR TITLE
[ec] add wait() to ~hrpExecutionContext

### DIFF
--- a/ec/hrpEC/hrpEC-common.cpp
+++ b/ec/hrpEC/hrpEC-common.cpp
@@ -11,6 +11,7 @@ namespace RTC
 {
     hrpExecutionContext::~hrpExecutionContext()
     {
+        wait();
         if (m_thread_pending)
             abort ();
     }


### PR DESCRIPTION
This PR enables to destroy hrpExecutionContext cleanly.
