### PR TITLE
[SequencePlayer] add setJointVelocities, setJointVelocitiesSequence, setJointTorques, setJointTorquesSequence

### DIFF
--- a/idl/SequencePlayerService.idl
+++ b/idl/SequencePlayerService.idl
@@ -56,6 +56,38 @@ module OpenHRP
     boolean setJointAngle(in string jname, in double jv, in double tm);
 
     /**
+     * @brief Interpolate all joint velocitys on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot.
+     * @param jvs sequence of joint velocitys
+     * @param tm duration [s]
+     * @return true joint velocitys are set successfully, false otherwise
+     */
+    boolean setJointVelocities(in dSequence jvs, in double tm);
+
+    /**
+     * @brief Interpolate all joint velocitys on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal. [>= 315.5.0]
+     * @param jvs sequence of sequence of joint velocitys [rad]
+     * @param tm sequence of duration [s]
+     * @return true joint velocitys are set successfully, false otherwise
+     */
+    boolean setJointVelocitiesSequence(in dSequenceSequence jvss, in dSequence tms);
+
+    /**
+     * @brief Interpolate all joint torques on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot.
+     * @param jvs sequence of joint torques
+     * @param tm duration [s]
+     * @return true joint torques are set successfully, false otherwise
+     */
+    boolean setJointTorques(in dSequence jvs, in double tm);
+
+    /**
+     * @brief Interpolate all joint torques on robot using duration specified by \em tm. Returns without waiting for whole sequence to be sent to robot. If this function called during the robot moves, it overwrite current goal. [>= 315.5.0]
+     * @param jvs sequence of sequence of joint torques [rad]
+     * @param tm sequence of duration [s]
+     * @return true joint torques are set successfully, false otherwise
+     */
+    boolean setJointTorquesSequence(in dSequenceSequence jvss, in dSequence tms);
+
+    /**
      * @brief Interpolate position of the base link. Function returns without waiting for interpolation to finish
      * @param pos position of the base link [m]
      * @param tm duration [s]

--- a/rtc/SequencePlayer/SequencePlayer.cpp
+++ b/rtc/SequencePlayer/SequencePlayer.cpp
@@ -49,6 +49,7 @@ SequencePlayer::SequencePlayer(RTC::Manager* manager)
       m_zmpRefInitIn("zmpRefInit", m_zmpRefInit),
       m_qRefOut("qRef", m_qRef),
       m_tqRefOut("tqRef", m_tqRef),
+      m_dqRefOut("dqRef", m_dqRef),
       m_zmpRefOut("zmpRef", m_zmpRef),
       m_accRefOut("accRef", m_accRef),
       m_basePosOut("basePos", m_basePos),
@@ -88,6 +89,7 @@ RTC::ReturnCode_t SequencePlayer::onInitialize()
     // Set OutPort buffer
     addOutPort("qRef", m_qRefOut);
     addOutPort("tqRef", m_tqRefOut);
+    addOutPort("dqRef", m_dqRefOut);
     addOutPort("zmpRef", m_zmpRefOut);
     addOutPort("accRef", m_accRefOut);
     addOutPort("basePos", m_basePosOut);
@@ -175,6 +177,7 @@ RTC::ReturnCode_t SequencePlayer::onInitialize()
     // allocate memory for outPorts
     m_qRef.data.length(dof);
     m_tqRef.data.length(dof);
+    m_dqRef.data.length(dof);
     m_optionalData.data.length(optional_data_dim);
 
     return RTC::RTC_OK;
@@ -247,7 +250,7 @@ RTC::ReturnCode_t SequencePlayer::onExecute(RTC::UniqueId ec_id)
 	Guard guard(m_mutex);
 
         double zmp[3], acc[3], pos[3], rpy[3], wrenches[6*m_wrenches.size()];
-        m_seq->get(m_qRef.data.get_buffer(), zmp, acc, pos, rpy, m_tqRef.data.get_buffer(), wrenches, m_optionalData.data.get_buffer());
+        m_seq->get(m_qRef.data.get_buffer(), zmp, acc, pos, rpy, m_tqRef.data.get_buffer(), wrenches, m_optionalData.data.get_buffer(), m_dqRef.data.get_buffer());
         m_zmpRef.data.x = zmp[0];
         m_zmpRef.data.y = zmp[1];
         m_zmpRef.data.z = zmp[2];
@@ -304,6 +307,7 @@ RTC::ReturnCode_t SequencePlayer::onExecute(RTC::UniqueId ec_id)
         m_qRef.tm = m_qInit.tm;
         m_qRefOut.write();
         m_tqRefOut.write();
+        m_dqRefOut.write();
         m_zmpRefOut.write();
         m_accRefOut.write();
         m_basePosOut.write();
@@ -543,6 +547,68 @@ bool SequencePlayer::setJointAnglesSequenceFull(const OpenHRP::dSequenceSequence
     for ( unsigned int i = 0; i < i_optionals.length(); i++ ) v_optionals.push_back(i_optionals[i].get_buffer());
     for ( unsigned int i = 0; i < i_tms.length();  i++ )  v_tms.push_back(i_tms[i]);
     return m_seq->setJointAnglesSequenceFull(v_jvss, v_vels, v_torques, v_poss, v_rpys, v_accs, v_zmps, v_wrenches, v_optionals, v_tms);
+}
+
+bool SequencePlayer::setJointVelocities(const double *velocitys, double tm)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+    if (!setInitialState()) return false;
+    std::vector<const double*> v_vels;
+    std::vector<double> v_tms;
+    v_vels.push_back(velocitys);
+    v_tms.push_back(tm);
+    m_seq->setJointVelocitiesSequence(v_vels, v_tms);
+    return true;
+}
+
+bool SequencePlayer::setJointVelocitiesSequence(const OpenHRP::dSequenceSequence velocityss, const OpenHRP::dSequence& times)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+
+    if (!setInitialState()) return false;
+
+    std::vector<const double*> v_vels;
+    std::vector<double> v_tms;
+    for ( unsigned int i = 0; i < velocityss.length(); i++ ) v_vels.push_back(velocityss[i].get_buffer());
+    for ( unsigned int i = 0; i <  times.length();  i++ )  v_tms.push_back(times[i]);
+    return m_seq->setJointVelocitiesSequence(v_vels, v_tms);
+}
+
+bool SequencePlayer::setJointTorques(const double *torques, double tm)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+    if (!setInitialState()) return false;
+    std::vector<const double*> v_torques;
+    std::vector<double> v_tms;
+    v_torques.push_back(torques);
+    v_tms.push_back(tm);
+    m_seq->setJointTorquesSequence(v_torques, v_tms);
+    return true;
+}
+
+bool SequencePlayer::setJointTorquesSequence(const OpenHRP::dSequenceSequence torquess, const OpenHRP::dSequence& times)
+{
+    if ( m_debugLevel > 0 ) {
+        std::cerr << __PRETTY_FUNCTION__ << std::endl;
+    }
+    Guard guard(m_mutex);
+
+    if (!setInitialState()) return false;
+
+    std::vector<const double*> v_torques;
+    std::vector<double> v_tms;
+    for ( unsigned int i = 0; i < torquess.length(); i++ ) v_torques.push_back(torquess[i].get_buffer());
+    for ( unsigned int i = 0; i <  times.length();  i++ )  v_tms.push_back(times[i]);
+    return m_seq->setJointTorquesSequence(v_torques, v_tms);
 }
 
 bool SequencePlayer::setBasePos(const double *pos, double tm)

--- a/rtc/SequencePlayer/SequencePlayer.h
+++ b/rtc/SequencePlayer/SequencePlayer.h
@@ -104,6 +104,10 @@ class SequencePlayer
   bool setJointAnglesSequence(const OpenHRP::dSequenceSequence angless, const OpenHRP::bSequence& mask, const OpenHRP::dSequence& times);
   bool setJointAnglesSequenceFull(const OpenHRP::dSequenceSequence i_jvss, const OpenHRP::dSequenceSequence i_vels, const OpenHRP::dSequenceSequence i_torques, const OpenHRP::dSequenceSequence i_poss, const OpenHRP::dSequenceSequence i_rpys, const OpenHRP::dSequenceSequence i_accs, const OpenHRP::dSequenceSequence i_zmps, const OpenHRP::dSequenceSequence i_wrenches, const OpenHRP::dSequenceSequence i_optionals, const dSequence i_tms);
   bool clearJointAngles();
+  bool setJointVelocities(const double *velocitys, double tm);
+  bool setJointVelocitiesSequence(const OpenHRP::dSequenceSequence velocityss, const OpenHRP::dSequence& times);
+  bool setJointTorques(const double *torques, double tm);
+  bool setJointTorquesSequence(const OpenHRP::dSequenceSequence torquess, const OpenHRP::dSequence& times);
   bool setBasePos(const double *pos, double tm);
   bool setBaseRpy(const double *rpy, double tm);
   bool setZmp(const double *zmp, double tm);
@@ -147,6 +151,8 @@ class SequencePlayer
   OutPort<TimedDoubleSeq> m_qRefOut;
   TimedDoubleSeq m_tqRef;
   OutPort<TimedDoubleSeq> m_tqRefOut;
+  TimedDoubleSeq m_dqRef;
+  OutPort<TimedDoubleSeq> m_dqRefOut;
   TimedPoint3D m_zmpRef;
   OutPort<TimedPoint3D> m_zmpRefOut;
   TimedAcceleration3D m_accRef;

--- a/rtc/SequencePlayer/SequencePlayerService_impl.cpp
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.cpp
@@ -194,6 +194,60 @@ CORBA::Boolean SequencePlayerService_impl::setJointAngle(const char *jname, CORB
     return m_player->setJointAngle(id, jv, tm);
 }
 
+CORBA::Boolean SequencePlayerService_impl::setJointVelocities(const dSequence& jvs, CORBA::Double tm)
+{
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  return m_player->setJointVelocities(jvs.get_buffer(), tm);
+}
+
+CORBA::Boolean SequencePlayerService_impl::setJointVelocitiesSequence(const dSequenceSequence& jvss, const dSequence& tms)
+{
+  if (jvss.length() <= 0) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint velocitys sequence is invalid:" << jvss.length() << " > 0" << std::endl;
+      return false;
+  }
+  if (jvss.length() != tms.length()) {
+      std::cerr << __PRETTY_FUNCTION__ << " length of joint velocitys sequence and time sequence differ, joint velocity:" << jvss.length() << ", time:" << tms.length() << std::endl;
+      return false;
+  }
+  const dSequence& jvs = jvss[0];
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  return m_player->setJointVelocitiesSequence(jvss, tms);
+}
+
+CORBA::Boolean SequencePlayerService_impl::setJointTorques(const dSequence& jvs, CORBA::Double tm)
+{
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  return m_player->setJointTorques(jvs.get_buffer(), tm);
+}
+
+CORBA::Boolean SequencePlayerService_impl::setJointTorquesSequence(const dSequenceSequence& jvss, const dSequence& tms)
+{
+  if (jvss.length() <= 0) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint torques sequence is invalid:" << jvss.length() << " > 0" << std::endl;
+      return false;
+  }
+  if (jvss.length() != tms.length()) {
+      std::cerr << __PRETTY_FUNCTION__ << " length of joint torques sequence and time sequence differ, joint torque:" << jvss.length() << ", time:" << tms.length() << std::endl;
+      return false;
+  }
+  const dSequence& jvs = jvss[0];
+  if (jvs.length() != (unsigned int)(m_player->robot()->numJoints())) {
+      std::cerr << __PRETTY_FUNCTION__ << " num of joint is differ, input:" << jvs.length() << ", robot:" << (unsigned int)(m_player->robot()->numJoints()) << std::endl;
+      return false;
+  }
+  return m_player->setJointTorquesSequence(jvss, tms);
+}
+
 CORBA::Boolean SequencePlayerService_impl::setBasePos(const dSequence& pos, CORBA::Double tm)
 {
     if (pos.length() != 3) return false;

--- a/rtc/SequencePlayer/SequencePlayerService_impl.h
+++ b/rtc/SequencePlayer/SequencePlayerService_impl.h
@@ -25,6 +25,10 @@ public:
   CORBA::Boolean setJointAngles(const dSequence& jvs, CORBA::Double tm);
   CORBA::Boolean setJointAnglesWithMask(const dSequence& jvs, const bSequence& mask, CORBA::Double tm);
   CORBA::Boolean setJointAngle(const char *jname, CORBA::Double jv, CORBA::Double tm);
+  CORBA::Boolean setJointVelocities(const dSequence& jvs, CORBA::Double tm);
+  CORBA::Boolean setJointVelocitiesSequence(const dSequenceSequence& jvs, const dSequence &tms);
+  CORBA::Boolean setJointTorques(const dSequence& jvs, CORBA::Double tm);
+  CORBA::Boolean setJointTorquesSequence(const dSequenceSequence& jvs, const dSequence &tms);
   CORBA::Boolean setBasePos(const dSequence& pos, CORBA::Double tm);
   CORBA::Boolean setBaseRpy(const dSequence& rpy, CORBA::Double tm);
   CORBA::Boolean setZmp(const dSequence& zmp, CORBA::Double tm);

--- a/rtc/SequencePlayer/seqplay.h
+++ b/rtc/SequencePlayer/seqplay.h
@@ -45,16 +45,18 @@ public:
     //
     void setJointAngle(unsigned int i_rank, double jv, double tm);
     void loadPattern(const char *i_basename, double i_tm);
+    bool setJointVelocitiesSequence(std::vector<const double*> vel, std::vector<double> tm);
+    bool setJointTorquesSequence(std::vector<const double*> torque, std::vector<double> tm);
     void clear(double i_timeLimit=0);
     void get(double *o_q, double *o_zmp, double *o_accel,
-	     double *o_basePos, double *o_baseRpy, double *o_tq, double *o_wrenches, double *o_optional_data);
+	     double *o_basePos, double *o_baseRpy, double *o_tq, double *o_wrenches, double *o_optional_data, double *o_dq);
     void go(const double *i_q, const double *i_zmp, const double *i_acc,
-            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data, double i_time, 
+            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data, const double *i_dq, double i_time, 
             bool immediate=true);
     void go(const double *i_q, const double *i_zmp, const double *i_acc,
-            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data,
+            const double *i_p, const double *i_rpy, const double *i_tq, const double *i_wrenches, const double *i_optional_data, const double *i_dq,
 	    const double *ii_q, const double *ii_zmp, const double *ii_acc,
-            const double *ii_p, const double *ii_rpy, const double *ii_tq, const double *ii_wrenches, const double *ii_optional_data,
+            const double *ii_p, const double *ii_rpy, const double *ii_tq, const double *ii_wrenches, const double *ii_optional_data, const double *ii_dq,
             double i_time, bool immediate=true);
     void sync();
     bool setInterpolationMode(interpolator::interpolation_mode i_mode_);
@@ -142,7 +144,7 @@ private:
         double time2remove;
     };
     void pop_back();
-    enum {Q, ZMP, ACC, P, RPY, TQ, WRENCHES, OPTIONAL_DATA, NINTERPOLATOR};
+    enum {Q, ZMP, ACC, P, RPY, TQ, WRENCHES, OPTIONAL_DATA, DQ, NINTERPOLATOR};
     interpolator *interpolators[NINTERPOLATOR];
     std::map<std::string, groupInterpolator *> groupInterpolators; 
     int debug_level, m_dof;


### PR DESCRIPTION
1. SequencePlayerのサービスに、`setJointVelocities`, `setJointVelocitiesSequence`, `setJointTorques`, `setJointTorquesSequence` を追加しました. 
2. SequencePlayerの出力ポートに指令関節速度のdqRefを追加し、SequencePlayer内に指令関節速度用の補間器を追加しました。

速度指令の車輪や、電流指令のグリッパからなるロボットを動かすときに、指令関節速度やトルクをこれらのサービスから指令できると便利であるためです。

これまで、SequencePlayerに指令関節速度を与えるインタフェースはありませんでした。指令関節トルクを与えるインタフェースは`setJointAnglesSequenceFull`しかなく、これは指令関節トルク以外にも多くの種類の指令値を同時に与える必要があるため、この目的では使いにくいものでした。