### PR TITLE
[SequencePlayer] call setInitialState() in setBasePos, setbaseRpy, setZmp and setWrenches

### DIFF
--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -551,6 +551,7 @@ bool SequencePlayer::setBasePos(const double *pos, double tm)
         std::cerr << __PRETTY_FUNCTION__ << std::endl;
     }
     Guard guard(m_mutex);
+    if (!setInitialState()) return false;
     m_seq->setBasePos(pos, tm);
     return true;
 }
@@ -561,6 +562,7 @@ bool SequencePlayer::setBaseRpy(const double *rpy, double tm)
         std::cerr << __PRETTY_FUNCTION__ << std::endl;
     }
     Guard guard(m_mutex);
+    if (!setInitialState()) return false;
     m_seq->setBaseRpy(rpy, tm);
     return true;
 }
@@ -571,6 +573,7 @@ bool SequencePlayer::setZmp(const double *zmp, double tm)
         std::cerr << __PRETTY_FUNCTION__ << std::endl;
     }
     Guard guard(m_mutex);
+    if (!setInitialState()) return false;
     m_seq->setZmp(zmp, tm);
     return true;
 }
@@ -578,6 +581,7 @@ bool SequencePlayer::setZmp(const double *zmp, double tm)
 bool SequencePlayer::setWrenches(const double *wrenches, double tm)
 {
     Guard guard(m_mutex);
+    if (!setInitialState()) return false;
     m_seq->setWrenches(wrenches, tm);
     return true;
 }


### PR DESCRIPTION
SequencePlayerが起動してから、`setJointAngles`などのサービスを呼ぶ前に`setBasePos` `setBaseRpy` `setZmp` `setWrenches` のサービスを呼ぶと、指令関節角度等のSequencePlayerの出力が不連続に飛ぶという危険なバグがあります。

例えば、各種RTCを起動して、`sh_svc.goActual()`->`rh_svc.servoOn()`->`seq_svc.setWrenches()` とすると、指令関節角度が不連続に飛びます.

原因は、https://github.com/fkanehiro/hrpsys-base/pull/1297 と同じで、`setBasePos` `setBaseRpy` `setZmp` `setWrenches` は`setInitialState()`関数を内部で呼んでいないためです。SequencePlayerは内部に複数の補間器を持ちますが、複数の補間器のうち一つでも補間中のものがあれば、SequencePlayerはは全ての補間機の現在の値をOutPortから出力します. `setInitialState()`関数は`setJointAngles`などのサービス内で呼ばれる関数で、`setInitialState()`を呼ぶと、補間中の補間器が一つも無い場合、JointAngle, BasePos, BaseRpy, Zmpといった補間器が現在のStateHolderの値にリセットされます. そのため、SequencePlayerが起動してから一回も `setInitialState()`関数が呼ばれていない状態や、`sh_svc.goActual()`してから一回も`setInitialState()`関数が呼ばれていない状態で`setBasePos` `setBaseRpy` `setZmp` `setWrenches`などのサービスを呼ぶと、SequencePlayerの全てのOutPortからStateHolderの現在の出力とは関係なく補間器の初期値(ゼロ)が出力されてしまいます。

`setBasePos` `setBaseRpy` `setZmp` `setWrenches` で`setInitialState()`関数を呼ぶようにして、このバグを直しました。