### PR TITLE
Remove Coil dependencies from CollisionDetector to compile

### DIFF
--- a/rtc/CollisionDetector/CollisionDetector.cpp
+++ b/rtc/CollisionDetector/CollisionDetector.cpp
@@ -21,8 +21,6 @@
 #include "hrpsys/util/BVutil.h"
 #include "hrpsys/idl/RobotHardwareService.hh"
 
-#include <chrono>
-
 #include "CollisionDetector.h"
 
 #define deg2rad(x)	((x)*M_PI/180)
@@ -414,7 +412,6 @@ RTC::ReturnCode_t CollisionDetector::onExecute(RTC::UniqueId ec_id)
         //        }
         //collision check process in case of angle set above
 	m_robot->calcForwardKinematics();
-	//coil::TimeValue tm1 = coil::gettimeofday();
     auto tm1 = std::chrono::steady_clock::now();
 
     std::map<std::string, CollisionLinkPair *>::iterator it = m_pair.begin();

--- a/rtc/CollisionDetector/CollisionDetector.h
+++ b/rtc/CollisionDetector/CollisionDetector.h
@@ -33,6 +33,8 @@
 #include "CollisionDetectorService_impl.h"
 #include "../SoftErrorLimiter/beep.h"
 
+#include <chrono>
+
 // Service implementation headers
 // <rtc-template block="service_impl_h">
 


### PR DESCRIPTION
coil:TimeValue is no longer available in the coil 2.0 