### PR TITLE
[RobotHardware] call close_iob() on SIGINT

### DIFF
--- a/rtc/RobotHardware/RobotHardware.cpp
+++ b/rtc/RobotHardware/RobotHardware.cpp
@@ -194,12 +194,11 @@ RTC::ReturnCode_t RobotHardware::onInitialize()
 }
 
 
-/*
 RTC::ReturnCode_t RobotHardware::onFinalize()
 {
+  delete m_robot.get(); // to call close_iob() in destructor of robot
   return RTC::RTC_OK;
 }
-*/
 
 /*
 RTC::ReturnCode_t RobotHardware::onStartup(RTC::UniqueId ec_id)

--- a/rtc/RobotHardware/RobotHardware.h
+++ b/rtc/RobotHardware/RobotHardware.h
@@ -62,7 +62,7 @@ class RobotHardware
 
   // The finalize action (on ALIVE->END transition)
   // formaer rtc_exiting_entry()
-  // virtual RTC::ReturnCode_t onFinalize();
+  virtual RTC::ReturnCode_t onFinalize();
 
   // The startup action when ExecutionContext startup
   // former rtc_starting_entry()


### PR DESCRIPTION
hrpEC以外のecを使用しているときに、SIGINTでrtcdが終了するときにclose_iob()を呼んでから終了するようにするための変更です。

close_iob()の中で指令トルクを0にするといった終了処理を行っているのですが、rtcdが終了するときにclose_iob()を呼んでから終了してほしいです。

OpenRTM_aistは、SIGKILLやSIGTERMで終了する場合には強制終了してしまいますが、SIGINTで終了する場合には、各RTCのonFinalize()を呼んだり、各ExecutionContextのisRunning() (or m_running)をfalseにセットしたりといった終了処理を行ってから終了します。

https://github.com/OpenRTM/OpenRTM-aist/blob/ce8fe01a103dfbbcc367d30377ec1f00892d3283/src/lib/rtm/Manager.cpp#L100

今、hrpECは終了処理中にclose_iobを呼ぶのですが、RobotHardware.rtcは終了処理中にclose_iobを呼びません。(robotクラスのデストラクタでclose_iobが呼ばれるのですが、signalで終了する場合にはデストラクタは呼ばれないため)

https://github.com/fkanehiro/hrpsys-base/blob/7926d0f125c06636d9bb67864439f9bb33aa96c9/ec/hrpEC/hrpEC-common.cpp#L173

https://github.com/fkanehiro/hrpsys-base/blob/7926d0f125c06636d9bb67864439f9bb33aa96c9/rtc/RobotHardware/robot.cpp#L30

そのため、hrpEC以外のecを使用しているときに、SIGINTでrtcdが終了するときにclose_iob()を呼んでから終了することができませんでした。

RobotHardware.rtcのonFinalize()中でclose_iobを呼ぶようにしました。