### PR TITLE
[SoftErrorLimiter/robot.cpp] check jointId >=0 in setServoErrorLimit

### DIFF
--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -372,7 +372,7 @@ bool robot::servo(const char *jname, bool turnon)
         }
         m_reportedEmergency = false;
         return ret;
-    }else if ((l = link(jname))){
+    }else if ((l = link(jname)) && (l->jointId >= 0)){
         return servo(l->jointId, turnon);
     }else{
         char *s = (char *)jname; while(*s) {*s=toupper(*s);s++;}
@@ -428,6 +428,7 @@ bool robot::power(const char *jname, bool turnon)
     }else{
         Link *l = link(jname);
         if (!l) return false;
+        if (l->jointId < 0) return false;
         jid = l->jointId;
     }
     return power(jid, turnon);
@@ -749,7 +750,7 @@ bool robot::setServoGainPercentage(const char *i_jname, double i_percentage)
             gain_counter[i] = 0;
         }
         std::cerr << "[RobotHardware] setServoGainPercentage " << i_percentage << "[%] for all joints" << std::endl;
-    }else if ((l = link(i_jname))){
+    }else if ((l = link(i_jname)) && (l->jointId >= 0)){
         if (!read_pgain(l->jointId, &old_pgain[l->jointId])) old_pgain[l->jointId] = pgain[l->jointId];
         pgain[l->jointId] = default_pgain[l->jointId] * i_percentage/100.0;
         if (!read_dgain(l->jointId, &old_dgain[l->jointId])) old_dgain[l->jointId] = dgain[l->jointId];
@@ -800,7 +801,7 @@ bool robot::setServoTorqueGainPercentage(const char *i_jname, double i_percentag
             gain_counter[i] = 0;
         }
         std::cerr << "[RobotHardware] setServoTorqueGainPercentage " << i_percentage << "[%] for all joints" << std::endl;
-    }else if ((l = link(i_jname))){
+    }else if ((l = link(i_jname)) && (l->jointId >= 0)){
 #if defined(ROBOT_IOB_VERSION) && ROBOT_IOB_VERSION >= 4
         if (!read_torque_pgain(l->jointId, &old_tqpgain[l->jointId])) old_tqpgain[l->jointId] = tqpgain[l->jointId];
         tqpgain[l->jointId] = default_tqpgain[l->jointId] * i_percentage/100.0;
@@ -838,7 +839,7 @@ bool robot::setServoErrorLimit(const char *i_jname, double i_limit)
         for (unsigned int i=0; i<numJoints(); i++){
             m_servoErrorLimit[i] = i_limit;
         }
-    }else if ((l = link(i_jname))){
+    }else if ((l = link(i_jname)) && (l->jointId >= 0)){
         m_servoErrorLimit[l->jointId] = i_limit;
     }else{
         char *s = (char *)i_jname; while(*s) {*s=toupper(*s);s++;}
@@ -989,6 +990,7 @@ bool robot::setJointInertia(const char *jname, double mn)
     Link *l = link(jname);
     if (!l) return false;
     int jid = l->jointId;
+    if (jid < 0) return false;
     return write_joint_inertia(jid, mn);
 #else
     return false;
@@ -1040,7 +1042,7 @@ bool robot::setJointControlMode(const char *i_jname, joint_control_mode mode)
             write_control_mode(i, mode);
         }
         std::cerr << "[RobotHardware] setJointControlMode for all joints : " << mode << std::endl;
-    } else if ((l = link(i_jname))) {
+    } else if ((l = link(i_jname)) && (l->jointId >= 0)) {
         write_control_mode(l->jointId, mode);
         std::cerr << "[RobotHardware] setJointControlMode for " << i_jname << " : " << mode << std::endl;
     } else {

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -849,6 +849,7 @@ bool SequencePlayer::removeJointGroup(const char *gname)
     bool ret;
     {
         Guard guard(m_mutex);
+        if (!setInitialState()) return false;
         ret = m_seq->removeJointGroup(gname);
     }
     return ret;

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -391,6 +391,10 @@ bool SequencePlayer::setJointAngle(short id, double angle, double tm)
     }
     Guard guard(m_mutex);
     if (!setInitialState()) return false;
+    if (id < 0 || id >= m_robot->numJoints()){
+        std::cerr << "[setJointAngle] Invalid jointId " << id << std::endl;
+        return false;
+    }
     dvector q(m_robot->numJoints());
     m_seq->getJointAngles(q.data());
     q[id] = angle;

--- a/rtc/SoftErrorLimiter/robot.cpp
+++ b/rtc/SoftErrorLimiter/robot.cpp
@@ -25,11 +25,11 @@ bool robot::setServoErrorLimit(const char *i_jname, double i_limit) {
       m_servoErrorLimit[i] = i_limit;
     }
     std::cerr << "[el] setServoErrorLimit " << i_limit << "[rad] for all joints" << std::endl;
-  }else if ((l = link(i_jname))){
+  }else if ((l = link(i_jname)) && (l->jointId >= 0)){
     m_servoErrorLimit[l->jointId] = i_limit;
     std::cerr << "[el] setServoErrorLimit " << i_limit << "[rad] for " << i_jname << std::endl;
   }else{
-    std::cerr << "[el] Invalid joint name of setServoErrorLimit " << i_jname << "!" << std::endl;
+    std::cerr << "[el] Invalid joint name of jointId of setServoErrorLimit name:" << i_jname << " jointId:" << l->jointId << "!" << std::endl;
     return false;
   }
   return true;

--- a/util/monitor/Monitor.cpp
+++ b/util/monitor/Monitor.cpp
@@ -190,9 +190,9 @@ void Monitor::showStatus(hrp::BodyPtr &body)
             // error
             if( i<rstate.angle.length() && i<rstate.command.length() ){
                 double e = (rstate.angle[i]-rstate.command[i])*180/M_PI;
-                if ( abs(e) > 1 ) yellow();
-                if ( abs(e) > 2 ) magenta();
-                if ( abs(e) > 4 ) red();
+                if ( std::abs(e) > 1 ) yellow();
+                if ( std::abs(e) > 2 ) magenta();
+                if ( std::abs(e) > 4 ) red();
                 fprintf(stdout, "%8.3f ", e);
                 black();
             }else{
@@ -201,9 +201,9 @@ void Monitor::showStatus(hrp::BodyPtr &body)
             // velocity
             if( i<velocity.size() ) {
                 double e = velocity[i]; //*180/M_PI;
-                if ( abs(e) >  2 ) yellow();
-                if ( abs(e) > 10 ) magenta();
-                if ( abs(e) > 20 ) red();
+                if ( std::abs(e) >  2 ) yellow();
+                if ( std::abs(e) > 10 ) magenta();
+                if ( std::abs(e) > 20 ) red();
                 fprintf(stdout, "%8.2f ", e);
                 black();
             }else{
@@ -212,9 +212,9 @@ void Monitor::showStatus(hrp::BodyPtr &body)
             // accleration
             if( i<acceleration.size() ) {
                 double e = acceleration[i]; //*180/M_PI;
-                if ( abs(e) >  50 ) yellow();
-                if ( abs(e) > 100 ) magenta();
-                if ( abs(e) > 200 ) red();
+                if ( std::abs(e) >  50 ) yellow();
+                if ( std::abs(e) > 100 ) magenta();
+                if ( std::abs(e) > 200 ) red();
                 fprintf(stdout, "%8.1f ", e);
                 black();
             }else{


### PR DESCRIPTION
setServoErrorLimit関数においてi_jnameから取得した関節のjointIdが設定されているかどうかのチェックを追加しました

hcf.el_svc.setServoErrorLimit()の引数にjointIdが設定されていない関節名を指定すると，
このチェックを行わない場合はaddress-sanitizer(-fsanitize=address)にてheap-buffer-overflowが必ず検出されるのに対して，
このPRによりaddress-sanitizerをパスできることを確認しました