### PR TITLE
Update cmake, remove coil dependencies and update libqhull include path 

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -170,24 +170,10 @@ if(USE_HRPSYSUTIL AND APPLE AND NOT PCL_FOUND)
 endif()
 
 execute_process(
-  COMMAND python -c "from distutils import sysconfig; print sysconfig.get_config_var(\"VERSION\")"
+  COMMAND python -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
   OUTPUT_VARIABLE PYTHON_VERSION
   RESULT_VARIABLE PYTHON_VERSION_SUCCESS
   OUTPUT_STRIP_TRAILING_WHITESPACE)
-if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
-  execute_process(
-    COMMAND python2 -c "from distutils import sysconfig; print sysconfig.get_config_var(\"VERSION\")"
-    OUTPUT_VARIABLE PYTHON_VERSION
-    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
-if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
-  execute_process(
-    COMMAND python3 -c "from distutils import sysconfig; print(sysconfig.get_config_var(\"VERSION\"))"
-    OUTPUT_VARIABLE PYTHON_VERSION
-    RESULT_VARIABLE PYTHON_VERSION_SUCCESS
-    OUTPUT_STRIP_TRAILING_WHITESPACE)
-endif()
 if(NOT PYTHON_VERSION_SUCCESS STREQUAL 0)
   message(FATAL_ERROR "Could not determine Python version, maybe it is not installed?")
 endif()

--- a/cmake_modules/FindQuickHull.cmake
+++ b/cmake_modules/FindQuickHull.cmake
@@ -1,12 +1,21 @@
-FIND_PATH(
-QHULL_DIR
-NAMES include/qhull/qhull.h
-PATHS /usr /usr/local
-DOC "the top directory of qhull")
+#FIND_PATH(
+#QHULL_DIR
+#NAMES qhull_a.h
+#PATHS /usr/include/libqhull | /usr/local
+#DOC "the top directory of qhull")
+
+find_file(
+    QHULL_DIR
+    NAMES libqhull/libqhull.h qhull.h
+    HINTS "${QHULL_ROOT}" "$ENV{QHULL_ROOT}" "${QHULL_INCLUDE_DIR}"
+    PATHS "$ENV{PROGRAMFILES}/QHull" "$ENV{PROGRAMW6432}/QHull"
+          "$ENV{PROGRAMFILES}/qhull 6.2.0.1373"
+          "$ENV{PROGRAMW6432}/qhull 6.2.0.1373"
+    PATH_SUFFIXES qhull src/libqhull libqhull include)
 
 IF ( QHULL_DIR )
     MESSAGE(STATUS "Found Qhull in ${QHULL_DIR}")
-    set(QHULL_INCLUDE_DIR ${QHULL_DIR}/include)
+    set(QHULL_INCLUDE_DIR ${QHULL_DIR})
     if (APPLE)
       set(QHULL_LIBRARIES qhull)
     else()

--- a/cmake_modules/FindQuickHull.cmake
+++ b/cmake_modules/FindQuickHull.cmake
@@ -1,9 +1,3 @@
-#FIND_PATH(
-#QHULL_DIR
-#NAMES qhull_a.h
-#PATHS /usr/include/libqhull | /usr/local
-#DOC "the top directory of qhull")
-
 find_file(
     QHULL_DIR
     NAMES libqhull/libqhull.h qhull.h

--- a/lib/util/BVutil.cpp
+++ b/lib/util/BVutil.cpp
@@ -3,7 +3,7 @@ extern "C" {
 #if (defined __APPLE__)
 #include <pcl/surface/qhull.h>
 #else
-#include <qhull/qhull_a.h>
+#include <libqhull/qhull_a.h>
 #endif
 }
 #include <hrpModel/Link.h>

--- a/lib/util/BodyRTC.cpp
+++ b/lib/util/BodyRTC.cpp
@@ -481,11 +481,15 @@ bool BodyRTC::setServoErrorLimit(const char *i_jname, double i_limit)
 
 char *time_string()
 {
-    struct timeval tv;
-    gettimeofday(&tv, NULL);
-    struct tm *tm_ = localtime(&tv.tv_sec);
-    static char time[20];
-    sprintf(time, "%02d:%02d:%02d.%06d", tm_->tm_hour, tm_->tm_min, tm_->tm_sec, (int)tv.tv_usec);
+    struct timespec ts;
+    clock_gettime(CLOCK_REALTIME, &ts); 
+
+    struct tm tm_;
+    localtime_r(&ts.tv_sec, &tm_); 
+
+    static char time[26]; 
+    snprintf(time, sizeof(time), "%02d:%02d:%02d.%06ld", tm_.tm_hour, tm_.tm_min, tm_.tm_sec, ts.tv_nsec / 1000);
+
     return time;
 }
 

--- a/rtc/CollisionDetector/SetupCollisionPair.cpp
+++ b/rtc/CollisionDetector/SetupCollisionPair.cpp
@@ -19,7 +19,7 @@ extern "C" {
 #if (defined __APPLE__)
 #include <pcl/surface/qhull.h>
 #else
-#include <qhull/qhull_a.h>
+#include <libqhull/qhull_a.h>
 #endif
 }
 

--- a/rtc/CollisionDetector/vclip_1.0/src/PolyTree.C
+++ b/rtc/CollisionDetector/vclip_1.0/src/PolyTree.C
@@ -61,7 +61,7 @@ extern "C" {
 #if (defined __APPLE__)
 #include <pcl/surface/qhull.h>
 #else
-#include "qhull/qhull_a.h"
+#include "libqhull/qhull_a.h"
 #endif
 }
 //char qh_version[] = "vclip 1.0";


### PR DESCRIPTION
* CMakeLists
The previous cmake file didn't consider that multiple python version could be installed on the same computer. The previous cmake was prioritizing python2 over python3 preventing us to run Choreonoid due to the fact that this one was looking for the default python version defined on the computer. Now the user can any version of python, it'll take the default python version defined which will be used as well by Choreonoid. 


* QuickHull 
Using the following command to install libqhull : `sudo apt-get install libqhull8.0` it installs the include files in the following folder : 
`/usr/include/libqhull/`. Based on the previous implementation of FindQuickHull.cmake the include path was not set properly as well as the include path given in the source code. 

