### PR TITLE
Fallback to python2 if python is not Python 2

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -171,7 +171,18 @@ endif()
 execute_process(
   COMMAND python -c "from distutils import sysconfig; print sysconfig.get_config_var(\"VERSION\")"
   OUTPUT_VARIABLE PYTHON_VERSION
+  RESULT_VARIABLE PYTHON_VERSION_SUCCESS
   OUTPUT_STRIP_TRAILING_WHITESPACE)
+if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
+  execute_process(
+    COMMAND python2 -c "from distutils import sysconfig; print sysconfig.get_config_var(\"VERSION\")"
+    OUTPUT_VARIABLE PYTHON_VERSION
+    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
+    OUTPUT_STRIP_TRAILING_WHITESPACE)
+  if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
+    message(FATAL_ERROR "Could not determine Python 2 version, maybe it is not installed?")
+  endif()
+endif()
 set(python_dist_pkg_dir lib/python${PYTHON_VERSION}/dist-packages)
 
 configure_file(hrpsys-base.pc.in ${CMAKE_CURRENT_BINARY_DIR}/hrpsys-base.pc @ONLY)


### PR DESCRIPTION
In some cases, python is not necesarilly pointing to a Python 2 installation. In that case the `PYTHON_VERSION` computation fails (because it's using syntax that is incompatible with Python 3) and the Python files are installed in the wrong location.

Instead of this, the PR tries to run the script under the `python2` interpreter. If this fails, the configuration errors out