### PR TITLE
[StateHolder] fix undefined initialization of m_tq

### DIFF
--- a/rtc/StateHolder/StateHolder.cpp
+++ b/rtc/StateHolder/StateHolder.cpp
@@ -243,7 +243,12 @@ RTC::ReturnCode_t StateHolder::onExecute(RTC::UniqueId ec_id)
     }
     if (m_requestGoActual || (m_q.data.length() == 0 && m_currentQ.data.length() > 0)){
         m_q = m_currentQ;
-        if (m_q.data.length() != m_tq.data.length()) m_tq.data.length(m_q.data.length());
+        if (m_q.data.length() != m_tq.data.length()) {
+          m_tq.data.length(m_q.data.length());
+          for(size_t i=0;i<m_tq.data.length();i++){
+            m_tq.data[i] = 0;
+          }
+        }
         // Reset reference wrenches to zero
         for (unsigned int i=0; i<m_wrenchesIn.size(); i++){
             m_wrenches[i].data[0] = m_wrenches[i].data[1] = m_wrenches[i].data[2] = 0.0;


### PR DESCRIPTION
起動直後のStateHolderの`tqOut`ポートから、5.02608005523173e+180 などといった値が出力され続けるという現象が発生していて、そのままRobotHardwareに接続すると危険でした。

原因は、StateHolder中の配列`m_tq`の各要素が未初期化であったためでした。

`m_tq`の各要素を0に初期化するようにしました。