### PR TITLE
[RobotHardware/robot.cpp] send correct emergency signal when servo alarm

### DIFF
--- a/rtc/RobotHardware/robot.cpp
+++ b/rtc/RobotHardware/robot.cpp
@@ -710,9 +710,9 @@ bool robot::checkEmergency(emg_reason &o_reason, int &o_id)
         if (alarm & SS_EMERGENCY) {
             if (!m_reportedEmergency) {
                 m_reportedEmergency = true;
-                o_reason = EMG_SERVO_ALARM;
-                o_id = i;
             }
+            o_reason = EMG_SERVO_ALARM;
+            o_id = i;
             return true;
         }
     }


### PR DESCRIPTION
RobotHardwareからemergencySignalとして`EMG_SERVO_ERROR`が出ていて、このif文によって全身がservo offするにも関わらず、

https://github.com/fkanehiro/hrpsys-base/blob/2336d264de48625a914a5edcb2063343f69a0b47/rtc/RobotHardware/RobotHardware.cpp#L242-L243

実際には`EMG_SERVO_ALARM`が発生していて、`EMG_SERVO_ERROR`は発生していない、というバグがあります。

原因は、変数`reason`はenumの初期値として`EMG_SERVO_ERROR`が入っていて、
https://github.com/fkanehiro/hrpsys-base/blob/2336d264de48625a914a5edcb2063343f69a0b47/rtc/RobotHardware/robot.h#L254

`SS_EMERGENCY`が発生していて`m_reportedEmergency`が`true`の場合には変数`reason`が初期値のまま変更されずに返るためでした。
https://github.com/fkanehiro/hrpsys-base/blob/2336d264de48625a914a5edcb2063343f69a0b47/rtc/RobotHardware/robot.cpp#L708-L717

変数`reason`に`EMG_SERVO_ALARM`を入れてから返るように修正しました。

(関連)
https://github.com/fkanehiro/hrpsys-base/commit/2d088ad2330933b48b22f04e8b53b1fb7a514074
https://github.com/fkanehiro/hrpsys-base/pull/556
https://github.com/fkanehiro/hrpsys-base/pull/564