### PR TITLE
[DataLogger] Log data is saved as a zip archive

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -41,6 +41,7 @@
   <build_depend>openhrp3</build_depend>
   <build_depend>python-tk</build_depend>
   <build_depend>sdl</build_depend>
+  <build_depend>libzip-dev</build_depend>
 
   <run_depend>cv_bridge</run_depend>
   <run_depend>glut</run_depend>

--- a/rtc/DataLogger/CMakeLists.txt
+++ b/rtc/DataLogger/CMakeLists.txt
@@ -1,11 +1,11 @@
 set(comp_sources DataLogger.cpp DataLoggerService_impl.cpp)
 set(libs hrpsysBaseStub)
 add_library(DataLogger SHARED ${comp_sources})
-target_link_libraries(DataLogger ${libs})
+target_link_libraries(DataLogger ${libs} zip)
 set_target_properties(DataLogger PROPERTIES PREFIX "")
 
 add_executable(DataLoggerComp DataLoggerComp.cpp ${comp_sources})
-target_link_libraries(DataLoggerComp ${libs})
+target_link_libraries(DataLoggerComp ${libs} zip)
 
 add_executable(logSplitter logSplitter.cpp)
 target_link_libraries(logSplitter ${libs})

--- a/rtc/DataLogger/DataLogger.h
+++ b/rtc/DataLogger/DataLogger.h
@@ -166,6 +166,7 @@ class DataLogger
   coil::Mutex m_suspendFlagMutex;
   unsigned int m_log_precision;
   int dummy;
+  bool save_zip(const std::string &i_basename);
 };
 
 


### PR DESCRIPTION
If the file name ends with ".zip", it is saved as a zip archive.

The save service called as
```
save("filename.zip")
```

'filename.zip' will be created.
It contains 'filename.log_portname0', ... , 'filename.log_portnameN'.
