### PR TITLE
[hrpEC/hroEC-common] fix memory leak

### DIFF
--- a/ec/hrpEC/hrpEC-common.cpp
+++ b/ec/hrpEC/hrpEC-common.cpp
@@ -146,7 +146,7 @@ namespace RTC
 #else
                         RTC::RTObject_var rtc = list[i];
 #endif
-                        rtc_names.push_back(std::string(rtc->get_component_profile()->instance_name));
+                        rtc_names.push_back(std::string(RTC::ComponentProfile_var(rtc->get_component_profile())->instance_name));
                     }
                 }
                 printRTCProcessingTime(processes);


### PR DESCRIPTION
`get_component_profile()` は`RTC::ComponentProfile`型のポインタを返しますが、`_retn()`によって所有権を関数の呼び出し側に渡すので、_var型変数で受ける必要があります。

(参考)
https://github.com/OpenRTM/OpenRTM-aist/blob/65e64cd63f7d6a6d7382f3f42dee9d6efd6b0f95/src/lib/rtm/RTObject.cpp#L690
https://github.com/tork-a/openrtm_aist-release/blob/5033bbae02c0e2815554b9e28d5112a3c28081b0/src/lib/rtm/RTObject.cpp#L731
https://www.openrtm.org/openrtm/en/doc/developersguide/serviceport_adavanced