### PR TITLE
[RobotHardware/robot.cpp][robot::power] fix for robots which have a relay for each joint

### DIFF
--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -440,12 +440,19 @@ bool robot::power(int jid, bool turnon)
     int com = OFF;
 
     if (turnon) {
+#if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 4
+        int s;
+        read_servo_state(jid, &s);
+        if (s == ON)
+            return false;
+#else
         for(unsigned int i=0; i<numJoints(); i++) {
             int s;
             read_servo_state(i, &s);
             if (s == ON)
                 return false;
         }
+#endif
         com = ON;
     }
 


### PR DESCRIPTION
`robot::power`関数内に、ロボットの全身の関節が一つのrelayを共有する前提の処理があります。その結果、各関節がそれぞれrelayを持つロボットで、ロボットの一部の関節のみをpower onした状態で、別の関節を後からpower onすることができませんでした。

古いロボットにはロボットの全身の関節が一つのrelayを共有するものがあるため、
https://github.com/fkanehiro/hrpsys-base/blob/15429cef326184df73d873b05380f3fdc984165c/rtc/RobotHardware/robot.cpp#L452-L453
`ROBOT_IOB_VERSION >= 4`の場合に限り、ロボットの全身の関節が一つのrelayを共有する前提の処理を無くしました。

