### PR TITLE
[SequencePlayer/seqplay.h] skip removing state if state==created in remove()

### DIFF
--- a/rtc/SequencePlayer/seqplay.cpp
+++ b/rtc/SequencePlayer/seqplay.cpp
@@ -455,6 +455,10 @@ bool seqplay::removeJointGroup(const char *gname, double time)
 	groupInterpolator *i = groupInterpolators[gname];
 	if (i){
 		i->remove(time);
+		if (i->state == groupInterpolator::removed){
+			groupInterpolators.erase(gname);
+			delete i;
+		}
 		return true;
 	}else{
 		std::cerr << "[removeJointGroup] group name " << gname << " is not installed" << std::endl;

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -123,7 +123,7 @@ private:
             state = working;
         }
         void remove(double time){
-            if (state == created) state = removed;
+            if (state == created || state == removed) state = removed;
             else{
                 state = removing;
                 time2remove = time;

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -69,7 +69,7 @@ private:
             delete inter;
         }
         void get(double *full, double *dfull = NULL, bool popp=true){
-            if (state == created) return;
+            if (state == created || state == removed) return;
             if (state == removing){
                 double x[indices.size()];
                 double v[indices.size()];
@@ -123,8 +123,11 @@ private:
             state = working;
         }
         void remove(double time){
-            state = removing;
-            time2remove = time;
+            if (state == created) state = removed;
+            else{
+                state = removing;
+                time2remove = time;
+            }
         }
         void clear(double i_timeLimit=0) {
             tick_t t1 = get_tick();


### PR DESCRIPTION
SequencePlayerの`removeJointGroup()`を未使用のJointGroupに対して呼ぶと、SequencePlayerから出力される指令関節角度の値が0に突然変化し、2.5秒かけてもとの値に戻る、という挙動を示し、危険でした。

原因は、未使用のJointGroup(`state==created`)はget関数のなかで何もしないことが期待されているにも関わらず、`removeJointGroup()`を呼ぶとstateが`removing`に変化してしまい、初期値の0から2.5秒かけてもとの値に戻る補間軌道が実行されてしまうためでした。
https://github.com/fkanehiro/hrpsys-base/blob/41f853a4e47d688d7d130c54888e50244e667e25/rtc/SequencePlayer/seqplay.h#L71-L90
https://github.com/fkanehiro/hrpsys-base/blob/41f853a4e47d688d7d130c54888e50244e667e25/rtc/SequencePlayer/seqplay.h#L125-L128

未使用のJointGroup(`state==created`)は、`removeJointGroup()`を呼んだときに、state`removing` を経由せずに直接state`removed`に遷移するようにしました。